### PR TITLE
SBT Update performance downgrade caused by large number of dependencyOve...

### DIFF
--- a/src/java/org/apache/ivy/core/module/id/MatcherLookup.java
+++ b/src/java/org/apache/ivy/core/module/id/MatcherLookup.java
@@ -55,9 +55,7 @@ import org.apache.ivy.plugins.matcher.MapMatcher;
  */
 public class MatcherLookup {
 
-    private static final String FORMAT = "{org:%s, module:%s}";
-
-    private static final String DEFAULT = String.format(FORMAT, "default", "default");
+    private static final String DEFAULT = "{org:default, module:default}";
 
     private Map/* <String, List<MapMatcher>> */lookup = new HashMap();
 
@@ -129,7 +127,7 @@ public class MatcherLookup {
         if (org == null || module == null) {
             return DEFAULT;
         }
-        return String.format(FORMAT, org, module);
+        return "{org:" + org + ", module:" + module + "}";
     }
 
 }

--- a/src/java/org/apache/ivy/core/module/id/MatcherLookup.java
+++ b/src/java/org/apache/ivy/core/module/id/MatcherLookup.java
@@ -1,0 +1,135 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.ivy.core.module.id;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ivy.core.IvyPatternHelper;
+import org.apache.ivy.plugins.matcher.ExactPatternMatcher;
+import org.apache.ivy.plugins.matcher.MapMatcher;
+
+/**
+ * This class targets to speed up lookup for exact pattern matcher by keys, which are created with
+ * (organization, module) information. When exact pattern matcher is added, the key is created from
+ * matcher's attributes. When matcher is looked up against specific module, the key is recreated
+ * from module's attributes.
+ * <p>
+ * </p>
+ * The lookup doesn't target to speed up lookup for non exact pattern matcher. All non exact
+ * matchers are placed in non-keyed collection.
+ * <p>
+ * </p>
+ * At lookup for matchers against specific module, all non exact pattern matchers are iterated to
+ * match with module attributes, and exact pattern matchers binding to the same key will also
+ * iterated to match with module attributes.
+ * <p>
+ * </p>
+ * If there are much more exact pattern matchers than non exact pattern matchers, the matcher lookup
+ * speed can benefit from this class significantly. A quick example could be user declares lots of
+ * dependencyOverrides which are typically exact pattern matchers.
+ * <p>
+ * </p>
+ * If there are balanced exact and non exact pattern matchers, the matcher lookup speed doesn't hurt
+ * by this class.
+ * <p>
+ * </p>
+ */
+public class MatcherLookup {
+
+    private static final String FORMAT = "{org:%s, module:%s}";
+
+    private static final String DEFAULT = String.format(FORMAT, "default", "default");
+
+    private Map/* <String, List<MapMatcher>> */lookup = new HashMap();
+
+    private List/* <MapMatcher> */non_exact_matchers = new ArrayList();
+
+    /**
+     * Add matcher.
+     * 
+     * If matcher is exact pattern matcher, it will be associated with a key and placed in keyed
+     * collection.
+     * 
+     * If matcher is not exact pattern matcher, it will be placed into non-keyed collection
+     * 
+     * @param matcher
+     */
+    public void add(MapMatcher matcher) {
+        if (!(matcher.getPatternMatcher() instanceof ExactPatternMatcher)) {
+            non_exact_matchers.add(matcher);
+            return;
+        }
+        Object key = key(matcher.getAttributes());
+        List exact_matchers = (List) lookup.get(key);
+        if (exact_matchers == null) {
+            exact_matchers = new ArrayList();
+            lookup.put(key, exact_matchers);
+        }
+        exact_matchers.add(matcher);
+    }
+
+    /**
+     * Get a list of matchers which can apply to module with specified attributes
+     * 
+     * @param attrs
+     *            A map of attributes that matcher should match.
+     * 
+     * @return list A list of candidate matchers that matches specified attributes
+     */
+    public List get(Map attrs) {
+        List matchers = new ArrayList();
+        for (Iterator iter = non_exact_matchers.iterator(); iter.hasNext();) {
+            MapMatcher matcher = (MapMatcher) iter.next();
+            if (matcher.matches(attrs)) {
+                matchers.add(matcher);
+            }
+        }
+        Object key = key(attrs);
+        List exact_matchers = (List) lookup.get(key);
+        if (exact_matchers != null) {
+            for (Iterator iter = exact_matchers.iterator(); iter.hasNext();) {
+                MapMatcher matcher = (MapMatcher) iter.next();
+                if (matcher.matches(attrs)) {
+                    matchers.add(matcher);
+                }
+            }
+        }
+        return matchers;
+    }
+
+    /**
+     * Create a key from specified attributes
+     * 
+     * @param attrs
+     *            A map of attributes
+     * @return key object
+     */
+    private Object key(Map attrs) {
+        Object org = attrs.get(IvyPatternHelper.ORGANISATION_KEY);
+        Object module = attrs.get(IvyPatternHelper.MODULE_KEY);
+        if (org == null || module == null) {
+            return DEFAULT;
+        }
+        return String.format(FORMAT, org, module);
+    }
+
+}

--- a/src/java/org/apache/ivy/core/module/id/ModuleRules.java
+++ b/src/java/org/apache/ivy/core/module/id/ModuleRules.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.apache.ivy.plugins.matcher.MapMatcher;
 import org.apache.ivy.util.Checks;
@@ -53,6 +52,8 @@ import org.apache.ivy.util.filter.NoFilter;
 public class ModuleRules {
     private Map/* <MapMatcher,Object> */rules = new LinkedHashMap();
 
+    private MatcherLookup matcher_lookup = new MatcherLookup();
+
     /**
      * Constructs an empty ModuleRules.
      */
@@ -61,6 +62,9 @@ public class ModuleRules {
 
     private ModuleRules(Map/* <MapMatcher,Object> */rules) {
         this.rules = new LinkedHashMap(rules);
+        for (Iterator iter = rules.keySet().iterator(); iter.hasNext();) {
+            matcher_lookup.add((MapMatcher) iter.next());
+        }
     }
 
     /**
@@ -76,6 +80,7 @@ public class ModuleRules {
         Checks.checkNotNull(rule, "rule");
 
         rules.put(condition, rule);
+        matcher_lookup.add(condition);
     }
 
     /**
@@ -164,14 +169,12 @@ public class ModuleRules {
     }
 
     private Object getRule(Map moduleAttributes, Filter filter) {
-        for (Iterator iter = rules.entrySet().iterator(); iter.hasNext();) {
-            Map.Entry ruleEntry = (Entry) iter.next();
-            MapMatcher midm = (MapMatcher) ruleEntry.getKey();
-            if (midm.matches(moduleAttributes)) {
-                Object rule = ruleEntry.getValue();
-                if (filter.accept(rule)) {
-                    return rule;
-                }
+        List matchers = matcher_lookup.get(moduleAttributes);
+        for (Iterator iter = matchers.iterator(); iter.hasNext();) {
+            MapMatcher midm = (MapMatcher) iter.next();
+            Object rule = rules.get(midm);
+            if (filter.accept(rule)) {
+                return rule;
             }
         }
         return null;
@@ -198,15 +201,13 @@ public class ModuleRules {
     }
 
     private Object[] getRules(Map moduleAttributes, Filter filter) {
+        List matchers = matcher_lookup.get(moduleAttributes);
         List matchingRules = new ArrayList();
-        for (Iterator iter = rules.entrySet().iterator(); iter.hasNext();) {
-            Map.Entry ruleEntry = (Entry) iter.next();
-            MapMatcher midm = (MapMatcher) ruleEntry.getKey();
-            if (midm.matches(moduleAttributes)) {
-                Object rule = ruleEntry.getValue();
-                if (filter.accept(rule)) {
-                    matchingRules.add(rule);
-                }
+        for (Iterator iter = matchers.iterator(); iter.hasNext();) {
+            MapMatcher midm = (MapMatcher) iter.next();
+            Object rule = rules.get(midm);
+            if (filter.accept(rule)) {
+                matchingRules.add(rule);
             }
         }
         return matchingRules.toArray();


### PR DESCRIPTION
...rrides

In order to keep artifact version standards following the train, we need to use SBT dependencyOverrides.
The overrides include about 950 entries long. Once we put the overrides into play, the udpate time goes
up by 4x-5x. With profiler data, we identify a severe hot spot at ModuleRules.getRules(), which consumes

> 80% CPU and >900MB memmory usage in our case. The root cuase is ivy has to iterate whole rule map to
> to find right matchers, so the performance is downgraded significantly when rules map is pretty large.
> This patch target to speed up matcher lookup for dependencyOverrides resolution.

The issue was initially raised at 

  http://stackoverflow.com/questions/22187264/dependencyoverrides-causes-sbt-update-times-to-go-up-by-4-5x

From our test, we observe 60% SBT Update time improvement with this change. 
