### PR TITLE
Replace native file ops with delegated calls

### DIFF
--- a/src/example/multi-project/projects/find/src/find/Main.java
+++ b/src/example/multi-project/projects/find/src/find/Main.java
@@ -55,7 +55,7 @@ public final class Main {
             CommandLineParser parser = new GnuParser();
     
             CommandLine line = parser.parse(options, args);
-            File dir = new File(line.getOptionValue("dir", "."));
+            File dir = FileUtil.newFile(line.getOptionValue("dir", "."));
             String name = line.getOptionValue("name", "jar");
             Collection files = FindFile.find(dir, name);
             System.out.println("listing files in " + dir + " containing " + name);

--- a/src/example/multi-project/projects/list/src/list/Main.java
+++ b/src/example/multi-project/projects/list/src/list/Main.java
@@ -50,7 +50,7 @@ public final class Main {
         CommandLineParser parser = new GnuParser();
 
         CommandLine line = parser.parse(options, args);
-        File dir = new File(line.getOptionValue("dir", "."));
+        File dir = FileUtil.newFile(line.getOptionValue("dir", "."));
         Collection files = ListFile.list(dir);
         System.out.println("listing files in " + dir);
         for (Iterator it = files.iterator(); it.hasNext();) {

--- a/src/example/multi-project/projects/sizewhere/src/sizewhere/Main.java
+++ b/src/example/multi-project/projects/sizewhere/src/sizewhere/Main.java
@@ -53,7 +53,7 @@ public final class Main {
         CommandLineParser parser = new GnuParser();
 
         CommandLine line = parser.parse(options, args);
-        File dir = new File(line.getOptionValue("dir", "."));
+        File dir = FileUtil.newFile(line.getOptionValue("dir", "."));
         String name = line.getOptionValue("name", "jar");
         System.out.println("total size of files in " + dir 
             + " containing " + name + ": " + SizeWhere.totalSize(dir, name));

--- a/src/java/org/apache/ivy/Main.java
+++ b/src/java/org/apache/ivy/Main.java
@@ -492,7 +492,7 @@ public final class Main {
                 }
             }
 
-            PrintWriter writer = new PrintWriter(new FileOutputStream(outFile));
+            PrintWriter writer = new PrintWriter(FileUtil.newOutputStream(outFile));
             if (buf.length() > 0) {
                 writer.println(buf.substring(0, buf.length() - pathSeparator.length()));
             }

--- a/src/java/org/apache/ivy/Main.java
+++ b/src/java/org/apache/ivy/Main.java
@@ -50,6 +50,7 @@ import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorWriter;
 import org.apache.ivy.plugins.report.XmlReportParser;
 import org.apache.ivy.util.DefaultMessageLogger;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 import org.apache.ivy.util.cli.CommandLine;
 import org.apache.ivy.util.cli.CommandLineParser;
@@ -247,7 +248,7 @@ public final class Main {
         IvySettings settings = initSettings(line, ivy);
         ivy.pushContext();
 
-        File cache = new File(settings.substitute(line.getOptionValue("cache", settings
+        File cache = FileUtil.newFile(settings.substitute(line.getOptionValue("cache", settings
                 .getDefaultCache().getAbsolutePath())));
 
         if (line.hasOption("cache")) {
@@ -285,7 +286,7 @@ public final class Main {
             XmlModuleDescriptorWriter.write(md, ivyfile);
             confs = new String[] {"default"};
         } else {
-            ivyfile = new File(settings.substitute(line.getOptionValue("ivy", "ivy.xml")));
+            ivyfile = FileUtil.newFile(settings.substitute(line.getOptionValue("ivy", "ivy.xml")));
             if (!ivyfile.exists()) {
                 error("ivy file not found: " + ivyfile);
             } else if (ivyfile.isDirectory()) {
@@ -409,7 +410,7 @@ public final class Main {
                         System.getProperty("path.separator"));
                 while (tokenizer.hasMoreTokens()) {
                     String token = tokenizer.nextToken();
-                    File file = new File(token);
+                    File file = FileUtil.newFile(token);
                     if (file.exists()) {
                         fileList.add(file);
                     } else {
@@ -443,7 +444,7 @@ public final class Main {
         if ("".equals(settingsPath)) {
             ivy.configureDefault();
         } else {
-            File conffile = new File(settingsPath);
+            File conffile = FileUtil.newFile(settingsPath);
             if (!conffile.exists()) {
                 error("ivy configuration file not found: " + conffile);
             } else if (conffile.isDirectory()) {

--- a/src/java/org/apache/ivy/ant/BuildOBRTask.java
+++ b/src/java/org/apache/ivy/ant/BuildOBRTask.java
@@ -40,6 +40,7 @@ import org.apache.ivy.osgi.repo.ManifestAndLocation;
 import org.apache.ivy.osgi.repo.ResolverManifestIterable;
 import org.apache.ivy.plugins.resolver.BasicResolver;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 import org.apache.tools.ant.BuildException;
 import org.xml.sax.ContentHandler;
@@ -169,7 +170,7 @@ public class BuildOBRTask extends IvyCacheTask {
 
         OutputStream out;
         try {
-            out = new FileOutputStream(file);
+            out = FileUtil.newOutputStream(file);
         } catch (FileNotFoundException e) {
             throw new BuildException(file + " was not found", e);
         }

--- a/src/java/org/apache/ivy/ant/ConvertManifestTask.java
+++ b/src/java/org/apache/ivy/ant/ConvertManifestTask.java
@@ -31,6 +31,7 @@ import org.apache.ivy.osgi.core.ExecutionEnvironmentProfileProvider;
 import org.apache.ivy.osgi.core.ManifestParser;
 import org.apache.ivy.osgi.core.OSGiManifestParser;
 import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorWriter;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 
 public class ConvertManifestTask extends IvyTask {
@@ -70,7 +71,7 @@ public class ConvertManifestTask extends IvyTask {
 
         Manifest m;
         try {
-            m = new Manifest(new FileInputStream(manifest));
+            m = new Manifest(FileUtil.newInputStream(manifest));
         } catch (FileNotFoundException e) {
             throw new BuildException("the manifest file '" + manifest + "' was not found", e);
         } catch (IOException e) {

--- a/src/java/org/apache/ivy/ant/IvyAntSettings.java
+++ b/src/java/org/apache/ivy/ant/IvyAntSettings.java
@@ -347,7 +347,7 @@ public class IvyAntSettings extends DataType {
         File[] settingsLocations = new File[] {
                 FileUtil.newFile(getProject().getBaseDir(), settingsFileName),
                 FileUtil.newFile(getProject().getBaseDir(), "ivyconf.xml"), FileUtil.newFile(settingsFileName),
-                new File("ivyconf.xml")};
+                FileUtil.newFile("ivyconf.xml")};
         for (int i = 0; i < settingsLocations.length; i++) {
             file = settingsLocations[i];
             task.log("searching settings file: trying " + file, Project.MSG_VERBOSE);

--- a/src/java/org/apache/ivy/ant/IvyAntSettings.java
+++ b/src/java/org/apache/ivy/ant/IvyAntSettings.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 import org.apache.ivy.Ivy;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.settings.IvyVariableContainer;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 import org.apache.ivy.util.url.CredentialsStore;
 import org.apache.ivy.util.url.URLHandler;
@@ -344,8 +345,8 @@ public class IvyAntSettings extends DataType {
             settingsFileName = variableContainer.getVariable("ivy.settings.file");
         }
         File[] settingsLocations = new File[] {
-                new File(getProject().getBaseDir(), settingsFileName),
-                new File(getProject().getBaseDir(), "ivyconf.xml"), new File(settingsFileName),
+                FileUtil.newFile(getProject().getBaseDir(), settingsFileName),
+                FileUtil.newFile(getProject().getBaseDir(), "ivyconf.xml"), FileUtil.newFile(settingsFileName),
                 new File("ivyconf.xml")};
         for (int i = 0; i < settingsLocations.length; i++) {
             file = settingsLocations[i];

--- a/src/java/org/apache/ivy/ant/IvyArtifactReport.java
+++ b/src/java/org/apache/ivy/ant/IvyArtifactReport.java
@@ -44,6 +44,7 @@ import org.apache.ivy.core.resolve.IvyNode;
 import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.core.resolve.ResolvedModuleRevision;
 import org.apache.ivy.core.retrieve.RetrieveOptions;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.xml.sax.SAXException;
@@ -253,7 +254,7 @@ public class IvyArtifactReport extends IvyPostResolveTask {
 
     private void writeRetrieveLocation(TransformerHandler saxHandler, String artifactDestPath)
             throws SAXException {
-        artifactDestPath = removeLeadingPath(getProject().getBaseDir(), new File(artifactDestPath));
+        artifactDestPath = removeLeadingPath(getProject().getBaseDir(), FileUtil.newFile(artifactDestPath));
 
         saxHandler.startElement(null, "retrieve-location", "retrieve-location",
             new AttributesImpl());

--- a/src/java/org/apache/ivy/ant/IvyArtifactReport.java
+++ b/src/java/org/apache/ivy/ant/IvyArtifactReport.java
@@ -20,6 +20,7 @@ package org.apache.ivy.ant;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.text.ParseException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -127,7 +128,7 @@ public class IvyArtifactReport extends IvyPostResolveTask {
     private void generateXml(IvyNode[] dependencies, Map moduleRevToArtifactsMap,
             Map artifactsToCopy) {
         try {
-            FileOutputStream fileOuputStream = new FileOutputStream(tofile);
+            OutputStream fileOuputStream = FileUtil.newOutputStream(tofile);
             try {
                 TransformerHandler saxHandler = createTransformerHandler(fileOuputStream);
 
@@ -181,7 +182,7 @@ public class IvyArtifactReport extends IvyPostResolveTask {
         }
     }
 
-    private TransformerHandler createTransformerHandler(FileOutputStream fileOuputStream)
+    private TransformerHandler createTransformerHandler(OutputStream fileOuputStream)
             throws TransformerFactoryConfigurationError, TransformerConfigurationException,
             SAXException {
         SAXTransformerFactory transformerFact = (SAXTransformerFactory) SAXTransformerFactory

--- a/src/java/org/apache/ivy/ant/IvyBuildList.java
+++ b/src/java/org/apache/ivy/ant/IvyBuildList.java
@@ -38,6 +38,7 @@ import org.apache.ivy.core.module.id.ModuleId;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortOptions;
 import org.apache.ivy.plugins.parser.ModuleDescriptorParserRegistry;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
@@ -201,7 +202,7 @@ public class IvyBuildList extends IvyTask {
             DirectoryScanner ds = fs.getDirectoryScanner(getProject());
             String[] builds = ds.getIncludedFiles();
             for (int i = 0; i < builds.length; i++) {
-                File buildFile = new File(ds.getBasedir(), builds[i]);
+                File buildFile = FileUtil.newFile(ds.getBasedir(), builds[i]);
                 File ivyFile = getIvyFileFor(buildFile);
                 if (!ivyFile.exists()) {
                     onMissingDescriptor(buildFile, ivyFile, noDescriptor);
@@ -505,7 +506,7 @@ public class IvyBuildList extends IvyTask {
     }
 
     private File getIvyFileFor(File buildFile) {
-        return new File(buildFile.getParentFile(), ivyFilePath);
+        return FileUtil.newFile(buildFile.getParentFile(), ivyFilePath);
     }
 
     public boolean isHaltonerror() {

--- a/src/java/org/apache/ivy/ant/IvyCachePath.java
+++ b/src/java/org/apache/ivy/ant/IvyCachePath.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.ivy.core.report.ArtifactDownloadReport;
 import org.apache.ivy.osgi.core.BundleInfo;
 import org.apache.ivy.osgi.core.ManifestParser;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.Path;
@@ -92,7 +93,7 @@ public class IvyCachePath extends IvyCacheTask {
             path.createPathElement().setLocation(f);
             return;
         }
-        File manifest = new File(f, "META-INF/MANIFEST.MF");
+        File manifest = FileUtil.newFile(f, "META-INF/MANIFEST.MF");
         if (!manifest.exists()) {
             path.createPathElement().setLocation(f);
             return;
@@ -108,7 +109,7 @@ public class IvyCachePath extends IvyCacheTask {
             if (p.equals(".")) {
                 path.createPathElement().setLocation(f);
             } else {
-                path.createPathElement().setLocation(new File(f, p));
+                path.createPathElement().setLocation(FileUtil.newFile(f, p));
             }
         }
     }

--- a/src/java/org/apache/ivy/ant/IvyCheck.java
+++ b/src/java/org/apache/ivy/ant/IvyCheck.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.ivy.Ivy;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
@@ -84,7 +85,7 @@ public class IvyCheck extends IvyTask {
 
                 String[] srcFiles = ds.getIncludedFiles();
                 for (int j = 0; j < srcFiles.length; j++) {
-                    File file = new File(fromDir, srcFiles[j]);
+                    File file = FileUtil.newFile(fromDir, srcFiles[j]);
                     if (ivy.check(file.toURI().toURL(), resolvername)) {
                         Message.verbose("checked " + file + ": OK");
                     }

--- a/src/java/org/apache/ivy/ant/IvyDeliver.java
+++ b/src/java/org/apache/ivy/ant/IvyDeliver.java
@@ -29,6 +29,7 @@ import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.module.status.StatusManager;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.util.DateUtil;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.taskdefs.CallTarget;
@@ -350,7 +351,7 @@ public class IvyDeliver extends IvyTask {
         if (deliveryList == null) {
             String deliveryListPath = getProperty(settings, "ivy.delivery.list.file");
             if (deliveryListPath == null) {
-                deliveryList = new File(System.getProperty("java.io.tmpdir")
+                deliveryList = FileUtil.newFile(System.getProperty("java.io.tmpdir")
                         + "/delivery.properties");
             } else {
                 deliveryList = getProject().resolveFile(settings.substitute(deliveryListPath));

--- a/src/java/org/apache/ivy/ant/IvyExtractFromSources.java
+++ b/src/java/org/apache/ivy/ant/IvyExtractFromSources.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.ivy.core.module.id.ModuleRevisionId;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
@@ -142,7 +143,7 @@ public class IvyExtractFromSources extends Task {
             }
         }
         try {
-            PrintWriter writer = new PrintWriter(new FileOutputStream(to));
+            PrintWriter writer = new PrintWriter(FileUtil.newOutputStream(to));
             writer.println("<ivy-module version=\"1.0\">");
             writer.println("\t<info organisation=\"" + organisation + "\"");
             writer.println("\t       module=\"" + module + "\"");

--- a/src/java/org/apache/ivy/ant/IvyReport.java
+++ b/src/java/org/apache/ivy/ant/IvyReport.java
@@ -348,7 +348,7 @@ public class IvyReport extends IvyTask {
                 OutputStream outStream = null;
                 try {
                     inStream = new BufferedInputStream(FileUtil.newInputStream(reportFile));
-                    outStream = new BufferedOutputStream(new FileOutputStream(outFile));
+                    outStream = new BufferedOutputStream(FileUtil.newOutputStream(outFile));
                     StreamResult res = new StreamResult(outStream);
                     Source src = new StreamSource(inStream, JAXPUtils.getSystemId(style));
                     transformer.transform(src, res);

--- a/src/java/org/apache/ivy/ant/IvyReport.java
+++ b/src/java/org/apache/ivy/ant/IvyReport.java
@@ -310,7 +310,7 @@ public class IvyReport extends IvyTask {
         InputStream xsltStream = null;
         try {
             // create stream to stylesheet
-            xsltStream = new BufferedInputStream(new FileInputStream(style));
+            xsltStream = new BufferedInputStream(FileUtil.newInputStream(style));
             Source xsltSource = new StreamSource(xsltStream, JAXPUtils.getSystemId(style));
 
             // create transformer
@@ -347,7 +347,7 @@ public class IvyReport extends IvyTask {
                 InputStream inStream = null;
                 OutputStream outStream = null;
                 try {
-                    inStream = new BufferedInputStream(new FileInputStream(reportFile));
+                    inStream = new BufferedInputStream(FileUtil.newInputStream(reportFile));
                     outStream = new BufferedOutputStream(new FileOutputStream(outFile));
                     StreamResult res = new StreamResult(outStream);
                     Source src = new StreamSource(inStream, JAXPUtils.getSystemId(style));

--- a/src/java/org/apache/ivy/ant/IvyReport.java
+++ b/src/java/org/apache/ivy/ant/IvyReport.java
@@ -228,7 +228,7 @@ public class IvyReport extends IvyTask {
 
             File out;
             if (todir != null) {
-                out = new File(todir, getOutputPattern(confs[i], "xml"));
+                out = FileUtil.newFile(todir, getOutputPattern(confs[i], "xml"));
             } else {
                 out = getProject().resolveFile(getOutputPattern(confs[i], "xml"));
             }
@@ -244,7 +244,7 @@ public class IvyReport extends IvyTask {
         if (xslFile == null) {
             File css;
             if (todir != null) {
-                css = new File(todir, "ivy-report.css");
+                css = FileUtil.newFile(todir, "ivy-report.css");
             } else {
                 css = getProject().resolveFile("ivy-report.css");
             }
@@ -264,7 +264,7 @@ public class IvyReport extends IvyTask {
         // style should be a file (and not an url)
         // so we have to copy it from classpath to cache
         ResolutionCacheManager cacheMgr = getIvyInstance().getResolutionCacheManager();
-        File style = new File(cacheMgr.getResolutionCacheRoot(), "ivy-report.xsl");
+        File style = FileUtil.newFile(cacheMgr.getResolutionCacheRoot(), "ivy-report.xsl");
         if (!style.exists()) {
             Message.debug("copying ivy-report.xsl to " + style.getAbsolutePath());
             FileUtil.copy(XmlReportOutputter.class.getResourceAsStream("ivy-report.xsl"), style,
@@ -331,7 +331,7 @@ public class IvyReport extends IvyTask {
             for (int i = 0; i < confs.length; i++) {
                 File reportFile = cacheMgr
                         .getConfigurationResolveReportInCache(resolveId, confs[i]);
-                File outFile = new File(out, getOutputPattern(confs[i], ext));
+                File outFile = FileUtil.newFile(out, getOutputPattern(confs[i], ext));
 
                 log("Processing " + reportFile + " to " + outFile);
 
@@ -388,7 +388,7 @@ public class IvyReport extends IvyTask {
         // style should be a file (and not an url)
         // so we have to copy it from classpath to cache
         ResolutionCacheManager cacheMgr = getIvyInstance().getResolutionCacheManager();
-        File style = new File(cacheMgr.getResolutionCacheRoot(), styleResourceName);
+        File style = FileUtil.newFile(cacheMgr.getResolutionCacheRoot(), styleResourceName);
         FileUtil.copy(XmlReportOutputter.class.getResourceAsStream(styleResourceName), style, null);
         return style;
     }

--- a/src/java/org/apache/ivy/ant/IvyRepositoryReport.java
+++ b/src/java/org/apache/ivy/ant/IvyRepositoryReport.java
@@ -125,7 +125,7 @@ public class IvyRepositoryReport extends IvyTask {
             if (xml) {
 
                 FileUtil.copy(cacheMgr.getConfigurationResolveReportInCache(resolveId, "default"),
-                    new File(getTodir(), outputname + ".xml"), null);
+                    FileUtil.newFile(getTodir(), outputname + ".xml"), null);
             }
             if (xsl) {
                 genreport(cacheMgr, md.getModuleRevisionId().getOrganisation(), md
@@ -146,7 +146,7 @@ public class IvyRepositoryReport extends IvyTask {
 
         String resolveId = ResolveOptions.getDefaultResolveId(new ModuleId(organisation, module));
         xslt.setIn(cache.getConfigurationResolveReportInCache(resolveId, "default"));
-        xslt.setOut(new File(getTodir(), outputname + "." + xslext));
+        xslt.setOut(FileUtil.newFile(getTodir(), outputname + "." + xslext));
 
         xslt.setStyle(xslFile);
 
@@ -174,7 +174,7 @@ public class IvyRepositoryReport extends IvyTask {
     private String getGraphStylePath(File cache) throws IOException {
         // style should be a file (and not an url)
         // so we have to copy it from classpath to cache
-        File style = new File(cache, "ivy-report-graph-all.xsl");
+        File style = FileUtil.newFile(cache, "ivy-report-graph-all.xsl");
         FileUtil.copy(XmlReportOutputter.class.getResourceAsStream("ivy-report-graph-all.xsl"),
             style, null);
         return style.getAbsolutePath();
@@ -188,7 +188,7 @@ public class IvyRepositoryReport extends IvyTask {
     private String getDotStylePath(File cache) throws IOException {
         // style should be a file (and not an url)
         // so we have to copy it from classpath to cache
-        File style = new File(cache, "ivy-report-dot-all.xsl");
+        File style = FileUtil.newFile(cache, "ivy-report-dot-all.xsl");
         FileUtil.copy(XmlReportOutputter.class.getResourceAsStream("ivy-report-dot-all.xsl"),
             style, null);
         return style.getAbsolutePath();
@@ -203,7 +203,7 @@ public class IvyRepositoryReport extends IvyTask {
 
         String resolveId = ResolveOptions.getDefaultResolveId(new ModuleId(organisation, module));
         xslt.setIn(cache.getConfigurationResolveReportInCache(resolveId, "default"));
-        xslt.setOut(new File(getTodir(), outputname + "." + ext));
+        xslt.setOut(FileUtil.newFile(getTodir(), outputname + "." + ext));
         xslt.setBasedir(cache.getResolutionCacheRoot());
         xslt.setStyle(style);
         xslt.execute();

--- a/src/java/org/apache/ivy/ant/IvyVar.java
+++ b/src/java/org/apache/ivy/ant/IvyVar.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 
 import org.apache.ivy.Ivy;
 import org.apache.ivy.core.settings.IvySettings;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 
 /**
@@ -92,7 +93,7 @@ public class IvyVar extends IvyTask {
             InputStream is = null;
             try {
                 if (getFile() != null) {
-                    is = new FileInputStream(getFile());
+                    is = FileUtil.newInputStream(getFile());
                 } else if (getUrl() != null) {
                     is = new URL(getUrl()).openStream();
                 } else {

--- a/src/java/org/apache/ivy/core/RelativeUrlResolver.java
+++ b/src/java/org/apache/ivy/core/RelativeUrlResolver.java
@@ -17,6 +17,8 @@
  */
 package org.apache.ivy.core;
 
+import org.apache.ivy.util.FileUtil;
+
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -52,7 +54,7 @@ public abstract class RelativeUrlResolver {
      */
     public URL getURL(URL context, String file, String url) throws MalformedURLException {
         if (file != null) {
-            File f = new File(file);
+            File f = FileUtil.newFile(file);
             if (f.isAbsolute()) {
                 return f.toURI().toURL();
             } else {

--- a/src/java/org/apache/ivy/core/cache/DefaultRepositoryCacheManager.java
+++ b/src/java/org/apache/ivy/core/cache/DefaultRepositoryCacheManager.java
@@ -143,7 +143,7 @@ public class DefaultRepositoryCacheManager implements RepositoryCacheManager, Iv
     public File getIvyFileInCache(ModuleRevisionId mrid) {
         String file = IvyPatternHelper.substitute(getIvyPattern(),
             DefaultArtifact.newIvyArtifact(mrid, null));
-        return new File(getRepositoryCacheRoot(), file);
+        return FileUtil.newFile(getRepositoryCacheRoot(), file);
     }
 
     public String getIvyPattern() {
@@ -364,7 +364,7 @@ public class DefaultRepositoryCacheManager implements RepositoryCacheManager, Iv
      * the resolve has been done with useOrigin = true
      */
     public File getArchiveFileInCache(Artifact artifact, ArtifactOrigin origin) {
-        File archive = new File(getRepositoryCacheRoot(), getArchivePathInCache(artifact, origin));
+        File archive = FileUtil.newFile(getRepositoryCacheRoot(), getArchivePathInCache(artifact, origin));
         if (!archive.exists() && !ArtifactOrigin.isUnknown(origin) && origin.isLocal()) {
             File original = Checks.checkAbsolute(origin.getLocation(), artifact
                     + " origin location");
@@ -385,7 +385,7 @@ public class DefaultRepositoryCacheManager implements RepositoryCacheManager, Iv
         if (useOrigin && !ArtifactOrigin.isUnknown(origin) && origin.isLocal()) {
             return Checks.checkAbsolute(origin.getLocation(), artifact + " origin location");
         } else {
-            return new File(getRepositoryCacheRoot(), getArchivePathInCache(artifact, origin));
+            return FileUtil.newFile(getRepositoryCacheRoot(), getArchivePathInCache(artifact, origin));
         }
     }
 
@@ -665,7 +665,7 @@ public class DefaultRepositoryCacheManager implements RepositoryCacheManager, Iv
     }
 
     private PropertiesFile getCachedDataFile(ModuleRevisionId mRevId) {
-        return new PropertiesFile(new File(getRepositoryCacheRoot(), IvyPatternHelper.substitute(
+        return new PropertiesFile(FileUtil.newFile(getRepositoryCacheRoot(), IvyPatternHelper.substitute(
             getDataFilePattern(), mRevId)), "ivy cached data file for " + mRevId);
     }
 
@@ -757,7 +757,7 @@ public class DefaultRepositoryCacheManager implements RepositoryCacheManager, Iv
                             if (madr.getArtifactOrigin().isExists()) {
                                 if (madr.getArtifactOrigin().isLocal()
                                         && madr.getArtifactOrigin().getArtifact().getUrl() != null) {
-                                    madr.setOriginalLocalFile(new File(madr.getArtifactOrigin()
+                                    madr.setOriginalLocalFile(FileUtil.newFile(madr.getArtifactOrigin()
                                             .getArtifact().getUrl().toURI()));
                                 } else {
                                     // find locally cached file
@@ -1093,7 +1093,7 @@ public class DefaultRepositoryCacheManager implements RepositoryCacheManager, Iv
                         if (archiveFile.exists()) {
                             archiveFile.delete();
                         }
-                        File part = new File(archiveFile.getAbsolutePath() + ".part");
+                        File part = FileUtil.newFile(archiveFile.getAbsolutePath() + ".part");
                         repository.get(resource.getName(), part);
                         if (!part.renameTo(archiveFile)) {
                             throw new IOException(
@@ -1511,7 +1511,7 @@ public class DefaultRepositoryCacheManager implements RepositoryCacheManager, Iv
             // keep a copy of the original file
             if (dest.exists()) {
                 originalPath = dest.getAbsolutePath();
-                backup = new File(dest.getAbsolutePath() + ".backup");
+                backup = FileUtil.newFile(dest.getAbsolutePath() + ".backup");
                 FileUtil.copy(dest, backup, null, true);
             }
             delegate.download(artifact, resource, dest);
@@ -1519,7 +1519,7 @@ public class DefaultRepositoryCacheManager implements RepositoryCacheManager, Iv
 
         public void restore() throws IOException {
             if ((backup != null) && backup.exists()) {
-                File original = new File(originalPath);
+                File original = FileUtil.newFile(originalPath);
                 FileUtil.copy(backup, original, null, true);
                 backup.delete();
             }

--- a/src/java/org/apache/ivy/core/cache/DefaultResolutionCacheManager.java
+++ b/src/java/org/apache/ivy/core/cache/DefaultResolutionCacheManager.java
@@ -170,7 +170,7 @@ public class DefaultResolutionCacheManager implements ResolutionCacheManager, Iv
         if (!paths.isEmpty()) {
             File parentsFile = getResolvedIvyPropertiesInCache(ModuleRevisionId.newInstance(mrevId,
                 mrevId.getRevision() + "-parents"));
-            FileOutputStream out = new FileOutputStream(parentsFile);
+            OutputStream out = FileUtil.newOutputStream(parentsFile);
             paths.store(out, null);
             out.close();
         }

--- a/src/java/org/apache/ivy/core/cache/DefaultResolutionCacheManager.java
+++ b/src/java/org/apache/ivy/core/cache/DefaultResolutionCacheManager.java
@@ -112,17 +112,17 @@ public class DefaultResolutionCacheManager implements ResolutionCacheManager, Iv
     public File getResolvedIvyFileInCache(ModuleRevisionId mrid) {
         String file = IvyPatternHelper.substitute(getResolvedIvyPattern(), mrid.getOrganisation(),
             mrid.getName(), mrid.getRevision(), "ivy", "ivy", "xml");
-        return new File(getResolutionCacheRoot(), file);
+        return FileUtil.newFile(getResolutionCacheRoot(), file);
     }
 
     public File getResolvedIvyPropertiesInCache(ModuleRevisionId mrid) {
         String file = IvyPatternHelper.substitute(getResolvedIvyPropertiesPattern(),
             mrid.getOrganisation(), mrid.getName(), mrid.getRevision(), "ivy", "ivy", "xml");
-        return new File(getResolutionCacheRoot(), file);
+        return FileUtil.newFile(getResolutionCacheRoot(), file);
     }
 
     public File getConfigurationResolveReportInCache(String resolveId, String conf) {
-        return new File(getResolutionCacheRoot(), resolveId + "-" + conf + ".xml");
+        return FileUtil.newFile(getResolutionCacheRoot(), resolveId + "-" + conf + ".xml");
     }
 
     public File[] getConfigurationResolveReportsInCache(final String resolveId) {
@@ -286,7 +286,7 @@ public class DefaultResolutionCacheManager implements ResolutionCacheManager, Iv
                 String file = path.substring(path.lastIndexOf('/') + 1);
 
                 if (paths.containsKey(file + "|" + url)) {
-                    File result = new File(paths.get(file + "|" + url).toString());
+                    File result = FileUtil.newFile(paths.get(file + "|" + url).toString());
                     return result.toURI().toURL();
                 }
             }

--- a/src/java/org/apache/ivy/core/cache/DefaultResolutionCacheManager.java
+++ b/src/java/org/apache/ivy/core/cache/DefaultResolutionCacheManager.java
@@ -17,11 +17,7 @@
  */
 package org.apache.ivy.core.cache;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FilenameFilter;
-import java.io.IOException;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.ParseException;
@@ -147,7 +143,7 @@ public class DefaultResolutionCacheManager implements ResolutionCacheManager, Iv
         File parentsFile = getResolvedIvyPropertiesInCache(ModuleRevisionId.newInstance(mrid,
             mrid.getRevision() + "-parents"));
         if (parentsFile.exists()) {
-            FileInputStream in = new FileInputStream(parentsFile);
+            InputStream in = FileUtil.newInputStream(parentsFile);
             paths.load(in);
             in.close();
         }

--- a/src/java/org/apache/ivy/core/deliver/DeliverEngine.java
+++ b/src/java/org/apache/ivy/core/deliver/DeliverEngine.java
@@ -20,6 +20,7 @@ package org.apache.ivy.core.deliver;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -39,6 +40,7 @@ import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorUpdater;
 import org.apache.ivy.plugins.report.XmlReportParser;
 import org.apache.ivy.plugins.repository.Resource;
 import org.apache.ivy.util.ConfigurationUtils;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 import org.xml.sax.SAXException;
 
@@ -120,7 +122,7 @@ public class DeliverEngine {
                     + "; please resolve dependencies before delivering!");
         }
         Properties props = new Properties();
-        FileInputStream in = new FileInputStream(ivyProperties);
+        InputStream in = FileUtil.newInputStream(ivyProperties);
         props.load(in);
         in.close();
 

--- a/src/java/org/apache/ivy/core/pack/PackagingManager.java
+++ b/src/java/org/apache/ivy/core/pack/PackagingManager.java
@@ -26,6 +26,7 @@ import org.apache.ivy.core.module.descriptor.Artifact;
 import org.apache.ivy.core.module.descriptor.DefaultArtifact;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.IvySettingsAware;
+import org.apache.ivy.util.FileUtil;
 
 public class PackagingManager implements IvySettingsAware {
 
@@ -82,7 +83,7 @@ public class PackagingManager implements IvySettingsAware {
         String[] packings = packaging.split(",");
         InputStream in = null;
         try {
-            in = new FileInputStream(localFile);
+            in = FileUtil.newInputStream(localFile);
             for (int i = packings.length - 1; i >= 1; i--) {
                 ArchivePacking packing = settings.getPackingRegistry().get(packings[i]);
                 if (packing == null) {

--- a/src/java/org/apache/ivy/core/pack/ZipPacking.java
+++ b/src/java/org/apache/ivy/core/pack/ZipPacking.java
@@ -17,10 +17,7 @@
  */
 package org.apache.ivy.core.pack;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -66,7 +63,7 @@ public class ZipPacking extends ArchivePacking {
                 if (entry.isDirectory()) {
                     f.mkdirs();
                 } else {
-                    FileOutputStream out = new FileOutputStream(f);
+                    OutputStream out = FileUtil.newOutputStream(f);
                     try {
                         FileUtil.copy(zip, out, null, false);
                     } finally {

--- a/src/java/org/apache/ivy/core/pack/ZipPacking.java
+++ b/src/java/org/apache/ivy/core/pack/ZipPacking.java
@@ -54,7 +54,7 @@ public class ZipPacking extends ArchivePacking {
             zip = new ZipInputStream(packed);
             ZipEntry entry = null;
             while (((entry = zip.getNextEntry()) != null)) {
-                File f = new File(dest, entry.getName());
+                File f = FileUtil.newFile(dest, entry.getName());
                 Message.verbose("\t\texpanding " + entry.getName() + " to " + f);
 
                 // create intermediary directories - sometimes zip don't add them

--- a/src/java/org/apache/ivy/core/resolve/ResolveEngine.java
+++ b/src/java/org/apache/ivy/core/resolve/ResolveEngine.java
@@ -20,6 +20,7 @@ package org.apache.ivy.core.resolve;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URL;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -69,6 +70,7 @@ import org.apache.ivy.plugins.parser.ModuleDescriptorParserRegistry;
 import org.apache.ivy.plugins.repository.url.URLResource;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
 import org.apache.ivy.plugins.version.VersionMatcher;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 import org.apache.ivy.util.filter.Filter;
 
@@ -323,7 +325,7 @@ public class ResolveEngine {
                     }
                 }
             }
-            FileOutputStream out = new FileOutputStream(ivyPropertiesInCache);
+            OutputStream out = FileUtil.newOutputStream(ivyPropertiesInCache);
             props.store(out, md.getResolvedModuleRevisionId() + " resolved revisions");
             out.close();
             Message.verbose("\tresolved ivy file produced in cache");

--- a/src/java/org/apache/ivy/core/settings/IvySettings.java
+++ b/src/java/org/apache/ivy/core/settings/IvySettings.java
@@ -477,13 +477,13 @@ public class IvySettings implements SortEngineSettings, PublishEngineSettings, P
 
     public synchronized void setSettingsVariables(File settingsFile) {
         try {
-            setVariable("ivy.settings.dir", new File(settingsFile.getAbsolutePath()).getParent());
+            setVariable("ivy.settings.dir", FileUtil.newFile(settingsFile.getAbsolutePath()).getParent());
             setDeprecatedVariable("ivy.conf.dir", "ivy.settings.dir");
             setVariable("ivy.settings.file", settingsFile.getAbsolutePath());
             setDeprecatedVariable("ivy.conf.file", "ivy.settings.file");
             setVariable("ivy.settings.url", settingsFile.toURI().toURL().toExternalForm());
             setDeprecatedVariable("ivy.conf.url", "ivy.settings.url");
-            setVariable("ivy.settings.dir.url", new File(settingsFile.getAbsolutePath())
+            setVariable("ivy.settings.dir.url", FileUtil.newFile(settingsFile.getAbsolutePath())
                     .getParentFile().toURI().toURL().toExternalForm());
         } catch (MalformedURLException e) {
             IllegalArgumentException iae = new IllegalArgumentException(
@@ -821,7 +821,7 @@ public class IvySettings implements SortEngineSettings, PublishEngineSettings, P
                 Message.verbose("using ivy.default.ivy.user.dir variable for default ivy user dir: "
                         + defaultUserDir);
             } else {
-                setDefaultIvyUserDir(new File(System.getProperty("user.home"), ".ivy2"));
+                setDefaultIvyUserDir(FileUtil.newFile(System.getProperty("user.home"), ".ivy2"));
                 Message.verbose("no default ivy user dir defined: set to " + defaultUserDir);
             }
         }
@@ -840,7 +840,7 @@ public class IvySettings implements SortEngineSettings, PublishEngineSettings, P
             if (cache != null) {
                 defaultCache = Checks.checkAbsolute(cache, "ivy.cache.dir");
             } else {
-                setDefaultCache(new File(getDefaultIvyUserDir(), "cache"));
+                setDefaultCache(FileUtil.newFile(getDefaultIvyUserDir(), "cache"));
                 Message.verbose("no default cache defined: set to " + defaultCache);
             }
         }

--- a/src/java/org/apache/ivy/core/settings/IvySettings.java
+++ b/src/java/org/apache/ivy/core/settings/IvySettings.java
@@ -190,7 +190,7 @@ public class IvySettings implements SortEngineSettings, PublishEngineSettings, P
 
     private File defaultUserDir;
 
-    private File baseDir = new File(".").getAbsoluteFile();
+    private File baseDir = FileUtil.newFile(".").getAbsoluteFile();
 
     private List classpathURLs = new ArrayList();
 

--- a/src/java/org/apache/ivy/core/settings/IvySettings.java
+++ b/src/java/org/apache/ivy/core/settings/IvySettings.java
@@ -234,7 +234,7 @@ public class IvySettings implements SortEngineSettings, PublishEngineSettings, P
             for (int i = 0; i < files.length; i++) {
                 try {
                     typeDefs(
-                        new FileInputStream(Checks.checkAbsolute(files[i].trim(),
+                        FileUtil.newInputStream(Checks.checkAbsolute(files[i].trim(),
                             "ivy.typedef.files")), true);
                 } catch (FileNotFoundException e) {
                     Message.warn("typedefs file not found: " + files[i].trim());
@@ -558,7 +558,7 @@ public class IvySettings implements SortEngineSettings, PublishEngineSettings, P
     }
 
     public synchronized void loadProperties(File file, boolean overwrite) throws IOException {
-        loadProperties(new FileInputStream(file), overwrite);
+        loadProperties(FileUtil.newInputStream(file), overwrite);
     }
 
     private void loadProperties(InputStream stream, boolean overwrite) throws IOException {

--- a/src/java/org/apache/ivy/core/settings/XmlSettingsParser.java
+++ b/src/java/org/apache/ivy/core/settings/XmlSettingsParser.java
@@ -43,10 +43,7 @@ import org.apache.ivy.plugins.conflict.ConflictManager;
 import org.apache.ivy.plugins.latest.LatestStrategy;
 import org.apache.ivy.plugins.lock.LockStrategy;
 import org.apache.ivy.plugins.matcher.PatternMatcher;
-import org.apache.ivy.util.Checks;
-import org.apache.ivy.util.Configurator;
-import org.apache.ivy.util.FileResolver;
-import org.apache.ivy.util.Message;
+import org.apache.ivy.util.*;
 import org.apache.ivy.util.url.CredentialsStore;
 import org.apache.ivy.util.url.URLHandler;
 import org.apache.ivy.util.url.URLHandlerRegistry;
@@ -416,7 +413,7 @@ public class XmlSettingsParser extends DefaultHandler {
                 Message.verbose("including file: " + settingsURL);
                 if ("file".equals(settingsURL.getProtocol())) {
                     try {
-                        File settingsFile = new File(new URI(settingsURL.toExternalForm()));
+                        File settingsFile = FileUtil.newFile(new URI(settingsURL.toExternalForm()));
                         String optional = (String) attributes.get("optional");
                         if ("true".equals(optional) && !settingsFile.exists()) {
                             return;
@@ -451,7 +448,7 @@ public class XmlSettingsParser extends DefaultHandler {
             // ignore, we'll try to create a correct URL below
         }
 
-        File incFile = new File(filePath);
+        File incFile = FileUtil.newFile(filePath);
         if (incFile.isAbsolute()) {
             if (!incFile.exists()) {
                 throw new FileNotFoundException(incFile.getAbsolutePath());
@@ -459,11 +456,11 @@ public class XmlSettingsParser extends DefaultHandler {
             return incFile.toURI().toURL();
         } else if ("file".equals(this.settings.getProtocol())) {
             try {
-                File settingsFile = new File(new URI(this.settings.toExternalForm()));
+                File settingsFile = FileUtil.newFile(new URI(this.settings.toExternalForm()));
                 if (!settingsFile.exists()) {
                     throw new FileNotFoundException(settingsFile.getAbsolutePath());
                 }
-                return new File(settingsFile.getParentFile(), filePath).toURI().toURL();
+                return FileUtil.newFile(settingsFile.getParentFile(), filePath).toURI().toURL();
             } catch (URISyntaxException e) {
                 return new URL(this.settings, filePath);
             }

--- a/src/java/org/apache/ivy/osgi/core/ManifestParser.java
+++ b/src/java/org/apache/ivy/osgi/core/ManifestParser.java
@@ -30,6 +30,7 @@ import java.util.jar.Manifest;
 
 import org.apache.ivy.osgi.util.Version;
 import org.apache.ivy.osgi.util.VersionRange;
+import org.apache.ivy.util.FileUtil;
 
 /**
  * Provides an OSGi manifest parser.
@@ -83,7 +84,7 @@ public class ManifestParser {
     }
 
     public static BundleInfo parseManifest(File manifestFile) throws IOException, ParseException {
-        FileInputStream fis = new FileInputStream(manifestFile);
+        InputStream fis = FileUtil.newInputStream(manifestFile);
         try {
             BundleInfo parseManifest = parseManifest(fis);
             return parseManifest;

--- a/src/java/org/apache/ivy/osgi/obr/OBRResolver.java
+++ b/src/java/org/apache/ivy/osgi/obr/OBRResolver.java
@@ -17,10 +17,7 @@
  */
 package org.apache.ivy.osgi.obr;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -117,9 +114,9 @@ public class OBRResolver extends AbstractOSGiResolver {
     }
 
     private void loadRepoFromFile(URI baseUri, File repoFile, String sourceLocation) {
-        FileInputStream in;
+        InputStream in;
         try {
-            in = new FileInputStream(repoFile);
+            in = FileUtil.newInputStream(repoFile);
         } catch (FileNotFoundException e) {
             throw new RuntimeException("The OBR repository resolver " + getName()
                     + " couldn't be configured: the file " + sourceLocation + " was not found");

--- a/src/java/org/apache/ivy/osgi/obr/OBRResolver.java
+++ b/src/java/org/apache/ivy/osgi/obr/OBRResolver.java
@@ -34,6 +34,7 @@ import org.apache.ivy.osgi.obr.xml.OBRXMLParser;
 import org.apache.ivy.osgi.repo.AbstractOSGiResolver;
 import org.apache.ivy.plugins.repository.Resource;
 import org.apache.ivy.plugins.repository.url.URLResource;
+import org.apache.ivy.util.FileUtil;
 import org.xml.sax.SAXException;
 
 public class OBRResolver extends AbstractOSGiResolver {
@@ -68,7 +69,7 @@ public class OBRResolver extends AbstractOSGiResolver {
                     + " couldn't be configured: repoXmlFile and repoXmlUrl cannot be set both");
         }
         if (repoXmlFile != null) {
-            File f = new File(repoXmlFile);
+            File f = FileUtil.newFile(repoXmlFile);
             loadRepoFromFile(f.getParentFile().toURI(), f, repoXmlFile);
         } else if (repoXmlURL != null) {
             final URL url;

--- a/src/java/org/apache/ivy/osgi/repo/ArtifactReportManifestIterable.java
+++ b/src/java/org/apache/ivy/osgi/repo/ArtifactReportManifestIterable.java
@@ -17,10 +17,7 @@
  */
 package org.apache.ivy.osgi.repo;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
+import java.io.*;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -96,9 +93,9 @@ public class ArtifactReportManifestIterable implements Iterable<ManifestAndLocat
                     }
                 }
                 if (jar.getUnpackedLocalFile() != null && jar.getUnpackedLocalFile().isDirectory()) {
-                    FileInputStream in = null;
+                    InputStream in = null;
                     try {
-                        in = new FileInputStream(FileUtil.newFile(jar.getUnpackedLocalFile(),
+                        in = FileUtil.newInputStream(FileUtil.newFile(jar.getUnpackedLocalFile(),
                                 "META-INF/MANIFEST.MF"));
                         next = new ManifestAndLocation(new Manifest(in), jar.getUnpackedLocalFile()
                                 .toURI(), sourceURI);
@@ -127,7 +124,7 @@ public class ArtifactReportManifestIterable implements Iterable<ManifestAndLocat
                     }
                     JarInputStream in = null;
                     try {
-                        in = new JarInputStream(new FileInputStream(artifact));
+                        in = new JarInputStream(FileUtil.newInputStream(artifact));
                         Manifest manifest = in.getManifest();
                         if (manifest != null) {
                             next = new ManifestAndLocation(manifest, artifact.toURI(), sourceURI);

--- a/src/java/org/apache/ivy/osgi/repo/ArtifactReportManifestIterable.java
+++ b/src/java/org/apache/ivy/osgi/repo/ArtifactReportManifestIterable.java
@@ -33,6 +33,7 @@ import java.util.jar.Manifest;
 
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.report.ArtifactDownloadReport;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 
 public class ArtifactReportManifestIterable implements Iterable<ManifestAndLocation> {
@@ -97,7 +98,7 @@ public class ArtifactReportManifestIterable implements Iterable<ManifestAndLocat
                 if (jar.getUnpackedLocalFile() != null && jar.getUnpackedLocalFile().isDirectory()) {
                     FileInputStream in = null;
                     try {
-                        in = new FileInputStream(new File(jar.getUnpackedLocalFile(),
+                        in = new FileInputStream(FileUtil.newFile(jar.getUnpackedLocalFile(),
                                 "META-INF/MANIFEST.MF"));
                         next = new ManifestAndLocation(new Manifest(in), jar.getUnpackedLocalFile()
                                 .toURI(), sourceURI);

--- a/src/java/org/apache/ivy/osgi/repo/FSManifestIterable.java
+++ b/src/java/org/apache/ivy/osgi/repo/FSManifestIterable.java
@@ -17,6 +17,8 @@
  */
 package org.apache.ivy.osgi.repo;
 
+import org.apache.ivy.util.FileUtil;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
@@ -99,7 +101,7 @@ public class FSManifestIterable extends AbstractFSManifestIterable<File> {
     }
 
     protected InputStream getInputStream(File f) throws FileNotFoundException {
-        return new FileInputStream(f);
+        return FileUtil.newInputStream(f);
     }
 
     protected List<File> listBundleFiles(File dir) {

--- a/src/java/org/apache/ivy/osgi/repo/RepositoryManifestIterable.java
+++ b/src/java/org/apache/ivy/osgi/repo/RepositoryManifestIterable.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.apache.ivy.plugins.repository.Repository;
 import org.apache.ivy.plugins.repository.Resource;
 import org.apache.ivy.plugins.resolver.util.ResolverHelper;
+import org.apache.ivy.util.FileUtil;
 
 public class RepositoryManifestIterable extends AbstractFSManifestIterable<String> {
 
@@ -51,7 +52,7 @@ public class RepositoryManifestIterable extends AbstractFSManifestIterable<Strin
         try {
             return new URI(resource.getName());
         } catch (URISyntaxException e) {
-            return new File(resource.getName()).toURI();
+            return FileUtil.newFile(resource.getName()).toURI();
         }
     }
 

--- a/src/java/org/apache/ivy/osgi/updatesite/UpdateSiteLoader.java
+++ b/src/java/org/apache/ivy/osgi/updatesite/UpdateSiteLoader.java
@@ -46,6 +46,7 @@ import org.apache.ivy.osgi.updatesite.xml.UpdateSite;
 import org.apache.ivy.osgi.updatesite.xml.UpdateSiteDigestParser;
 import org.apache.ivy.plugins.repository.url.URLRepository;
 import org.apache.ivy.plugins.repository.url.URLResource;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 import org.xml.sax.SAXException;
 
@@ -195,9 +196,9 @@ public class UpdateSiteLoader {
                 return false;
             }
 
-            readIn = new FileInputStream(report.getLocalFile());
+            readIn = FileUtil.newInputStream(report.getLocalFile());
         } else {
-            InputStream in = new FileInputStream(report.getLocalFile());
+            InputStream in = FileUtil.newInputStream(report.getLocalFile());
 
             try {
                 // compressed, let's get the pointer on the actual xml
@@ -232,7 +233,7 @@ public class UpdateSiteLoader {
         if (report.getDownloadStatus() == DownloadStatus.FAILED) {
             return null;
         }
-        InputStream in = new FileInputStream(report.getLocalFile());
+        InputStream in = FileUtil.newInputStream(report.getLocalFile());
         try {
             UpdateSite site = EclipseUpdateSiteParser.parse(in);
             site.setUri(normalizeSiteUri(site.getUri(), siteUri));
@@ -281,7 +282,7 @@ public class UpdateSiteLoader {
         if (report.getDownloadStatus() == DownloadStatus.FAILED) {
             return null;
         }
-        InputStream in = new FileInputStream(report.getLocalFile());
+        InputStream in = FileUtil.newInputStream(report.getLocalFile());
         try {
             ZipInputStream zipped = findEntry(in, "digest.xml");
             if (zipped == null) {
@@ -307,7 +308,7 @@ public class UpdateSiteLoader {
             if (report.getDownloadStatus() == DownloadStatus.FAILED) {
                 return null;
             }
-            InputStream in = new FileInputStream(report.getLocalFile());
+            InputStream in = FileUtil.newInputStream(report.getLocalFile());
             try {
                 ZipInputStream zipped = findEntry(in, "feature.xml");
                 if (zipped == null) {

--- a/src/java/org/apache/ivy/osgi/util/ZipUtil.java
+++ b/src/java/org/apache/ivy/osgi/util/ZipUtil.java
@@ -17,10 +17,9 @@
  */
 package org.apache.ivy.osgi.util;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.OutputStream;
+import org.apache.ivy.util.FileUtil;
+
+import java.io.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -53,7 +52,7 @@ public class ZipUtil {
                 strAbsPath.length());
 
             final byte[] b = new byte[(int) (currDir.length())];
-            final FileInputStream fis = new FileInputStream(currDir);
+            final InputStream fis = FileUtil.newInputStream(currDir);
             fis.read(b);
             fis.close();
 

--- a/src/java/org/apache/ivy/plugins/lock/ArtifactLockStrategy.java
+++ b/src/java/org/apache/ivy/plugins/lock/ArtifactLockStrategy.java
@@ -20,6 +20,7 @@ package org.apache.ivy.plugins.lock;
 import java.io.File;
 
 import org.apache.ivy.core.module.descriptor.Artifact;
+import org.apache.ivy.util.FileUtil;
 
 public abstract class ArtifactLockStrategy extends FileBasedLockStrategy {
 
@@ -29,10 +30,10 @@ public abstract class ArtifactLockStrategy extends FileBasedLockStrategy {
 
     public boolean lockArtifact(Artifact artifact, File artifactFileToDownload)
             throws InterruptedException {
-        return acquireLock(new File(artifactFileToDownload.getAbsolutePath() + ".lck"));
+        return acquireLock(FileUtil.newFile(artifactFileToDownload.getAbsolutePath() + ".lck"));
     }
 
     public void unlockArtifact(Artifact artifact, File artifactFileToDownload) {
-        releaseLock(new File(artifactFileToDownload.getAbsolutePath() + ".lck"));
+        releaseLock(FileUtil.newFile(artifactFileToDownload.getAbsolutePath() + ".lck"));
     }
 }

--- a/src/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorWriter.java
+++ b/src/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorWriter.java
@@ -45,6 +45,7 @@ import org.apache.ivy.core.settings.IvyVariableContainer;
 import org.apache.ivy.plugins.parser.m2.PomWriterOptions.ConfigurationScopeMapping;
 import org.apache.ivy.plugins.parser.m2.PomWriterOptions.ExtraDependency;
 import org.apache.ivy.util.ConfigurationUtils;
+import org.apache.ivy.util.FileUtil;
 
 public final class PomModuleDescriptorWriter {
 
@@ -78,7 +79,7 @@ public final class PomModuleDescriptorWriter {
         if (output.getParentFile() != null) {
             output.getParentFile().mkdirs();
         }
-        PrintWriter out = new PrintWriter(new OutputStreamWriter(new FileOutputStream(output),
+        PrintWriter out = new PrintWriter(new OutputStreamWriter(FileUtil.newOutputStream(output),
                 "UTF-8"));
         try {
             IvySettings settings = IvyContext.getContext().getSettings();

--- a/src/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorWriter.java
+++ b/src/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorWriter.java
@@ -72,7 +72,7 @@ public final class PomModuleDescriptorWriter {
             in = new LineNumberReader(new InputStreamReader(
                     PomModuleDescriptorWriter.class.getResourceAsStream("pom.template")));
         } else {
-            in = new LineNumberReader(new InputStreamReader(new FileInputStream(
+            in = new LineNumberReader(new InputStreamReader(FileUtil.newInputStream(
                     options.getTemplate())));
         }
 

--- a/src/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorParser.java
+++ b/src/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorParser.java
@@ -674,13 +674,13 @@ public class XmlModuleDescriptorParser extends AbstractModuleDescriptorParser {
                 return null;
             }
 
-            File file = new File(location);
+            File file = FileUtil.newFile(location);
             if (!file.isAbsolute()) {
                 URL url = settings.getRelativeUrlResolver().getURL(descriptorURL, location);
                 try {
-                    file = new File(new URI(url.toExternalForm()));
+                    file = FileUtil.newFile(new URI(url.toExternalForm()));
                 } catch (URISyntaxException e) {
-                    file = new File(url.getPath());
+                    file = FileUtil.newFile(url.getPath());
                 }
             }
 

--- a/src/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorUpdater.java
+++ b/src/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorUpdater.java
@@ -55,10 +55,7 @@ import org.apache.ivy.plugins.parser.ParserSettings;
 import org.apache.ivy.plugins.repository.Resource;
 import org.apache.ivy.plugins.repository.file.FileResource;
 import org.apache.ivy.plugins.repository.url.URLResource;
-import org.apache.ivy.util.Checks;
-import org.apache.ivy.util.DateUtil;
-import org.apache.ivy.util.Message;
-import org.apache.ivy.util.XMLHelper;
+import org.apache.ivy.util.*;
 import org.apache.ivy.util.extendable.ExtendableItemHelper;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
@@ -95,7 +92,7 @@ public final class XmlModuleDescriptorUpdater {
         if (destFile.getParentFile() != null) {
             destFile.getParentFile().mkdirs();
         }
-        OutputStream destStream = new FileOutputStream(destFile);
+        OutputStream destStream = FileUtil.newOutputStream(destFile);
         try {
             update(srcURL, destStream, options);
         } finally {
@@ -132,7 +129,7 @@ public final class XmlModuleDescriptorUpdater {
         if (destFile.getParentFile() != null) {
             destFile.getParentFile().mkdirs();
         }
-        OutputStream fos = new FileOutputStream(destFile);
+        OutputStream fos = FileUtil.newOutputStream(destFile);
         try {
             // TODO: use resource as input stream context?
             URL inputStreamContext = null;

--- a/src/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorWriter.java
+++ b/src/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorWriter.java
@@ -43,10 +43,7 @@ import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
 import org.apache.ivy.core.module.descriptor.OverrideDependencyDescriptorMediator;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.plugins.matcher.MapMatcher;
-import org.apache.ivy.util.DateUtil;
-import org.apache.ivy.util.Message;
-import org.apache.ivy.util.StringUtils;
-import org.apache.ivy.util.XMLHelper;
+import org.apache.ivy.util.*;
 import org.apache.ivy.util.extendable.ExtendableItem;
 
 /**
@@ -67,7 +64,7 @@ public final class XmlModuleDescriptorWriter {
         if (output.getParentFile() != null) {
             output.getParentFile().mkdirs();
         }
-        PrintWriter out = new PrintWriter(new OutputStreamWriter(new FileOutputStream(output),
+        PrintWriter out = new PrintWriter(new OutputStreamWriter(FileUtil.newOutputStream(output),
                 "UTF-8"));
         try {
             out.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");

--- a/src/java/org/apache/ivy/plugins/report/XmlReportOutputter.java
+++ b/src/java/org/apache/ivy/plugins/report/XmlReportOutputter.java
@@ -61,8 +61,8 @@ public class XmlReportOutputter implements ReportOutputter {
         Message.verbose("\treport for " + report.getModuleDescriptor().getModuleRevisionId() + " "
                 + report.getConfiguration() + " produced in " + reportFile);
 
-        File reportXsl = new File(reportParentDir, "ivy-report.xsl");
-        File reportCss = new File(reportParentDir, "ivy-report.css");
+        File reportXsl = FileUtil.newFile(reportParentDir, "ivy-report.xsl");
+        File reportCss = FileUtil.newFile(reportParentDir, "ivy-report.css");
         if (!reportXsl.exists()) {
             FileUtil.copy(XmlReportOutputter.class.getResourceAsStream("ivy-report.xsl"),
                 reportXsl, null);

--- a/src/java/org/apache/ivy/plugins/report/XmlReportOutputter.java
+++ b/src/java/org/apache/ivy/plugins/report/XmlReportOutputter.java
@@ -54,7 +54,7 @@ public class XmlReportOutputter implements ReportOutputter {
             report.getConfiguration());
         File reportParentDir = reportFile.getParentFile();
         reportParentDir.mkdirs();
-        OutputStream stream = new FileOutputStream(reportFile);
+        OutputStream stream = FileUtil.newOutputStream(reportFile);
         writer.output(report, confs, stream);
         stream.close();
 

--- a/src/java/org/apache/ivy/plugins/report/XmlReportParser.java
+++ b/src/java/org/apache/ivy/plugins/report/XmlReportParser.java
@@ -38,6 +38,7 @@ import org.apache.ivy.core.report.ArtifactDownloadReport;
 import org.apache.ivy.core.report.DownloadStatus;
 import org.apache.ivy.core.report.MetadataArtifactDownloadReport;
 import org.apache.ivy.util.DateUtil;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.extendable.ExtendableItemHelper;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
@@ -129,10 +130,10 @@ public class XmlReportParser {
                         madr.setDownloadTimeMillis(Long.parseLong(attributes.getValue("time")));
                         madr.setSearched(parseBoolean(attributes.getValue("searched")));
                         if (attributes.getValue("location") != null) {
-                            madr.setLocalFile(new File(attributes.getValue("location")));
+                            madr.setLocalFile(FileUtil.newFile(attributes.getValue("location")));
                         }
                         if (attributes.getValue("original-local-location") != null) {
-                            madr.setOriginalLocalFile(new File(attributes
+                            madr.setOriginalLocalFile(FileUtil.newFile(attributes
                                     .getValue("original-local-location")));
                         }
                         if (attributes.getValue("origin-location") != null) {
@@ -161,10 +162,10 @@ public class XmlReportParser {
                     aReport.setSize(Long.parseLong(attributes.getValue("size")));
                     aReport.setDownloadTimeMillis(Long.parseLong(attributes.getValue("time")));
                     if (attributes.getValue("location") != null) {
-                        aReport.setLocalFile(new File(attributes.getValue("location")));
+                        aReport.setLocalFile(FileUtil.newFile(attributes.getValue("location")));
                     }
                     if (attributes.getValue("unpackedFile") != null) {
-                        aReport.setUnpackedLocalFile(new File(attributes.getValue("unpackedFile")));
+                        aReport.setUnpackedLocalFile(FileUtil.newFile(attributes.getValue("unpackedFile")));
                     }
                     revisionArtifacts.add(aReport);
                 } else if ("origin-location".equals(qName)) {

--- a/src/java/org/apache/ivy/plugins/repository/ResourceHelper.java
+++ b/src/java/org/apache/ivy/plugins/repository/ResourceHelper.java
@@ -22,6 +22,7 @@ import java.net.MalformedURLException;
 
 import org.apache.ivy.plugins.repository.file.FileResource;
 import org.apache.ivy.plugins.repository.url.URLResource;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 
 public final class ResourceHelper {
@@ -38,7 +39,7 @@ public final class ResourceHelper {
             return false;
         }
         if (res instanceof FileResource) {
-            return new File(res.getName()).equals(f);
+            return FileUtil.newFile(res.getName()).equals(f);
         } else if (res instanceof URLResource) {
             try {
                 return f.toURI().toURL().toExternalForm().equals(res.getName());

--- a/src/java/org/apache/ivy/plugins/repository/file/FileResource.java
+++ b/src/java/org/apache/ivy/plugins/repository/file/FileResource.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.ivy.plugins.repository.Resource;
+import org.apache.ivy.util.FileUtil;
 
 public class FileResource implements Resource {
     private File file;
@@ -71,6 +72,6 @@ public class FileResource implements Resource {
     }
 
     public InputStream openStream() throws IOException {
-        return new FileInputStream(file);
+        return FileUtil.newInputStream(file);
     }
 }

--- a/src/java/org/apache/ivy/plugins/repository/ssh/Scp.java
+++ b/src/java/org/apache/ivy/plugins/repository/ssh/Scp.java
@@ -533,7 +533,7 @@ public class Scp {
      */
     public void get(String remoteFile, String localTarget) throws IOException, RemoteScpException {
         File f = FileUtil.newFile(localTarget);
-        FileOutputStream fop = new FileOutputStream(f);
+        OutputStream fop = FileUtil.newOutputStream(f);
         get(remoteFile, fop);
     }
 

--- a/src/java/org/apache/ivy/plugins/repository/ssh/Scp.java
+++ b/src/java/org/apache/ivy/plugins/repository/ssh/Scp.java
@@ -30,6 +30,7 @@ import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
+import org.apache.ivy.util.FileUtil;
 
 /**
  * This class is using the scp client to transfer data and information for the repository.
@@ -295,7 +296,7 @@ public class Scp {
 
         readResponse(is);
 
-        File f = new File(localFile);
+        File f = FileUtil.newFile(localFile);
         long remain = f.length();
 
         String cMode = mode;
@@ -531,7 +532,7 @@ public class Scp {
      *             in case of problems on the target system (connection ok)
      */
     public void get(String remoteFile, String localTarget) throws IOException, RemoteScpException {
-        File f = new File(localTarget);
+        File f = FileUtil.newFile(localTarget);
         FileOutputStream fop = new FileOutputStream(f);
         get(remoteFile, fop);
     }

--- a/src/java/org/apache/ivy/plugins/repository/ssh/Scp.java
+++ b/src/java/org/apache/ivy/plugins/repository/ssh/Scp.java
@@ -310,10 +310,10 @@ public class Scp {
 
         readResponse(is);
 
-        FileInputStream fis = null;
+        InputStream fis = null;
 
         try {
-            fis = new FileInputStream(f);
+            fis = FileUtil.newInputStream(f);
 
             while (remain > 0) {
                 int trans;

--- a/src/java/org/apache/ivy/plugins/repository/url/URLRepository.java
+++ b/src/java/org/apache/ivy/plugins/repository/url/URLRepository.java
@@ -121,7 +121,7 @@ public class URLRepository extends AbstractRepository {
                 throw ioe;
             }
 
-            File file = new File(path);
+            File file = FileUtil.newFile(path);
             if (file.exists() && file.isDirectory()) {
                 String[] files = file.list();
                 List ret = new ArrayList(files.length);

--- a/src/java/org/apache/ivy/plugins/repository/url/URLResource.java
+++ b/src/java/org/apache/ivy/plugins/repository/url/URLResource.java
@@ -26,6 +26,7 @@ import java.net.URL;
 
 import org.apache.ivy.plugins.repository.LocalizableResource;
 import org.apache.ivy.plugins.repository.Resource;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.url.URLHandler.URLInfo;
 import org.apache.ivy.util.url.URLHandlerRegistry;
 
@@ -108,9 +109,9 @@ public class URLResource implements LocalizableResource {
                     + url);
         }
         try {
-            return new File(url.toURI());
+            return FileUtil.newFile(url.toURI());
         } catch (URISyntaxException e) {
-            return new File(url.getPath());
+            return FileUtil.newFile(url.getPath());
         }
     }
 }

--- a/src/java/org/apache/ivy/plugins/repository/vfs/VfsRepository.java
+++ b/src/java/org/apache/ivy/plugins/repository/vfs/VfsRepository.java
@@ -210,7 +210,7 @@ public class VfsRepository extends AbstractRepository {
                     + " to put data to: resource has no content");
         }
 
-        FileUtil.copy(new FileInputStream(source), dest.getContent().getOutputStream(), progress);
+        FileUtil.copy(FileUtil.newInputStream(source), dest.getContent().getOutputStream(), progress);
     }
 
 }

--- a/src/java/org/apache/ivy/plugins/repository/vsftp/VsftpRepository.java
+++ b/src/java/org/apache/ivy/plugins/repository/vsftp/VsftpRepository.java
@@ -39,6 +39,7 @@ import org.apache.ivy.plugins.repository.BasicResource;
 import org.apache.ivy.plugins.repository.Resource;
 import org.apache.ivy.plugins.repository.TransferEvent;
 import org.apache.ivy.util.Checks;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 
 /**
@@ -153,7 +154,7 @@ public class VsftpRepository extends AbstractRepository {
 
             int index = source.lastIndexOf('/');
             String srcName = index == -1 ? source : source.substring(index + 1);
-            final File to = destDir == null ? Checks.checkAbsolute(srcName, "source") : new File(
+            final File to = destDir == null ? Checks.checkAbsolute(srcName, "source") : FileUtil.newFile(
                     destDir, srcName);
 
             final IOException[] ex = new IOException[1];

--- a/src/java/org/apache/ivy/plugins/resolver/AbstractSshBasedResolver.java
+++ b/src/java/org/apache/ivy/plugins/resolver/AbstractSshBasedResolver.java
@@ -21,6 +21,7 @@ import java.io.File;
 
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.repository.ssh.AbstractSshBasedRepository;
+import org.apache.ivy.util.FileUtil;
 
 /**
  * Abstract base class for all resolvers using SSH All necessary connection parameters can be set
@@ -79,7 +80,7 @@ public abstract class AbstractSshBasedResolver extends RepositoryResolver {
         super.setSettings(settings);
         if (!passfileSet) {
             getSshBasedRepository().setPassFile(
-                new File(settings.getDefaultIvyUserDir(), getSshBasedRepository().getHost()
+                FileUtil.newFile(settings.getDefaultIvyUserDir(), getSshBasedRepository().getHost()
                         + ".ssh.passwd"));
         }
     }

--- a/src/java/org/apache/ivy/plugins/resolver/BasicResolver.java
+++ b/src/java/org/apache/ivy/plugins/resolver/BasicResolver.java
@@ -76,10 +76,7 @@ import org.apache.ivy.plugins.resolver.util.MDResolvedResource;
 import org.apache.ivy.plugins.resolver.util.ResolvedResource;
 import org.apache.ivy.plugins.resolver.util.ResourceMDParser;
 import org.apache.ivy.plugins.version.VersionMatcher;
-import org.apache.ivy.util.Checks;
-import org.apache.ivy.util.ChecksumHelper;
-import org.apache.ivy.util.HostUtil;
-import org.apache.ivy.util.Message;
+import org.apache.ivy.util.*;
 
 /**
  *
@@ -1040,10 +1037,10 @@ public abstract class BasicResolver extends AbstractResolver {
                 if ("file".equals(url.getProtocol())) {
                     File f;
                     try {
-                        f = new File(new URI(url.toExternalForm()));
+                        f = FileUtil.newFile(new URI(url.toExternalForm()));
                     } catch (URISyntaxException e) {
                         // unexpected, try to get the best of it
-                        f = new File(url.getPath());
+                        f = FileUtil.newFile(url.getPath());
                     }
                     resource = new FileResource(new FileRepository(), f);
                 } else {
@@ -1144,7 +1141,7 @@ public abstract class BasicResolver extends AbstractResolver {
             if (dest.exists()) {
                 dest.delete();
             }
-            File part = new File(dest.getAbsolutePath() + ".part");
+            File part = FileUtil.newFile(dest.getAbsolutePath() + ".part");
             if (resource.getName().equals(String.valueOf(artifact.getUrl()))) {
                 if (part.getParentFile() != null) {
                     part.getParentFile().mkdirs();

--- a/src/java/org/apache/ivy/plugins/resolver/BasicResolver.java
+++ b/src/java/org/apache/ivy/plugins/resolver/BasicResolver.java
@@ -368,7 +368,7 @@ public abstract class BasicResolver extends AbstractResolver {
                         XmlModuleDescriptorWriter.write(md, dest);
                     } else {
                         // copy and update ivy file from source to cache
-                        parser.toIvyFile(new FileInputStream(src),
+                        parser.toIvyFile(FileUtil.newInputStream(src),
                             originalMdResource.getResource(), dest, md);
                         long repLastModified = originalMdResource.getLastModified();
                         if (repLastModified > 0) {

--- a/src/java/org/apache/ivy/plugins/resolver/JarResolver.java
+++ b/src/java/org/apache/ivy/plugins/resolver/JarResolver.java
@@ -31,6 +31,7 @@ import org.apache.ivy.plugins.repository.Resource;
 import org.apache.ivy.plugins.repository.jar.JarRepository;
 import org.apache.ivy.plugins.repository.url.URLRepository;
 import org.apache.ivy.plugins.repository.url.URLResource;
+import org.apache.ivy.util.FileUtil;
 
 public class JarResolver extends RepositoryResolver {
 
@@ -45,7 +46,7 @@ public class JarResolver extends RepositoryResolver {
     }
 
     public void setFile(String jarFile) {
-        setJarFile(new File(jarFile));
+        setJarFile(FileUtil.newFile(jarFile));
     }
 
     public void setUrl(String jarUrl) {

--- a/src/java/org/apache/ivy/plugins/resolver/MirroredURLResolver.java
+++ b/src/java/org/apache/ivy/plugins/resolver/MirroredURLResolver.java
@@ -34,6 +34,7 @@ import org.apache.ivy.osgi.repo.RelativeURLRepository;
 import org.apache.ivy.plugins.repository.url.ChainedRepository;
 import org.apache.ivy.plugins.repository.url.URLRepository;
 import org.apache.ivy.plugins.repository.url.URLResource;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 
 public class MirroredURLResolver extends RepositoryResolver {
@@ -89,7 +90,7 @@ public class MirroredURLResolver extends RepositoryResolver {
     }
 
     private List/* <String> */readMirrorList(File mirrorListFile) throws IOException {
-        BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(
+        BufferedReader in = new BufferedReader(new InputStreamReader(FileUtil.newInputStream(
                 mirrorListFile)));
         List/* <String> */list = new ArrayList();
         try {

--- a/src/java/org/apache/ivy/plugins/resolver/packager/BuiltFileResource.java
+++ b/src/java/org/apache/ivy/plugins/resolver/packager/BuiltFileResource.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import org.apache.ivy.core.IvyPatternHelper;
 import org.apache.ivy.core.module.descriptor.Artifact;
 import org.apache.ivy.plugins.repository.Resource;
+import org.apache.ivy.util.FileUtil;
 
 /**
  * Represents an artifact built by a {@link PackagerResolver}.
@@ -44,7 +45,7 @@ public class BuiltFileResource implements Resource {
     }
 
     public BuiltFileResource(File dir, Artifact artifact) {
-        this(new File(dir, IvyPatternHelper.substitute(BUILT_ARTIFACT_PATTERN, artifact)));
+        this(FileUtil.newFile(dir, IvyPatternHelper.substitute(BUILT_ARTIFACT_PATTERN, artifact)));
     }
 
     public String getName() {
@@ -52,7 +53,7 @@ public class BuiltFileResource implements Resource {
     }
 
     public Resource clone(String name) {
-        return new BuiltFileResource(new File(name));
+        return new BuiltFileResource(FileUtil.newFile(name));
     }
 
     public long getLastModified() {

--- a/src/java/org/apache/ivy/plugins/resolver/packager/BuiltFileResource.java
+++ b/src/java/org/apache/ivy/plugins/resolver/packager/BuiltFileResource.java
@@ -81,6 +81,6 @@ public class BuiltFileResource implements Resource {
     }
 
     public InputStream openStream() throws IOException {
-        return new FileInputStream(file);
+        return FileUtil.newInputStream(file);
     }
 }

--- a/src/java/org/apache/ivy/plugins/resolver/packager/PackagerCacheEntry.java
+++ b/src/java/org/apache/ivy/plugins/resolver/packager/PackagerCacheEntry.java
@@ -126,8 +126,8 @@ public class PackagerCacheEntry {
         // Execute the Ant build file
         Project project = new Project();
         project.init();
-        project.setUserProperty("ant.file", new File(dir, "build.xml").getAbsolutePath());
-        ProjectHelper.configureProject(project, new File(dir, "build.xml"));
+        project.setUserProperty("ant.file", FileUtil.newFile(dir, "build.xml").getAbsolutePath());
+        ProjectHelper.configureProject(project, FileUtil.newFile(dir, "build.xml"));
         project.setBaseDir(dir);
 
         // Configure logging verbosity
@@ -202,7 +202,7 @@ public class PackagerCacheEntry {
     }
 
     protected void saveFile(String name, InputStream input) throws IOException {
-        FileUtil.copy(input, new File(this.dir, name), null);
+        FileUtil.copy(input, FileUtil.newFile(this.dir, name), null);
     }
 
     protected void saveFile(String name) throws IOException {
@@ -236,7 +236,7 @@ public class PackagerCacheEntry {
     }
 
     private static File getSubdir(File rootDir, ModuleRevisionId mr) {
-        return new File(rootDir, mr.getOrganisation() + File.separatorChar + mr.getName()
+        return FileUtil.newFile(rootDir, mr.getOrganisation() + File.separatorChar + mr.getName()
                 + File.separatorChar + mr.getRevision());
     }
 }

--- a/src/java/org/apache/ivy/plugins/resolver/util/FileURLLister.java
+++ b/src/java/org/apache/ivy/plugins/resolver/util/FileURLLister.java
@@ -17,6 +17,8 @@
  */
 package org.apache.ivy.plugins.resolver.util;
 
+import org.apache.ivy.util.FileUtil;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -44,12 +46,12 @@ public class FileURLLister implements URLLister {
     public List listAll(URL url) throws IOException {
         String path;
         try {
-            path = new File(new URI(url.toExternalForm())).getPath();
+            path = FileUtil.newFile(new URI(url.toExternalForm())).getPath();
         } catch (URISyntaxException e) {
             // unexpected try to get the best of it
             path = url.getPath();
         }
-        File file = basedir == null ? new File(path) : new File(basedir, path);
+        File file = basedir == null ? FileUtil.newFile(path) : FileUtil.newFile(basedir, path);
         if (file.exists() && file.isDirectory()) {
             String[] files = file.list();
             List ret = new ArrayList(files.length);

--- a/src/java/org/apache/ivy/plugins/signer/bouncycastle/OpenPGPSignatureGenerator.java
+++ b/src/java/org/apache/ivy/plugins/signer/bouncycastle/OpenPGPSignatureGenerator.java
@@ -109,7 +109,7 @@ public class OpenPGPSignatureGenerator implements SignatureGenerator {
             sGen.initSign(PGPSignature.BINARY_DOCUMENT, pgpPrivKey);
 
             in = FileUtil.newInputStream(src);
-            out = new BCPGOutputStream(new ArmoredOutputStream(new FileOutputStream(dest)));
+            out = new BCPGOutputStream(new ArmoredOutputStream(FileUtil.newOutputStream(dest)));
 
             int ch = 0;
             while ((ch = in.read()) >= 0) {

--- a/src/java/org/apache/ivy/plugins/signer/bouncycastle/OpenPGPSignatureGenerator.java
+++ b/src/java/org/apache/ivy/plugins/signer/bouncycastle/OpenPGPSignatureGenerator.java
@@ -30,6 +30,7 @@ import java.security.SignatureException;
 import java.util.Iterator;
 
 import org.apache.ivy.plugins.signer.SignatureGenerator;
+import org.apache.ivy.util.FileUtil;
 import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.bouncycastle.bcpg.BCPGOutputStream;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -97,7 +98,7 @@ public class OpenPGPSignatureGenerator implements SignatureGenerator {
             }
 
             if (pgpSec == null) {
-                keyIn = new FileInputStream(secring);
+                keyIn = FileUtil.newInputStream(secring);
                 pgpSec = readSecretKey(keyIn);
             }
 
@@ -107,7 +108,7 @@ public class OpenPGPSignatureGenerator implements SignatureGenerator {
                     .getAlgorithm(), PGPUtil.SHA1, BouncyCastleProvider.PROVIDER_NAME);
             sGen.initSign(PGPSignature.BINARY_DOCUMENT, pgpPrivKey);
 
-            in = new FileInputStream(src);
+            in = FileUtil.newInputStream(src);
             out = new BCPGOutputStream(new ArmoredOutputStream(new FileOutputStream(dest)));
 
             int ch = 0;

--- a/src/java/org/apache/ivy/plugins/trigger/LogTrigger.java
+++ b/src/java/org/apache/ivy/plugins/trigger/LogTrigger.java
@@ -19,8 +19,6 @@ package org.apache.ivy.plugins.trigger;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
@@ -71,7 +69,7 @@ public class LogTrigger extends AbstractTrigger {
                 message += LINE_SEPARATOR;
                 String filename = file.getAbsolutePath();
                 if (encoding == null || encoding.length() == 0) {
-                    out = new FileWriter(filename, append);
+                    out = new OutputStreamWriter(FileUtil.newOutputStream(filename, append));
                 } else {
                     out = new BufferedWriter(new OutputStreamWriter(FileUtil.newOutputStream(filename,
                             append), encoding));

--- a/src/java/org/apache/ivy/plugins/trigger/LogTrigger.java
+++ b/src/java/org/apache/ivy/plugins/trigger/LogTrigger.java
@@ -28,6 +28,7 @@ import java.io.Writer;
 import org.apache.ivy.core.IvyPatternHelper;
 import org.apache.ivy.core.event.IvyEvent;
 import org.apache.ivy.core.resolve.ResolveProcessException;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 
 /**
@@ -72,7 +73,7 @@ public class LogTrigger extends AbstractTrigger {
                 if (encoding == null || encoding.length() == 0) {
                     out = new FileWriter(filename, append);
                 } else {
-                    out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(filename,
+                    out = new BufferedWriter(new OutputStreamWriter(FileUtil.newOutputStream(filename,
                             append), encoding));
                 }
                 out.write(message, 0, message.length());

--- a/src/java/org/apache/ivy/tools/analyser/JarJarDependencyAnalyser.java
+++ b/src/java/org/apache/ivy/tools/analyser/JarJarDependencyAnalyser.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.apache.ivy.core.module.descriptor.DefaultDependencyDescriptor;
 import org.apache.ivy.core.module.descriptor.DefaultModuleDescriptor;
 import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 
 public class JarJarDependencyAnalyser implements DependencyAnalyser {
@@ -86,7 +87,7 @@ public class JarJarDependencyAnalyser implements DependencyAnalyser {
     }
 
     public static void main(String[] args) {
-        JarJarDependencyAnalyser a = new JarJarDependencyAnalyser(new File(
+        JarJarDependencyAnalyser a = new JarJarDependencyAnalyser(FileUtil.newFile(
                 "D:/temp/test2/jarjar-0.7.jar"));
         a.analyze(new JarModuleFinder(
                 "D:/temp/test2/ivyrep/[organisation]/[module]/[revision]/[artifact].[ext]")

--- a/src/java/org/apache/ivy/tools/analyser/JarModuleFinder.java
+++ b/src/java/org/apache/ivy/tools/analyser/JarModuleFinder.java
@@ -26,6 +26,7 @@ import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.plugins.resolver.util.FileURLLister;
 import org.apache.ivy.plugins.resolver.util.ResolverHelper;
 import org.apache.ivy.plugins.resolver.util.URLLister;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 
 public class JarModuleFinder {
@@ -52,7 +53,7 @@ public class JarModuleFinder {
                         IvyPatternHelper.MODULE_KEY, modules[j]);
                     String[] revs = ResolverHelper.listTokenValues(lister, modPattern, "revision");
                     for (int k = 0; k < revs.length; k++) {
-                        File jar = new File(IvyPatternHelper.substitute(filePattern, orgs[i],
+                        File jar = FileUtil.newFile(IvyPatternHelper.substitute(filePattern, orgs[i],
                             modules[j], revs[k], modules[j], "jar", "jar"));
                         if (jar.exists()) {
                             ret.add(new JarModule(ModuleRevisionId.newInstance(orgs[i], modules[j],

--- a/src/java/org/apache/ivy/tools/analyser/RepositoryAnalyser.java
+++ b/src/java/org/apache/ivy/tools/analyser/RepositoryAnalyser.java
@@ -24,6 +24,7 @@ import org.apache.ivy.core.IvyPatternHelper;
 import org.apache.ivy.core.module.descriptor.DefaultArtifact;
 import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
 import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorWriter;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 
 public class RepositoryAnalyser {
@@ -32,7 +33,7 @@ public class RepositoryAnalyser {
         ModuleDescriptor[] mds = depAnalyser.analyze(finder.findJarModules());
         Message.info("found " + mds.length + " modules");
         for (int i = 0; i < mds.length; i++) {
-            File ivyFile = new File(IvyPatternHelper.substitute(
+            File ivyFile = FileUtil.newFile(IvyPatternHelper.substitute(
                 pattern,
                 DefaultArtifact.newIvyArtifact(mds[i].getModuleRevisionId(),
                     mds[i].getPublicationDate())));
@@ -54,7 +55,7 @@ public class RepositoryAnalyser {
         String jarjarLocation = args[0];
         String pattern = args[1];
 
-        JarJarDependencyAnalyser a = new JarJarDependencyAnalyser(new File(jarjarLocation));
+        JarJarDependencyAnalyser a = new JarJarDependencyAnalyser(FileUtil.newFile(jarjarLocation));
         new RepositoryAnalyser().analyse(pattern, a);
     }
 }

--- a/src/java/org/apache/ivy/util/Checks.java
+++ b/src/java/org/apache/ivy/util/Checks.java
@@ -52,7 +52,7 @@ public final class Checks {
 
     public static File checkAbsolute(String path, String fileName) {
         checkNotNull(path, fileName);
-        File f = new File(path);
+        File f = FileUtil.newFile(path);
         if (!f.isAbsolute()) {
             throw new IllegalArgumentException(fileName + " must be absolute: " + path);
         }

--- a/src/java/org/apache/ivy/util/ChecksumHelper.java
+++ b/src/java/org/apache/ivy/util/ChecksumHelper.java
@@ -95,7 +95,7 @@ public final class ChecksumHelper {
     }
 
     private static byte[] compute(File f, String algorithm) throws IOException {
-        InputStream is = new FileInputStream(f);
+        InputStream is = FileUtil.newInputStream(f);
 
         try {
             MessageDigest md = getMessageDigest(algorithm);

--- a/src/java/org/apache/ivy/util/ChecksumHelper.java
+++ b/src/java/org/apache/ivy/util/ChecksumHelper.java
@@ -54,7 +54,7 @@ public final class ChecksumHelper {
      */
     public static void check(File dest, File checksumFile, String algorithm) throws IOException {
         String csFileContent = FileUtil
-                .readEntirely(new BufferedReader(new FileReader(checksumFile))).trim()
+                .readEntirely(new BufferedReader(FileUtil.newReader(checksumFile))).trim()
                 .toLowerCase(Locale.US);
         String expected;
         if (csFileContent.indexOf(' ') > -1

--- a/src/java/org/apache/ivy/util/CredentialsUtil.java
+++ b/src/java/org/apache/ivy/util/CredentialsUtil.java
@@ -20,10 +20,7 @@ package org.apache.ivy.util;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.util.Properties;
 
 import javax.swing.ImageIcon;
@@ -134,9 +131,9 @@ public final class CredentialsUtil {
     public static Credentials loadPassfile(Credentials c, File passfile) {
         if (passfile != null && passfile.exists()) {
             Properties props = new EncrytedProperties();
-            FileInputStream fis = null;
+            InputStream fis = null;
             try {
-                fis = new FileInputStream(passfile);
+                fis = FileUtil.newInputStream(passfile);
                 props.load(fis);
                 String username = c.getUserName();
                 String passwd = c.getPasswd();

--- a/src/java/org/apache/ivy/util/CredentialsUtil.java
+++ b/src/java/org/apache/ivy/util/CredentialsUtil.java
@@ -107,9 +107,9 @@ public final class CredentialsUtil {
                 Properties props = new EncrytedProperties();
                 props.setProperty("username", username);
                 props.setProperty("passwd", passwd);
-                FileOutputStream fos = null;
+                OutputStream fos = null;
                 try {
-                    fos = new FileOutputStream(passfile);
+                    fos = FileUtil.newOutputStream(passfile);
                     props.store(fos, "");
                 } catch (Exception e) {
                     Message.warn("error occurred while saving password file " + passfile, e);

--- a/src/java/org/apache/ivy/util/FileResolver.java
+++ b/src/java/org/apache/ivy/util/FileResolver.java
@@ -22,7 +22,7 @@ import java.io.File;
 public interface FileResolver {
     public static final FileResolver DEFAULT = new FileResolver() {
         public File resolveFile(String path, String filename) {
-            return new File(path);
+            return FileUtil.newFile(path);
         }
     };
 

--- a/src/java/org/apache/ivy/util/FileUtil.java
+++ b/src/java/org/apache/ivy/util/FileUtil.java
@@ -207,7 +207,7 @@ public final class FileUtil {
             return deepCopy(src, dest, l, overwrite);
         }
         // else it is a file copy
-        copy(new FileInputStream(src), dest, l);
+        copy(FileUtil.newInputStream(src), dest, l);
         long srcLen = src.length();
         long destLen = dest.length();
         if (srcLen != destLen) {
@@ -276,7 +276,7 @@ public final class FileUtil {
         if (dest.getParentFile() != null) {
             dest.getParentFile().mkdirs();
         }
-        copy(src, new FileOutputStream(dest), l);
+        copy(src, FileUtil.newOutputStream(dest), l);
     }
 
     public static void copy(InputStream src, OutputStream dest, CopyProgressListener l)
@@ -385,7 +385,7 @@ public final class FileUtil {
      *             if an IO problems occurs during reading
      */
     public static String readEntirely(File f) throws IOException {
-        return readEntirely(new FileInputStream(f));
+        return readEntirely(FileUtil.newInputStream(f));
     }
 
     /**
@@ -694,6 +694,30 @@ public final class FileUtil {
         }
     }
 
+    public static InputStream newInputStream(File f) throws FileNotFoundException {
+        return fileOps.newInputStream(f);
+    }
+
+    public static InputStream newInputStream(String name) throws FileNotFoundException {
+        return fileOps.newInputStream(name);
+    }
+
+    public static OutputStream newOutputStream(File f) throws FileNotFoundException {
+        return fileOps.newOutputStream(f);
+    }
+
+    public static OutputStream newOutputStream(String name) throws FileNotFoundException {
+        return fileOps.newOutputStream(name);
+    }
+
+    public static OutputStream newOutputStream(File f, boolean append) throws FileNotFoundException {
+        return fileOps.newOutputStream(f, append);
+    }
+
+    public static OutputStream newOutputStream(String name, boolean append) throws FileNotFoundException {
+        return fileOps.newOutputStream(name, append);
+    }
+
     private static Class<? extends File> fileClass = File.class;
 
     /** Extension point to allow plugging in your own implementation of {@link File}.
@@ -722,5 +746,19 @@ public final class FileUtil {
         public OutputStream newOutputStream(String name) throws FileNotFoundException {
             return new FileOutputStream(newFile(name));
         }
+
+        public OutputStream newOutputStream(File f, boolean append) throws FileNotFoundException {
+            return new FileOutputStream(f, append);
+        }
+
+        public OutputStream newOutputStream(String name, boolean append) throws FileNotFoundException {
+            return new FileOutputStream(newFile(name), append);
+        }
+    }
+
+    private static FileOps fileOps = new FileOps();
+
+    public static void setFileOps(FileOps fops) {
+        fileOps = fops;
     }
 }

--- a/src/java/org/apache/ivy/util/FileUtil.java
+++ b/src/java/org/apache/ivy/util/FileUtil.java
@@ -445,9 +445,9 @@ public final class FileUtil {
 
     /**
      * Returns a list of Files composed of all directories being parent of file and child of root +
-     * file and root themselves. Example: getPathFiles(new File("test"), new
-     * File("test/dir1/dir2/file.txt")) => {new File("test/dir1"), new File("test/dir1/dir2"), new
-     * File("test/dir1/dir2/file.txt") } Note that if root is not an ancester of file, or if root is
+     * file and root themselves. Example: getPathFiles(FileUtil.newFile("test"), FileUtil.newFile
+     * ("test/dir1/dir2/file.txt")) => {FileUtil.newFile("test/dir1"), FileUtil.newFile("test/dir1/dir2"),
+     * FileUtil.newFile("test/dir1/dir2/file.txt") } Note that if root is not an ancester of file, or if root is
      * null, all directories from the file system root will be returned.
      */
     public static List getPathFiles(File root, File file) {

--- a/src/java/org/apache/ivy/util/FileUtil.java
+++ b/src/java/org/apache/ivy/util/FileUtil.java
@@ -34,7 +34,6 @@ import java.util.Stack;
 import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 
-import com.sun.istack.internal.NotNull;
 import org.apache.ivy.util.url.URLHandlerRegistry;
 
 /**
@@ -634,7 +633,7 @@ public final class FileUtil {
         return l;
     }
 
-    public static File newFile(File parent, @NotNull String child) {
+    public static File newFile(File parent, String child) {
         try {
             final Constructor<? extends File> cons = fileClass.getDeclaredConstructor(File.class, String.class);
             return cons.newInstance(parent, child);
@@ -649,7 +648,7 @@ public final class FileUtil {
         }
     }
 
-    public static File newFile(String parent, @NotNull String child) {
+    public static File newFile(String parent, String child) {
         try {
             Constructor<? extends File> cons = fileClass.getDeclaredConstructor(String.class, String.class);
             return cons.newInstance(parent, child);
@@ -664,7 +663,7 @@ public final class FileUtil {
         }
     }
 
-    public static File newFile(@NotNull String pathname) {
+    public static File newFile(String pathname) {
         try {
             Constructor<? extends File> cons = fileClass.getDeclaredConstructor(String.class);
             return cons.newInstance(pathname);
@@ -679,7 +678,7 @@ public final class FileUtil {
         }
     }
 
-    public static File newFile(@NotNull URI uri) {
+    public static File newFile(URI uri) {
         try {
             Constructor<? extends File> cons = fileClass.getDeclaredConstructor(URI.class);
             return cons.newInstance(uri);

--- a/src/java/org/apache/ivy/util/FileUtil.java
+++ b/src/java/org/apache/ivy/util/FileUtil.java
@@ -718,6 +718,14 @@ public final class FileUtil {
         return fileOps.newOutputStream(name, append);
     }
 
+    public static Reader newReader(String name) throws FileNotFoundException {
+        return fileOps.newReader(name);
+    }
+
+    public static Reader newReader(File f) throws FileNotFoundException {
+        return fileOps.newReader(f);
+    }
+
     private static Class<? extends File> fileClass = File.class;
 
     /** Extension point to allow plugging in your own implementation of {@link File}.
@@ -754,6 +762,16 @@ public final class FileUtil {
         public OutputStream newOutputStream(String name, boolean append) throws FileNotFoundException {
             return new FileOutputStream(newFile(name), append);
         }
+
+        public final Reader newReader(String name) throws FileNotFoundException {
+            return new InputStreamReader(newInputStream(name));
+        }
+
+        public final Reader newReader(File f) throws FileNotFoundException {
+            return new InputStreamReader(newInputStream(f));
+        }
+
+        // TODO Could do newWriter as well but it was only used in 1 place in the entire project.
     }
 
     private static FileOps fileOps = new FileOps();

--- a/src/java/org/apache/ivy/util/PropertiesFile.java
+++ b/src/java/org/apache/ivy/util/PropertiesFile.java
@@ -50,12 +50,12 @@ public class PropertiesFile extends Properties {
     }
 
     public void save() {
-        FileOutputStream fos = null;
+        OutputStream fos = null;
         try {
             if (file.getParentFile() != null && !file.getParentFile().exists()) {
                 file.getParentFile().mkdirs();
             }
-            fos = new FileOutputStream(file);
+            fos = FileUtil.newOutputStream(file);
             store(fos, header);
         } catch (Exception ex) {
             Message.warn("exception occurred while writing properties file " + file, ex);

--- a/src/java/org/apache/ivy/util/PropertiesFile.java
+++ b/src/java/org/apache/ivy/util/PropertiesFile.java
@@ -17,10 +17,7 @@
  */
 package org.apache.ivy.util;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.util.Properties;
 
 /**
@@ -35,9 +32,9 @@ public class PropertiesFile extends Properties {
         this.file = file;
         this.header = header;
         if (file.exists()) {
-            FileInputStream fis = null;
+            InputStream fis = null;
             try {
-                fis = new FileInputStream(file);
+                fis = FileUtil.newInputStream(file);
                 load(fis);
             } catch (Exception ex) {
                 Message.warn("exception occurred while reading properties file " + file, ex);

--- a/src/java/org/apache/ivy/util/url/BasicURLHandler.java
+++ b/src/java/org/apache/ivy/util/url/BasicURLHandler.java
@@ -249,7 +249,7 @@ public class BasicURLHandler extends AbstractURLHandler {
             conn.setRequestProperty("Content-length", Long.toString(source.length()));
             conn.setInstanceFollowRedirects(true);
 
-            InputStream in = new FileInputStream(source);
+            InputStream in = FileUtil.newInputStream(source);
             try {
                 OutputStream os = conn.getOutputStream();
                 FileUtil.copy(in, os, l);

--- a/src/java/org/apache/ivy/util/url/HttpClientHandler.java
+++ b/src/java/org/apache/ivy/util/url/HttpClientHandler.java
@@ -419,7 +419,7 @@ public class HttpClientHandler extends AbstractURLHandler {
         }
 
         public void writeRequest(OutputStream out) throws IOException {
-            InputStream instream = new FileInputStream(file);
+            InputStream instream = FileUtil.newInputStream(file);
             try {
                 FileUtil.copy(instream, out, null, false);
             } finally {

--- a/test/java/org/apache/ivy/IvyTest.java
+++ b/test/java/org/apache/ivy/IvyTest.java
@@ -37,7 +37,7 @@ public class IvyTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -53,11 +53,11 @@ public class IvyTest extends TestCase {
         MockMessageLogger mockLogger = new MockMessageLogger();
         Ivy ivy = Ivy.newInstance();
         ivy.getLoggerEngine().setDefaultLogger(mockLogger);
-        ivy.configure(new File("test/repositories/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
         assertFalse("IvyContext should be cleared and return a default Ivy instance", IvyContext
                 .getContext().getIvy() == ivy);
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
             getResolveOptions(ivy, new String[] {"*"}));
         assertNotNull(report);
@@ -70,8 +70,8 @@ public class IvyTest extends TestCase {
         MockMessageLogger mockLogger2 = new MockMessageLogger();
         Ivy ivy2 = new Ivy();
         ivy2.getLoggerEngine().setDefaultLogger(mockLogger2);
-        ivy2.configure(new File("test/repositories/norev/ivysettings.xml").toURI().toURL());
-        report = ivy2.resolve(new File("test/repositories/norev/ivy.xml"),
+        ivy2.configure(FileUtil.newFile("test/repositories/norev/ivysettings.xml").toURI().toURL());
+        report = ivy2.resolve(FileUtil.newFile("test/repositories/norev/ivy.xml"),
             getResolveOptions(ivy2, new String[] {"*"}));
         assertNotNull(report);
         assertFalse(report.hasError());
@@ -80,7 +80,7 @@ public class IvyTest extends TestCase {
                 .getContext().getIvy() == ivy2);
 
         // finally we reuse the first instance to make another resolution
-        report = ivy.resolve(new File("test/repositories/1/org6/mod6.1/ivys/ivy-0.3.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/1/org6/mod6.1/ivys/ivy-0.3.xml"),
             getResolveOptions(ivy, new String[] {"extension"}));
         assertNotNull(report);
         assertFalse(report.hasError());

--- a/test/java/org/apache/ivy/IvyTest.java
+++ b/test/java/org/apache/ivy/IvyTest.java
@@ -26,6 +26,7 @@ import org.apache.ivy.core.report.ResolveReport;
 import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.util.CacheCleaner;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.MockMessageLogger;
 
 public class IvyTest extends TestCase {
@@ -58,7 +59,7 @@ public class IvyTest extends TestCase {
                 .getContext().getIvy() == ivy);
 
         ResolveReport report = ivy.resolve(FileUtil.newFile(
-                "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
+                        "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
             getResolveOptions(ivy, new String[] {"*"}));
         assertNotNull(report);
         assertFalse(report.hasError());

--- a/test/java/org/apache/ivy/MainTest.java
+++ b/test/java/org/apache/ivy/MainTest.java
@@ -30,7 +30,7 @@ public class MainTest extends TestCase {
     private File cache;
 
     protected void setUp() throws Exception {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         System.setProperty("ivy.cache.dir", cache.getAbsolutePath());
     }
 
@@ -63,19 +63,19 @@ public class MainTest extends TestCase {
     public void testResolveSimple() throws Exception {
         run(new String[] {"-settings", "test/repositories/ivysettings.xml", "-ivy",
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"});
-        assertTrue(new File("build/cache/org1/mod1.2/ivy-2.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/cache/org1/mod1.2/ivy-2.0.xml").exists());
     }
 
     public void testResolveSimpleWithConfs() throws Exception {
         run(new String[] {"-settings", "test/repositories/ivysettings.xml", "-ivy",
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml", "-confs", "default"});
-        assertTrue(new File("build/cache/org1/mod1.2/ivy-2.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/cache/org1/mod1.2/ivy-2.0.xml").exists());
     }
 
     public void testResolveSimpleWithConfs2() throws Exception {
         run(new String[] {"-settings", "test/repositories/ivysettings.xml", "-confs", "default",
                 "-ivy", "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"});
-        assertTrue(new File("build/cache/org1/mod1.2/ivy-2.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/cache/org1/mod1.2/ivy-2.0.xml").exists());
     }
 
     public void testExtraParams1() throws Exception {

--- a/test/java/org/apache/ivy/MainTest.java
+++ b/test/java/org/apache/ivy/MainTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import junit.framework.TestCase;
 
 import org.apache.ivy.util.CacheCleaner;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.cli.CommandLine;
 import org.apache.ivy.util.cli.ParseException;
 

--- a/test/java/org/apache/ivy/TestHelper.java
+++ b/test/java/org/apache/ivy/TestHelper.java
@@ -262,7 +262,7 @@ public class TestHelper {
     public static FileSystemResolver newTestRepository() {
         FileSystemResolver testRepository = new FileSystemResolver();
         testRepository.setName("test");
-        String testRepoDir = new File("build/test/test-repo").getAbsolutePath();
+        String testRepoDir = FileUtil.newFile("build/test/test-repo").getAbsolutePath();
         testRepository.addIvyPattern(testRepoDir
                 + "/[organisation]/[module]/[revision]/[artifact].[ext]");
         testRepository.addArtifactPattern(testRepoDir
@@ -276,7 +276,7 @@ public class TestHelper {
      * @see #newTestRepository()
      */
     public static void cleanTestRepository() {
-        FileUtil.forceDelete(new File("build/test/test-repo"));
+        FileUtil.forceDelete(FileUtil.newFile("build/test/test-repo"));
     }
 
     /**
@@ -286,7 +286,7 @@ public class TestHelper {
      */
     public static void cleanTest() {
         cleanTestRepository();
-        FileUtil.forceDelete(new File("build/test/cache"));
+        FileUtil.forceDelete(FileUtil.newFile("build/test/cache"));
     }
 
     /**
@@ -298,7 +298,7 @@ public class TestHelper {
      * @return test settings
      */
     public static IvySettings loadTestSettings(IvySettings settings) {
-        settings.setDefaultCache(new File("build/test/cache"));
+        settings.setDefaultCache(FileUtil.newFile("build/test/cache"));
         settings.addResolver(newTestRepository());
         settings.setDefaultResolver("test");
         return settings;

--- a/test/java/org/apache/ivy/ant/AntBuildTriggerTest.java
+++ b/test/java/org/apache/ivy/ant/AntBuildTriggerTest.java
@@ -27,20 +27,20 @@ import org.apache.ivy.util.FileUtil;
 
 public class AntBuildTriggerTest extends TestCase {
     public void test() throws Exception {
-        assertFalse(new File("test/triggers/ant-build/A/A.jar").exists());
+        assertFalse(FileUtil.newFile("test/triggers/ant-build/A/A.jar").exists());
 
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/triggers/ant-build/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/triggers/ant-build/ivysettings.xml"));
 
-        ResolveReport r = ivy.resolve(new File("test/triggers/ant-build/B/ivy.xml"));
+        ResolveReport r = ivy.resolve(FileUtil.newFile("test/triggers/ant-build/B/ivy.xml"));
         assertFalse(r.hasError());
 
         // should have triggered an A publish
-        assertTrue(new File("test/triggers/ant-build/local/A/A.jar").exists());
+        assertTrue(FileUtil.newFile("test/triggers/ant-build/local/A/A.jar").exists());
     }
 
     protected void tearDown() throws Exception {
-        FileUtil.forceDelete(new File("test/triggers/ant-build/local/A"));
-        FileUtil.forceDelete(new File("test/triggers/ant-build/cache"));
+        FileUtil.forceDelete(FileUtil.newFile("test/triggers/ant-build/local/A"));
+        FileUtil.forceDelete(FileUtil.newFile("test/triggers/ant-build/cache"));
     }
 }

--- a/test/java/org/apache/ivy/ant/AntCallTriggerTest.java
+++ b/test/java/org/apache/ivy/ant/AntCallTriggerTest.java
@@ -38,15 +38,15 @@ import org.apache.tools.ant.input.InputHandler;
 
 public class AntCallTriggerTest extends TestCase {
     public void test() throws Exception {
-        assertFalse(new File("test/triggers/ant-call/A/out/foo.txt").exists());
-        runAnt(new File("test/triggers/ant-call/A/build.xml"), "resolve");
+        assertFalse(FileUtil.newFile("test/triggers/ant-call/A/out/foo.txt").exists());
+        runAnt(FileUtil.newFile("test/triggers/ant-call/A/build.xml"), "resolve");
         // should have unzipped foo.zip
-        assertTrue(new File("test/triggers/ant-call/A/out/foo.txt").exists());
+        assertTrue(FileUtil.newFile("test/triggers/ant-call/A/out/foo.txt").exists());
     }
 
     protected void tearDown() throws Exception {
-        FileUtil.forceDelete(new File("test/triggers/ant-call/A/out"));
-        FileUtil.forceDelete(new File("test/triggers/ant-call/cache"));
+        FileUtil.forceDelete(FileUtil.newFile("test/triggers/ant-call/A/out"));
+        FileUtil.forceDelete(FileUtil.newFile("test/triggers/ant-call/cache"));
     }
 
     private void runAnt(File buildFile, String target) throws BuildException {

--- a/test/java/org/apache/ivy/ant/BuildOBRTaskTest.java
+++ b/test/java/org/apache/ivy/ant/BuildOBRTaskTest.java
@@ -74,7 +74,7 @@ public class BuildOBRTaskTest extends TestCase {
     private BundleRepoDescriptor readObr(File obrFile) throws FileNotFoundException,
             ParseException, IOException, SAXException {
         BundleRepoDescriptor obr;
-        FileInputStream in = new FileInputStream(obrFile);
+        FileInputStream in = FileUtil.newInputStream(obrFile);
         try {
             obr = OBRXMLParser.parse(obrFile.toURI(), in);
         } finally {

--- a/test/java/org/apache/ivy/ant/BuildOBRTaskTest.java
+++ b/test/java/org/apache/ivy/ant/BuildOBRTaskTest.java
@@ -54,7 +54,7 @@ public class BuildOBRTaskTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -82,8 +82,8 @@ public class BuildOBRTaskTest extends TestCase {
     }
 
     public void testDir() throws Exception {
-        buildObr.setBaseDir(new File("test/test-repo/bundlerepo"));
-        File obrFile = new File("build/cache/obr.xml");
+        buildObr.setBaseDir(FileUtil.newFile("test/test-repo/bundlerepo"));
+        File obrFile = FileUtil.newFile("build/cache/obr.xml");
         buildObr.setOut(obrFile);
         buildObr.execute();
 
@@ -93,8 +93,8 @@ public class BuildOBRTaskTest extends TestCase {
     }
 
     public void testEmptyDir() throws Exception {
-        buildObr.setBaseDir(new File("test/test-p2/composite"));
-        File obrFile = new File("build/cache/obr.xml");
+        buildObr.setBaseDir(FileUtil.newFile("test/test-p2/composite"));
+        File obrFile = FileUtil.newFile("build/cache/obr.xml");
         buildObr.setOut(obrFile);
         buildObr.execute();
 
@@ -115,11 +115,11 @@ public class BuildOBRTaskTest extends TestCase {
 
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(otherProject);
-        resolve.setFile(new File("test/test-repo/ivy-test-buildobr.xml"));
+        resolve.setFile(FileUtil.newFile("test/test-repo/ivy-test-buildobr.xml"));
         resolve.setResolveId("withResolveId");
         resolve.execute();
 
-        File obrFile = new File("build/cache/obr.xml");
+        File obrFile = FileUtil.newFile("build/cache/obr.xml");
 
         buildObr.setProject(otherProject);
         buildObr.setResolveId("withResolveId");

--- a/test/java/org/apache/ivy/ant/BuildOBRTaskTest.java
+++ b/test/java/org/apache/ivy/ant/BuildOBRTaskTest.java
@@ -17,10 +17,7 @@
  */
 package org.apache.ivy.ant;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
+import java.io.*;
 import java.text.ParseException;
 
 import junit.framework.TestCase;
@@ -28,6 +25,7 @@ import junit.framework.TestCase;
 import org.apache.ivy.osgi.obr.xml.OBRXMLParser;
 import org.apache.ivy.osgi.repo.BundleRepoDescriptor;
 import org.apache.ivy.util.CollectionUtils;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.DefaultLogger;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
@@ -74,7 +72,7 @@ public class BuildOBRTaskTest extends TestCase {
     private BundleRepoDescriptor readObr(File obrFile) throws FileNotFoundException,
             ParseException, IOException, SAXException {
         BundleRepoDescriptor obr;
-        FileInputStream in = FileUtil.newInputStream(obrFile);
+        InputStream in = FileUtil.newInputStream(obrFile);
         try {
             obr = OBRXMLParser.parse(obrFile.toURI(), in);
         } finally {

--- a/test/java/org/apache/ivy/ant/FixDepsTaskTest.java
+++ b/test/java/org/apache/ivy/ant/FixDepsTaskTest.java
@@ -49,7 +49,7 @@ public class FixDepsTaskTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -67,7 +67,7 @@ public class FixDepsTaskTest extends TestCase {
     public void testSimple() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
 
-        File dest = new File("build/testFixDeps/testSimple.xml");
+        File dest = FileUtil.newFile("build/testFixDeps/testSimple.xml");
         fixDeps.setToFile(dest);
         fixDeps.execute();
 
@@ -95,7 +95,7 @@ public class FixDepsTaskTest extends TestCase {
     public void testMulticonf() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-multiconf.xml");
 
-        File dest = new File("build/testFixDeps/testMultiConf.xml");
+        File dest = FileUtil.newFile("build/testFixDeps/testMultiConf.xml");
         fixDeps.setToFile(dest);
         fixDeps.execute();
 
@@ -141,7 +141,7 @@ public class FixDepsTaskTest extends TestCase {
     public void testTransitivity() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-transitive.xml");
 
-        File dest = new File("build/testFixDeps/testTransitivity.xml");
+        File dest = FileUtil.newFile("build/testFixDeps/testTransitivity.xml");
         fixDeps.setToFile(dest);
         fixDeps.execute();
 
@@ -198,12 +198,12 @@ public class FixDepsTaskTest extends TestCase {
     public void testFixedResolve() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-transitive.xml");
 
-        File dest = new File("build/testFixDeps/testTransitivity.xml");
+        File dest = FileUtil.newFile("build/testFixDeps/testTransitivity.xml");
         fixDeps.setToFile(dest);
         fixDeps.execute();
 
         project.setProperty("ivy.dep.file", dest.getAbsolutePath());
-        File dest2 = new File("build/testFixDeps/testTransitivity2.xml");
+        File dest2 = FileUtil.newFile("build/testFixDeps/testTransitivity2.xml");
         fixDeps.setToFile(dest2);
         fixDeps.execute();
 

--- a/test/java/org/apache/ivy/ant/FixDepsTaskTest.java
+++ b/test/java/org/apache/ivy/ant/FixDepsTaskTest.java
@@ -27,6 +27,7 @@ import junit.framework.TestCase;
 import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorParser;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
 

--- a/test/java/org/apache/ivy/ant/IvyArtifactPropertyTest.java
+++ b/test/java/org/apache/ivy/ant/IvyArtifactPropertyTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 
 import junit.framework.TestCase;
 
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;

--- a/test/java/org/apache/ivy/ant/IvyArtifactPropertyTest.java
+++ b/test/java/org/apache/ivy/ant/IvyArtifactPropertyTest.java
@@ -66,7 +66,7 @@ public class IvyArtifactPropertyTest extends TestCase {
         String val = project.getProperty("mod1.2.mod1.2-2.0");
         assertNotNull(val);
         assertEquals(new File("build/cache/mod1.2/mod1.2-2.0.jar").getCanonicalPath(),
-            new File(val).getCanonicalPath());
+            FileUtil.newFile(val).getCanonicalPath());
     }
 
     public void testWithResolveId() throws Exception {
@@ -90,7 +90,7 @@ public class IvyArtifactPropertyTest extends TestCase {
         String val = project.getProperty("mod1.2.mod1.2-2.0");
         assertNotNull(val);
         assertEquals(new File("build/cache/mod1.2/mod1.2-2.0.jar").getCanonicalPath(),
-            new File(val).getCanonicalPath());
+            FileUtil.newFile(val).getCanonicalPath());
     }
 
     public void testWithResolveIdWithoutResolve() throws Exception {

--- a/test/java/org/apache/ivy/ant/IvyArtifactPropertyTest.java
+++ b/test/java/org/apache/ivy/ant/IvyArtifactPropertyTest.java
@@ -44,7 +44,7 @@ public class IvyArtifactPropertyTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -66,21 +66,21 @@ public class IvyArtifactPropertyTest extends TestCase {
         prop.execute();
         String val = project.getProperty("mod1.2.mod1.2-2.0");
         assertNotNull(val);
-        assertEquals(new File("build/cache/mod1.2/mod1.2-2.0.jar").getCanonicalPath(),
+        assertEquals(FileUtil.newFile("build/cache/mod1.2/mod1.2-2.0.jar").getCanonicalPath(),
             FileUtil.newFile(val).getCanonicalPath());
     }
 
     public void testWithResolveId() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setResolveId("abc");
         resolve.execute();
 
         // resolve another ivy file
         resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-latest.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-latest.xml"));
         resolve.execute();
 
         prop.setName("[module].[artifact]-[revision]");
@@ -90,7 +90,7 @@ public class IvyArtifactPropertyTest extends TestCase {
 
         String val = project.getProperty("mod1.2.mod1.2-2.0");
         assertNotNull(val);
-        assertEquals(new File("build/cache/mod1.2/mod1.2-2.0.jar").getCanonicalPath(),
+        assertEquals(FileUtil.newFile("build/cache/mod1.2/mod1.2-2.0.jar").getCanonicalPath(),
             FileUtil.newFile(val).getCanonicalPath());
     }
 

--- a/test/java/org/apache/ivy/ant/IvyArtifactReportTest.java
+++ b/test/java/org/apache/ivy/ant/IvyArtifactReportTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 
 import junit.framework.TestCase;
 
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
 

--- a/test/java/org/apache/ivy/ant/IvyArtifactReportTest.java
+++ b/test/java/org/apache/ivy/ant/IvyArtifactReportTest.java
@@ -42,7 +42,7 @@ public class IvyArtifactReportTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -58,10 +58,10 @@ public class IvyArtifactReportTest extends TestCase {
     }
 
     public void testSimple() throws Exception {
-        prop.setTofile(new File("build/test-artifact-report.xml"));
-        prop.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        prop.setTofile(FileUtil.newFile("build/test-artifact-report.xml"));
+        prop.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         prop.execute();
 
-        assertTrue(new File("build/test-artifact-report.xml").exists());
+        assertTrue(FileUtil.newFile("build/test-artifact-report.xml").exists());
     }
 }

--- a/test/java/org/apache/ivy/ant/IvyBuildListTest.java
+++ b/test/java/org/apache/ivy/ant/IvyBuildListTest.java
@@ -61,7 +61,7 @@ public class IvyBuildListTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -81,7 +81,7 @@ public class IvyBuildListTest extends TestCase {
 
     private void assertListOfFiles(String prefix, String[] expected, String[] actual) {
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(FileUtil.newFile(prefix + expected[i] + "/build.xml").getAbsolutePath(), new File(
+            assertEquals(FileUtil.newFile(prefix + expected[i] + "/build.xml").getAbsolutePath(), FileUtil.newFile(
                     actual[i]).getAbsolutePath());
         }
     }
@@ -93,7 +93,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testSimple() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlist"));
+        fs.setDir(FileUtil.newFile("test/buildlist"));
         fs.setIncludes("**/build.xml");
         fs.setExcludes("E2/build.xml,F/build.xml,G/build.xml");
 
@@ -109,7 +109,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testReverse() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlist"));
+        fs.setDir(FileUtil.newFile("test/buildlist"));
         fs.setIncludes("**/build.xml");
         fs.setExcludes("E2/build.xml,F/build.xml,G/build.xml");
 
@@ -126,7 +126,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testWithRoot() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlist"));
+        fs.setDir(FileUtil.newFile("test/buildlist"));
         fs.setIncludes("**/build.xml");
         fs.setExcludes("E2/**");
 
@@ -143,7 +143,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testWithRootCircular() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlist"));
+        fs.setDir(FileUtil.newFile("test/buildlist"));
         fs.setIncludes("**/build.xml");
 
         buildlist.addFileset(fs);
@@ -157,7 +157,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testWithTwoRoots() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlist"));
+        fs.setDir(FileUtil.newFile("test/buildlist"));
         fs.setIncludes("**/build.xml");
         fs.setExcludes("E2/**");
 
@@ -174,7 +174,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testWithRootExclude() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlist"));
+        fs.setDir(FileUtil.newFile("test/buildlist"));
         fs.setIncludes("**/build.xml");
         fs.setExcludes("E2/**");
 
@@ -192,7 +192,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testWithRootAndOnlyDirectDep() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlist"));
+        fs.setDir(FileUtil.newFile("test/buildlist"));
         fs.setIncludes("**/build.xml");
         fs.setExcludes("E2/**");
 
@@ -210,7 +210,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testWithLeaf() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlist"));
+        fs.setDir(FileUtil.newFile("test/buildlist"));
         fs.setIncludes("**/build.xml");
         fs.setExcludes("E2/**");
 
@@ -227,7 +227,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testWithLeafCircular() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlist"));
+        fs.setDir(FileUtil.newFile("test/buildlist"));
         fs.setIncludes("**/build.xml");
 
         buildlist.addFileset(fs);
@@ -241,7 +241,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testWithTwoLeafs() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlist"));
+        fs.setDir(FileUtil.newFile("test/buildlist"));
         fs.setIncludes("**/build.xml");
         fs.setExcludes("E2/**");
 
@@ -258,7 +258,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testWithLeafExclude() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlist"));
+        fs.setDir(FileUtil.newFile("test/buildlist"));
         fs.setIncludes("**/build.xml");
         fs.setExcludes("E2/**");
 
@@ -276,7 +276,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testWithLeafAndOnlyDirectDep() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlist"));
+        fs.setDir(FileUtil.newFile("test/buildlist"));
         fs.setIncludes("**/build.xml");
         fs.setExcludes("E2/**");
 
@@ -294,7 +294,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testRestartFrom() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlist"));
+        fs.setDir(FileUtil.newFile("test/buildlist"));
         fs.setIncludes("**/build.xml");
         fs.setExcludes("E2/build.xml,F/build.xml,G/build.xml");
 
@@ -311,7 +311,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testOnMissingDescriptor() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlist"));
+        fs.setDir(FileUtil.newFile("test/buildlist"));
         fs.setIncludes("**/build.xml");
         fs.setExcludes("E2/build.xml,F/build.xml,G/build.xml");
 
@@ -327,7 +327,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testOnMissingDescriptor2() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlist"));
+        fs.setDir(FileUtil.newFile("test/buildlist"));
         fs.setIncludes("**/build.xml");
         fs.setExcludes("E2/build.xml,F/build.xml,G/build.xml");
 
@@ -343,7 +343,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testWithModuleWithSameNameAndDifferentOrg() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlist"));
+        fs.setDir(FileUtil.newFile("test/buildlist"));
         fs.setIncludes("**/build.xml");
         fs.setExcludes("F/build.xml,G/build.xml");
 
@@ -362,14 +362,14 @@ public class IvyBuildListTest extends TestCase {
         other.add(FileUtil.newFile(files[5]).getAbsoluteFile().toURI());
         Collections.sort(other);
 
-        assertEquals(new File("test/buildlist/E/build.xml").getAbsoluteFile().toURI(), other.get(0));
-        assertEquals(new File("test/buildlist/E2/build.xml").getAbsoluteFile().toURI(),
+        assertEquals(FileUtil.newFile("test/buildlist/E/build.xml").getAbsoluteFile().toURI(), other.get(0));
+        assertEquals(FileUtil.newFile("test/buildlist/E2/build.xml").getAbsoluteFile().toURI(),
             other.get(1));
     }
 
     public void testNoParents() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlists/testNoParents"));
+        fs.setDir(FileUtil.newFile("test/buildlists/testNoParents"));
         fs.setIncludes("**/build.xml");
 
         buildlist.addFileset(fs);
@@ -386,7 +386,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testOneParent() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlists/testOneParent"));
+        fs.setDir(FileUtil.newFile("test/buildlists/testOneParent"));
         fs.setIncludes("**/build.xml");
 
         buildlist.addFileset(fs);
@@ -403,7 +403,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testTwoParents() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlists/testTwoParents"));
+        fs.setDir(FileUtil.newFile("test/buildlists/testTwoParents"));
         fs.setIncludes("**/build.xml");
 
         buildlist.addFileset(fs);
@@ -420,7 +420,7 @@ public class IvyBuildListTest extends TestCase {
 
     public void testRelativePathToParent() {
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlists/testRelativePathToParent"));
+        fs.setDir(FileUtil.newFile("test/buildlists/testRelativePathToParent"));
         fs.setIncludes("**/build.xml");
 
         buildlist.addFileset(fs);
@@ -436,11 +436,11 @@ public class IvyBuildListTest extends TestCase {
     }
 
     public void testAbsolutePathToParent() {
-        project.setProperty("master-parent.dir", new File(
+        project.setProperty("master-parent.dir", FileUtil.newFile(
                 "test/buildlists/testAbsolutePathToParent/master-parent").getAbsolutePath());
 
         FileSet fs = new FileSet();
-        fs.setDir(new File("test/buildlists/testAbsolutePathToParent"));
+        fs.setDir(FileUtil.newFile("test/buildlists/testAbsolutePathToParent"));
         fs.setIncludes("**/build.xml");
 
         buildlist.addFileset(fs);

--- a/test/java/org/apache/ivy/ant/IvyBuildListTest.java
+++ b/test/java/org/apache/ivy/ant/IvyBuildListTest.java
@@ -81,7 +81,7 @@ public class IvyBuildListTest extends TestCase {
 
     private void assertListOfFiles(String prefix, String[] expected, String[] actual) {
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(new File(prefix + expected[i] + "/build.xml").getAbsolutePath(), new File(
+            assertEquals(FileUtil.newFile(prefix + expected[i] + "/build.xml").getAbsolutePath(), new File(
                     actual[i]).getAbsolutePath());
         }
     }
@@ -358,8 +358,8 @@ public class IvyBuildListTest extends TestCase {
 
         // the order of E and E2 is undefined
         List other = new ArrayList();
-        other.add(new File(files[4]).getAbsoluteFile().toURI());
-        other.add(new File(files[5]).getAbsoluteFile().toURI());
+        other.add(FileUtil.newFile(files[4]).getAbsoluteFile().toURI());
+        other.add(FileUtil.newFile(files[5]).getAbsoluteFile().toURI());
         Collections.sort(other);
 
         assertEquals(new File("test/buildlist/E/build.xml").getAbsoluteFile().toURI(), other.get(0));

--- a/test/java/org/apache/ivy/ant/IvyBuildNumberTest.java
+++ b/test/java/org/apache/ivy/ant/IvyBuildNumberTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 
 import junit.framework.TestCase;
 
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
 

--- a/test/java/org/apache/ivy/ant/IvyBuildNumberTest.java
+++ b/test/java/org/apache/ivy/ant/IvyBuildNumberTest.java
@@ -39,7 +39,7 @@ public class IvyBuildNumberTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 

--- a/test/java/org/apache/ivy/ant/IvyCacheFilesetTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCacheFilesetTest.java
@@ -73,7 +73,7 @@ public class IvyCacheFilesetTest extends TestCase {
         assertEquals(1, directoryScanner.getIncludedFiles().length);
         assertEquals(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar")
                 .getAbsolutePath(),
-            new File(directoryScanner.getBasedir(), directoryScanner.getIncludedFiles()[0])
+            FileUtil.newFile(directoryScanner.getBasedir(), directoryScanner.getIncludedFiles()[0])
                     .getAbsolutePath());
     }
 
@@ -155,7 +155,7 @@ public class IvyCacheFilesetTest extends TestCase {
             assertEquals(1, directoryScanner.getIncludedFiles().length);
             assertEquals(
                 getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar", cache2)
-                        .getAbsolutePath(), new File(directoryScanner.getBasedir(),
+                        .getAbsolutePath(), FileUtil.newFile(directoryScanner.getBasedir(),
                         directoryScanner.getIncludedFiles()[0]).getAbsolutePath());
         } finally {
             Delete del = new Delete();

--- a/test/java/org/apache/ivy/ant/IvyCacheFilesetTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCacheFilesetTest.java
@@ -47,7 +47,7 @@ public class IvyCacheFilesetTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -140,7 +140,7 @@ public class IvyCacheFilesetTest extends TestCase {
     }
 
     public void testWithoutPreviousResolveAndNonDefaultCache() throws Exception {
-        File cache2 = new File("build/cache2");
+        File cache2 = FileUtil.newFile("build/cache2");
         cache2.mkdirs();
 
         try {
@@ -168,13 +168,13 @@ public class IvyCacheFilesetTest extends TestCase {
 
     public void testGetBaseDir() {
         File base = null;
-        base = fileset.getBaseDir(base, new File("x/aa/b/c"));
-        assertEquals(new File("x/aa/b").getAbsoluteFile(), base);
+        base = fileset.getBaseDir(base, FileUtil.newFile("x/aa/b/c"));
+        assertEquals(FileUtil.newFile("x/aa/b").getAbsoluteFile(), base);
 
-        base = fileset.getBaseDir(base, new File("x/aa/b/d/e"));
-        assertEquals(new File("x/aa/b").getAbsoluteFile(), base);
+        base = fileset.getBaseDir(base, FileUtil.newFile("x/aa/b/d/e"));
+        assertEquals(FileUtil.newFile("x/aa/b").getAbsoluteFile(), base);
 
-        base = fileset.getBaseDir(base, new File("x/ab/b/d"));
-        assertEquals(new File("x").getAbsoluteFile(), base);
+        base = fileset.getBaseDir(base, FileUtil.newFile("x/ab/b/d"));
+        assertEquals(FileUtil.newFile("x").getAbsoluteFile(), base);
     }
 }

--- a/test/java/org/apache/ivy/ant/IvyCacheFilesetTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCacheFilesetTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import junit.framework.TestCase;
 
 import org.apache.ivy.TestHelper;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Project;
@@ -156,7 +157,7 @@ public class IvyCacheFilesetTest extends TestCase {
             assertEquals(
                 getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar", cache2)
                         .getAbsolutePath(), FileUtil.newFile(directoryScanner.getBasedir(),
-                        directoryScanner.getIncludedFiles()[0]).getAbsolutePath());
+                            directoryScanner.getIncludedFiles()[0]).getAbsolutePath());
         } finally {
             Delete del = new Delete();
             del.setProject(new Project());

--- a/test/java/org/apache/ivy/ant/IvyCachePathTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCachePathTest.java
@@ -46,7 +46,7 @@ public class IvyCachePathTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -78,7 +78,7 @@ public class IvyCachePathTest extends TestCase {
         // we first resolve another ivy file
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-latest.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-latest.xml"));
         resolve.execute();
 
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.2", "mod1.2", "jar", "jar").exists());
@@ -118,7 +118,7 @@ public class IvyCachePathTest extends TestCase {
         // we then resolve another ivy file
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-latest.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-latest.xml"));
         resolve.execute();
 
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.2", "mod1.2", "jar", "jar").exists());
@@ -161,14 +161,14 @@ public class IvyCachePathTest extends TestCase {
     public void testWithResolveId() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setResolveId("withResolveId");
         resolve.execute();
 
         // resolve another ivy file
         resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-latest.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-latest.xml"));
         resolve.execute();
 
         path.setResolveId("withResolveId");
@@ -190,19 +190,19 @@ public class IvyCachePathTest extends TestCase {
 
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(otherProject);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setResolveId("withResolveId");
         resolve.execute();
 
         // resolve another ivy file
         resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-latest.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-latest.xml"));
         resolve.execute();
 
         path.setResolveId("withResolveId");
         path.setPathid("withresolveid-pathid");
-        path.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        path.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         path.execute();
 
         Object ref = project.getReference("withresolveid-pathid");
@@ -220,7 +220,7 @@ public class IvyCachePathTest extends TestCase {
 
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(otherProject);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
         resolve.setResolveId("testWithResolveIdAndMissingConfs");
         resolve.setConf("default");
         resolve.execute();
@@ -228,7 +228,7 @@ public class IvyCachePathTest extends TestCase {
         // resolve another ivy file
         resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-latest.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-latest.xml"));
         resolve.execute();
 
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-multiconf.xml");
@@ -236,7 +236,7 @@ public class IvyCachePathTest extends TestCase {
         path.setResolveId("testWithResolveIdAndMissingConfs");
         path.setPathid("withresolveid-pathid");
         path.setConf("default,compile");
-        path.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
+        path.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
         path.execute();
     }
 

--- a/test/java/org/apache/ivy/ant/IvyCachePathTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCachePathTest.java
@@ -70,7 +70,7 @@ public class IvyCachePathTest extends TestCase {
         Path p = (Path) ref;
         assertEquals(1, p.size());
         assertEquals(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar")
-                .getAbsolutePath(), new File(p.list()[0]).getAbsolutePath());
+                .getAbsolutePath(), FileUtil.newFile(p.list()[0]).getAbsolutePath());
     }
 
     public void testInline1() throws Exception {
@@ -95,7 +95,7 @@ public class IvyCachePathTest extends TestCase {
         Path p = (Path) ref;
         assertEquals(1, p.size());
         assertEquals(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar")
-                .getAbsolutePath(), new File(p.list()[0]).getAbsolutePath());
+                .getAbsolutePath(), FileUtil.newFile(p.list()[0]).getAbsolutePath());
     }
 
     public void testInline2() throws Exception {
@@ -112,7 +112,7 @@ public class IvyCachePathTest extends TestCase {
         Path p = (Path) ref;
         assertEquals(1, p.size());
         assertEquals(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar")
-                .getAbsolutePath(), new File(p.list()[0]).getAbsolutePath());
+                .getAbsolutePath(), FileUtil.newFile(p.list()[0]).getAbsolutePath());
 
         // we then resolve another ivy file
         IvyResolve resolve = new IvyResolve();
@@ -180,7 +180,7 @@ public class IvyCachePathTest extends TestCase {
         Path p = (Path) ref;
         assertEquals(1, p.size());
         assertEquals(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar")
-                .getAbsolutePath(), new File(p.list()[0]).getAbsolutePath());
+                .getAbsolutePath(), FileUtil.newFile(p.list()[0]).getAbsolutePath());
     }
 
     public void testWithResolveIdWithoutResolve() throws Exception {
@@ -210,7 +210,7 @@ public class IvyCachePathTest extends TestCase {
         Path p = (Path) ref;
         assertEquals(1, p.size());
         assertEquals(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar")
-                .getAbsolutePath(), new File(p.list()[0]).getAbsolutePath());
+                .getAbsolutePath(), FileUtil.newFile(p.list()[0]).getAbsolutePath());
     }
 
     public void testWithResolveIdAndMissingConfs() throws Exception {
@@ -249,7 +249,7 @@ public class IvyCachePathTest extends TestCase {
         assertTrue(ref instanceof Path);
         Path p = (Path) ref;
         assertEquals(1, p.size());
-        assertTrue(new File(p.list()[0]).isDirectory());
+        assertTrue(FileUtil.newFile(p.list()[0]).isDirectory());
     }
 
     public void testOSGi() throws Exception {
@@ -264,11 +264,11 @@ public class IvyCachePathTest extends TestCase {
         Path p = (Path) ref;
         assertEquals(4, p.size());
         File cacheDir = path.getSettings().getDefaultRepositoryCacheBasedir();
-        File unpacked = new File(cacheDir, "packaging/module3/jar_unpackeds/module3-1.0");
-        assertEquals(new File(unpacked, "lib/ant-antlr.jar"), new File(p.list()[0]));
-        assertEquals(new File(unpacked, "lib/ant-apache-bcel.jar"), new File(p.list()[1]));
-        assertEquals(new File(unpacked, "lib/ant-apache-bsf.jar"), new File(p.list()[2]));
-        assertEquals(new File(unpacked, "lib/ant-apache-log4j.jar"), new File(p.list()[3]));
+        File unpacked = FileUtil.newFile(cacheDir, "packaging/module3/jar_unpackeds/module3-1.0");
+        assertEquals(FileUtil.newFile(unpacked, "lib/ant-antlr.jar"), FileUtil.newFile(p.list()[0]));
+        assertEquals(FileUtil.newFile(unpacked, "lib/ant-apache-bcel.jar"), FileUtil.newFile(p.list()[1]));
+        assertEquals(FileUtil.newFile(unpacked, "lib/ant-apache-bsf.jar"), FileUtil.newFile(p.list()[2]));
+        assertEquals(FileUtil.newFile(unpacked, "lib/ant-apache-log4j.jar"), FileUtil.newFile(p.list()[3]));
     }
 
     public void testOSGi2() throws Exception {
@@ -283,8 +283,8 @@ public class IvyCachePathTest extends TestCase {
         Path p = (Path) ref;
         assertEquals(1, p.size());
         File cacheDir = path.getSettings().getDefaultRepositoryCacheBasedir();
-        File unpacked = new File(cacheDir, "packaging/module4/jar_unpackeds/module4-1.0");
-        assertEquals(unpacked, new File(p.list()[0]));
+        File unpacked = FileUtil.newFile(cacheDir, "packaging/module4/jar_unpackeds/module4-1.0");
+        assertEquals(unpacked, FileUtil.newFile(p.list()[0]));
     }
 
     public void testPackedOSGi() throws Exception {
@@ -299,11 +299,11 @@ public class IvyCachePathTest extends TestCase {
         Path p = (Path) ref;
         assertEquals(4, p.size());
         File cacheDir = path.getSettings().getDefaultRepositoryCacheBasedir();
-        File unpacked = new File(cacheDir, "packaging/module7/jar_unpackeds/module7-1.0");
-        assertEquals(new File(unpacked, "lib/ant-antlr.jar"), new File(p.list()[0]));
-        assertEquals(new File(unpacked, "lib/ant-apache-bcel.jar"), new File(p.list()[1]));
-        assertEquals(new File(unpacked, "lib/ant-apache-bsf.jar"), new File(p.list()[2]));
-        assertEquals(new File(unpacked, "lib/ant-apache-log4j.jar"), new File(p.list()[3]));
+        File unpacked = FileUtil.newFile(cacheDir, "packaging/module7/jar_unpackeds/module7-1.0");
+        assertEquals(FileUtil.newFile(unpacked, "lib/ant-antlr.jar"), FileUtil.newFile(p.list()[0]));
+        assertEquals(FileUtil.newFile(unpacked, "lib/ant-apache-bcel.jar"), FileUtil.newFile(p.list()[1]));
+        assertEquals(FileUtil.newFile(unpacked, "lib/ant-apache-bsf.jar"), FileUtil.newFile(p.list()[2]));
+        assertEquals(FileUtil.newFile(unpacked, "lib/ant-apache-log4j.jar"), FileUtil.newFile(p.list()[3]));
     }
 
     private File getArchiveFileInCache(String organisation, String module, String revision,

--- a/test/java/org/apache/ivy/ant/IvyCachePathTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCachePathTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import junit.framework.TestCase;
 
 import org.apache.ivy.TestHelper;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;

--- a/test/java/org/apache/ivy/ant/IvyCleanCacheTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCleanCacheTest.java
@@ -38,7 +38,7 @@ public class IvyCleanCacheTest extends TestCase {
 
     protected void setUp() throws Exception {
         Project p = new Project();
-        cacheDir = new File("build/cache");
+        cacheDir = FileUtil.newFile("build/cache");
         p.setProperty("cache", cacheDir.getAbsolutePath());
         cleanCache = new IvyCleanCache();
         cleanCache.setProject(p);

--- a/test/java/org/apache/ivy/ant/IvyCleanCacheTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCleanCacheTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 
 import junit.framework.TestCase;
 
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 

--- a/test/java/org/apache/ivy/ant/IvyCleanCacheTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCleanCacheTest.java
@@ -47,9 +47,9 @@ public class IvyCleanCacheTest extends TestCase {
                 .toExternalForm());
         settings.perform();
 
-        resolutionCache = new File(cacheDir, "resolution");
-        repoCache = new File(cacheDir, "repository");
-        repoCache2 = new File(cacheDir, "repository2");
+        resolutionCache = FileUtil.newFile(cacheDir, "resolution");
+        repoCache = FileUtil.newFile(cacheDir, "repository");
+        repoCache2 = FileUtil.newFile(cacheDir, "repository2");
         resolutionCache.mkdirs();
         repoCache.mkdirs();
         repoCache2.mkdirs();

--- a/test/java/org/apache/ivy/ant/IvyConfigureTest.java
+++ b/test/java/org/apache/ivy/ant/IvyConfigureTest.java
@@ -26,6 +26,7 @@ import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
 import org.apache.ivy.plugins.resolver.IBiblioResolver;
 import org.apache.ivy.plugins.resolver.IvyRepResolver;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.Reference;

--- a/test/java/org/apache/ivy/ant/IvyConfigureTest.java
+++ b/test/java/org/apache/ivy/ant/IvyConfigureTest.java
@@ -63,18 +63,18 @@ public class IvyConfigureTest extends TestCase {
         configure.setSettingsId("test");
         configure.execute();
 
-        assertEquals(new File("mycache").getAbsolutePath(),
+        assertEquals(FileUtil.newFile("mycache").getAbsolutePath(),
             project.getProperty("ivy.cache.dir.test"));
 
         // test with a File
         project = new Project();
         configure = new IvyConfigure();
         configure.setProject(project);
-        configure.setFile(new File("test/java/org/apache/ivy/ant/ivysettings-defaultCacheDir.xml"));
+        configure.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivysettings-defaultCacheDir.xml"));
         configure.setSettingsId("test2");
         configure.execute();
 
-        assertEquals(new File("mycache").getAbsolutePath(),
+        assertEquals(FileUtil.newFile("mycache").getAbsolutePath(),
             project.getProperty("ivy.cache.dir.test2"));
 
         // test if no defaultCacheDir is specified
@@ -82,7 +82,7 @@ public class IvyConfigureTest extends TestCase {
         configure = new IvyConfigure();
         configure.setProject(project);
         configure
-                .setFile(new File("test/java/org/apache/ivy/ant/ivysettings-noDefaultCacheDir.xml"));
+                .setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivysettings-noDefaultCacheDir.xml"));
         configure.setSettingsId("test3");
         configure.execute();
 
@@ -120,7 +120,7 @@ public class IvyConfigureTest extends TestCase {
     }
 
     public void testFile() throws Exception {
-        configure.setFile(new File("test/repositories/ivysettings.xml"));
+        configure.setFile(FileUtil.newFile("test/repositories/ivysettings.xml"));
 
         configure.execute();
 
@@ -129,21 +129,21 @@ public class IvyConfigureTest extends TestCase {
         IvySettings settings = ivy.getSettings();
         assertNotNull(settings);
 
-        assertEquals(new File("build/cache").getAbsoluteFile(), settings.getDefaultCache());
-        assertEquals(new File("test/repositories/ivysettings.xml").getAbsolutePath(), settings
+        assertEquals(FileUtil.newFile("build/cache").getAbsoluteFile(), settings.getDefaultCache());
+        assertEquals(FileUtil.newFile("test/repositories/ivysettings.xml").getAbsolutePath(), settings
                 .getVariables().getVariable("ivy.settings.file"));
         assertEquals(
-            new File("test/repositories/ivysettings.xml").toURI().toURL().toExternalForm(),
+            FileUtil.newFile("test/repositories/ivysettings.xml").toURI().toURL().toExternalForm(),
             settings.getVariables().getVariable("ivy.settings.url"));
-        assertEquals(new File("test/repositories").getAbsolutePath(), settings.getVariables()
+        assertEquals(FileUtil.newFile("test/repositories").getAbsolutePath(), settings.getVariables()
                 .getVariable("ivy.settings.dir"));
         assertEquals("myvalue", settings.getVariables().getVariable("myproperty"));
     }
 
     public void testURL() throws Exception {
-        String confUrl = new File("test/repositories/ivysettings-url.xml").toURI().toURL()
+        String confUrl = FileUtil.newFile("test/repositories/ivysettings-url.xml").toURI().toURL()
                 .toExternalForm();
-        String confDirUrl = new File("test/repositories").toURI().toURL().toExternalForm();
+        String confDirUrl = FileUtil.newFile("test/repositories").toURI().toURL().toExternalForm();
         if (confDirUrl.endsWith("/")) {
             confDirUrl = confDirUrl.substring(0, confDirUrl.length() - 1);
         }
@@ -153,7 +153,7 @@ public class IvyConfigureTest extends TestCase {
 
         IvySettings settings = getIvyInstance().getSettings();
 
-        assertEquals(new File("build/cache").getAbsoluteFile(), settings.getDefaultCache());
+        assertEquals(FileUtil.newFile("build/cache").getAbsoluteFile(), settings.getDefaultCache());
         assertEquals(confUrl, settings.getVariables().getVariable("ivy.settings.url"));
         assertEquals(confDirUrl, settings.getVariables().getVariable("ivy.settings.dir"));
         assertEquals("myvalue", settings.getVariables().getVariable("myproperty"));
@@ -203,7 +203,7 @@ public class IvyConfigureTest extends TestCase {
 
     public void testIncludeTwice() throws Exception {
         // IVY-601
-        configure.setFile(new File("test/java/org/apache/ivy/ant/ivysettings-include-twice.xml"));
+        configure.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivysettings-include-twice.xml"));
 
         configure.execute();
 
@@ -211,7 +211,7 @@ public class IvyConfigureTest extends TestCase {
     }
 
     public void testOverrideTrue() throws Exception {
-        configure.setFile(new File("test/repositories/ivysettings.xml"));
+        configure.setFile(FileUtil.newFile("test/repositories/ivysettings.xml"));
         configure.execute();
 
         Ivy ivy = getIvyInstance();
@@ -220,7 +220,7 @@ public class IvyConfigureTest extends TestCase {
         configure = new IvyConfigure();
         configure.setProject(project);
         configure.setOverride("true");
-        configure.setFile(new File("test/repositories/ivysettings.xml"));
+        configure.setFile(FileUtil.newFile("test/repositories/ivysettings.xml"));
         configure.execute();
         assertNotNull(getIvyInstance());
 
@@ -228,7 +228,7 @@ public class IvyConfigureTest extends TestCase {
     }
 
     public void testOverrideFalse() throws Exception {
-        configure.setFile(new File("test/repositories/ivysettings.xml"));
+        configure.setFile(FileUtil.newFile("test/repositories/ivysettings.xml"));
         configure.execute();
 
         Ivy ivy = getIvyInstance();
@@ -237,14 +237,14 @@ public class IvyConfigureTest extends TestCase {
         IvyConfigure newAntSettings = new IvyConfigure();
         newAntSettings.setProject(project);
         newAntSettings.setOverride("false");
-        newAntSettings.setFile(new File("test/repositories/ivysettings.xml"));
+        newAntSettings.setFile(FileUtil.newFile("test/repositories/ivysettings.xml"));
         newAntSettings.execute();
 
         assertTrue(ivy == getIvyInstance());
     }
 
     public void testOverrideNotAllowed() throws Exception {
-        configure.setFile(new File("test/repositories/ivysettings.xml"));
+        configure.setFile(FileUtil.newFile("test/repositories/ivysettings.xml"));
         configure.execute();
 
         Ivy ivy = getIvyInstance();
@@ -253,7 +253,7 @@ public class IvyConfigureTest extends TestCase {
         configure = new IvyConfigure();
         configure.setProject(project);
         configure.setOverride("notallowed");
-        configure.setFile(new File("test/repositories/ivysettings.xml"));
+        configure.setFile(FileUtil.newFile("test/repositories/ivysettings.xml"));
 
         try {
             configure.execute();

--- a/test/java/org/apache/ivy/ant/IvyConvertPomTest.java
+++ b/test/java/org/apache/ivy/ant/IvyConvertPomTest.java
@@ -27,7 +27,7 @@ public class IvyConvertPomTest extends TestCase {
     public void testSimple() throws Exception {
         IvyConvertPom task = new IvyConvertPom();
         task.setProject(new Project());
-        task.setPomFile(new File("test/java/org/apache/ivy/ant/test.pom"));
+        task.setPomFile(FileUtil.newFile("test/java/org/apache/ivy/ant/test.pom"));
         File destFile = File.createTempFile("ivy", ".xml");
         destFile.deleteOnExit();
         task.setIvyFile(destFile);

--- a/test/java/org/apache/ivy/ant/IvyConvertPomTest.java
+++ b/test/java/org/apache/ivy/ant/IvyConvertPomTest.java
@@ -37,7 +37,7 @@ public class IvyConvertPomTest extends TestCase {
         // keep the code in comments in case someone manage to fix this and to highlight the fact
         // that this is not checked
 
-        // String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(destFile)));
+        // String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(destFile)));
         // String expected = readEntirely("test-convertpom.xml").replaceAll("\r\n", "\n").replace(
         // '\r', '\n');
         // assertEquals(expected, wrote);

--- a/test/java/org/apache/ivy/ant/IvyConvertPomTest.java
+++ b/test/java/org/apache/ivy/ant/IvyConvertPomTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 
 import junit.framework.TestCase;
 
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.Project;
 
 public class IvyConvertPomTest extends TestCase {

--- a/test/java/org/apache/ivy/ant/IvyDeliverTest.java
+++ b/test/java/org/apache/ivy/ant/IvyDeliverTest.java
@@ -136,7 +136,7 @@ public class IvyDeliverTest extends TestCase {
         // we could do a better job of this with xmlunit
         int lineNo = 1;
 
-        BufferedReader merged = new BufferedReader(new FileReader(delivered));
+        BufferedReader merged = new BufferedReader(FileUtil.newReader(delivered));
         BufferedReader expected = new BufferedReader(new InputStreamReader(getClass()
                 .getResourceAsStream("ivy-extends-merged.xml")));
         try {

--- a/test/java/org/apache/ivy/ant/IvyDeliverTest.java
+++ b/test/java/org/apache/ivy/ant/IvyDeliverTest.java
@@ -492,7 +492,7 @@ public class IvyDeliverTest extends TestCase {
         // should have done the ivy delivering
         File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.2.xml");
         assertTrue(deliveredIvyFile.exists());
-        String deliveredFileContent = FileUtil.readEntirely(new BufferedReader(new FileReader(
+        String deliveredFileContent = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(
                 deliveredIvyFile)));
         assertTrue("import not replaced: import can still be found in file",
             deliveredFileContent.indexOf("import") == -1);
@@ -515,7 +515,7 @@ public class IvyDeliverTest extends TestCase {
         // should have done the ivy delivering
         File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.2.xml");
         assertTrue(deliveredIvyFile.exists());
-        String deliveredFileContent = FileUtil.readEntirely(new BufferedReader(new FileReader(
+        String deliveredFileContent = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(
                 deliveredIvyFile)));
         assertTrue("variable not replaced: myvar can still be found in file",
             deliveredFileContent.indexOf("myvar") == -1);

--- a/test/java/org/apache/ivy/ant/IvyDeliverTest.java
+++ b/test/java/org/apache/ivy/ant/IvyDeliverTest.java
@@ -62,7 +62,7 @@ public class IvyDeliverTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -83,21 +83,21 @@ public class IvyDeliverTest extends TestCase {
     private void cleanTestDir() {
         Delete del = new Delete();
         del.setProject(new Project());
-        del.setDir(new File("build/test/deliver"));
+        del.setDir(FileUtil.newFile("build/test/deliver"));
         del.execute();
     }
 
     private void cleanRetrieveDir() {
         Delete del = new Delete();
         del.setProject(new Project());
-        del.setDir(new File("build/test/retrieve"));
+        del.setDir(FileUtil.newFile("build/test/retrieve"));
         del.execute();
     }
 
     private void cleanRep() {
         Delete del = new Delete();
         del.setProject(new Project());
-        del.setDir(new File("test/repositories/1/apache"));
+        del.setDir(FileUtil.newFile("test/repositories/1/apache"));
         del.execute();
     }
 
@@ -113,8 +113,8 @@ public class IvyDeliverTest extends TestCase {
         pubParent.setProject(project);
         pubParent.setResolver("1");
         pubParent.setPubrevision("1.0");
-        File art = new File("build/test/deliver/resolve-simple-1.0.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/deliver/resolve-simple-1.0.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
         pubParent.execute();
 
         // resolve and deliver the child descriptor
@@ -129,7 +129,7 @@ public class IvyDeliverTest extends TestCase {
         deliver.execute();
 
         // should have delivered the file to the specified destination
-        File delivered = new File("build/test/deliver/merge/ivy-1.2.xml");
+        File delivered = FileUtil.newFile("build/test/deliver/merge/ivy-1.2.xml");
         assertTrue(delivered.exists());
 
         // do a text compare, since we want to test comments as well as structure.
@@ -171,7 +171,7 @@ public class IvyDeliverTest extends TestCase {
         deliver.execute();
 
         // should have done the ivy delivering
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.2.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.2.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), deliveredIvyFile.toURI().toURL(), true);
@@ -197,7 +197,7 @@ public class IvyDeliverTest extends TestCase {
         deliver.execute();
 
         // should have done the ivy delivering
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.2.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.2.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), deliveredIvyFile.toURI().toURL(), true);
@@ -214,14 +214,14 @@ public class IvyDeliverTest extends TestCase {
     public void testWithResolveId() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setResolveId("withResolveId");
         resolve.execute();
 
         // resolve another ivy file
         resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-latest.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-latest.xml"));
         resolve.execute();
 
         deliver.setResolveId("withResolveId");
@@ -230,7 +230,7 @@ public class IvyDeliverTest extends TestCase {
         deliver.execute();
 
         // should have done the ivy delivering
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.2.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.2.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), deliveredIvyFile.toURI().toURL(), true);
@@ -251,14 +251,14 @@ public class IvyDeliverTest extends TestCase {
         // do a resolve in the new build
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(other);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setResolveId("withResolveId");
         resolve.execute();
 
         // resolve another ivy file
         resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-latest.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-latest.xml"));
         resolve.execute();
 
         deliver.setResolveId("withResolveId");
@@ -267,7 +267,7 @@ public class IvyDeliverTest extends TestCase {
         deliver.execute();
 
         // should have done the ivy delivering
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.2.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.2.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), deliveredIvyFile.toURI().toURL(), true);
@@ -291,7 +291,7 @@ public class IvyDeliverTest extends TestCase {
         deliver.execute();
 
         // should have done the ivy delivering
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.2.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.2.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), deliveredIvyFile.toURI().toURL(), true);
@@ -311,7 +311,7 @@ public class IvyDeliverTest extends TestCase {
         deliver.execute();
 
         // should have done the ivy delivering
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.2.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.2.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), deliveredIvyFile.toURI().toURL(), true);
@@ -344,7 +344,7 @@ public class IvyDeliverTest extends TestCase {
 
         // should have done the ivy delivering, including setting the branch according to the
         // configured default
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.2.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.2.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), deliveredIvyFile.toURI().toURL(), true);
@@ -372,7 +372,7 @@ public class IvyDeliverTest extends TestCase {
         deliver.execute();
 
         // should have done the ivy delivering
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.2.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.2.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), deliveredIvyFile.toURI().toURL(), false);
@@ -399,7 +399,7 @@ public class IvyDeliverTest extends TestCase {
         deliver.execute();
 
         // should have done the ivy delivering
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.2.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.2.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), deliveredIvyFile.toURI().toURL(), false);
@@ -415,7 +415,7 @@ public class IvyDeliverTest extends TestCase {
         ret.setPattern("build/test/retrieve/[artifact]-[revision].[ext]");
         ret.execute();
 
-        File list = new File("build/test/retrieve");
+        File list = FileUtil.newFile("build/test/retrieve");
         String[] files = list.list();
         HashSet actualFileSet = new HashSet(Arrays.asList(files));
         HashSet expectedFileSet = new HashSet();
@@ -446,7 +446,7 @@ public class IvyDeliverTest extends TestCase {
         deliver.execute();
 
         // should have done the ivy delivering
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.2.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.2.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), deliveredIvyFile.toURI().toURL(), false);
@@ -462,7 +462,7 @@ public class IvyDeliverTest extends TestCase {
         ret.setPattern("build/test/retrieve/[artifact]-[revision].[ext]");
         ret.execute();
 
-        File list = new File("build/test/retrieve");
+        File list = FileUtil.newFile("build/test/retrieve");
         String[] files = list.list();
         HashSet actualFileSet = new HashSet(Arrays.asList(files));
         HashSet expectedFileSet = new HashSet();
@@ -490,7 +490,7 @@ public class IvyDeliverTest extends TestCase {
         deliver.execute();
 
         // should have done the ivy delivering
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.2.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.2.xml");
         assertTrue(deliveredIvyFile.exists());
         String deliveredFileContent = FileUtil.readEntirely(new BufferedReader(new FileReader(
                 deliveredIvyFile)));
@@ -513,7 +513,7 @@ public class IvyDeliverTest extends TestCase {
         deliver.execute();
 
         // should have done the ivy delivering
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.2.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.2.xml");
         assertTrue(deliveredIvyFile.exists());
         String deliveredFileContent = FileUtil.readEntirely(new BufferedReader(new FileReader(
                 deliveredIvyFile)));
@@ -535,7 +535,7 @@ public class IvyDeliverTest extends TestCase {
         deliver.execute();
 
         // should have done the ivy delivering
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.2.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.2.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), deliveredIvyFile.toURI().toURL(), true);
@@ -559,7 +559,7 @@ public class IvyDeliverTest extends TestCase {
         deliver.execute();
 
         // should have done the ivy delivering
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.2.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.2.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), deliveredIvyFile.toURI().toURL(), true);

--- a/test/java/org/apache/ivy/ant/IvyDependencyTreeTest.java
+++ b/test/java/org/apache/ivy/ant/IvyDependencyTreeTest.java
@@ -20,6 +20,7 @@ package org.apache.ivy.ant;
 import java.io.File;
 
 import org.apache.ivy.ant.testutil.AntTaskTestCase;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;

--- a/test/java/org/apache/ivy/ant/IvyDependencyTreeTest.java
+++ b/test/java/org/apache/ivy/ant/IvyDependencyTreeTest.java
@@ -42,7 +42,7 @@ public class IvyDependencyTreeTest extends AntTaskTestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -58,7 +58,7 @@ public class IvyDependencyTreeTest extends AntTaskTestCase {
     }
 
     public void testSimple() throws Exception {
-        dependencyTree.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        dependencyTree.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         dependencyTree.execute();
         assertLogContaining("Dependency tree for apache-resolve-simple");
         assertLogContaining("\\- org1#mod1.2;2.0");
@@ -67,14 +67,14 @@ public class IvyDependencyTreeTest extends AntTaskTestCase {
     public void testWithResolveId() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setResolveId("abc");
         resolve.execute();
 
         // resolve another ivy file
         resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-latest.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-latest.xml"));
         resolve.execute();
 
         dependencyTree.execute();
@@ -92,7 +92,7 @@ public class IvyDependencyTreeTest extends AntTaskTestCase {
     }
 
     public void testWithEvictedModule() throws Exception {
-        dependencyTree.setFile(new File("test/java/org/apache/ivy/ant/ivy-dyn-evicted.xml"));
+        dependencyTree.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-dyn-evicted.xml"));
         dependencyTree.execute();
         assertLogContaining("Dependency tree for apache-resolve-latest");
         assertLogNotContaining("+- org1#mod1.2;1+");
@@ -102,7 +102,7 @@ public class IvyDependencyTreeTest extends AntTaskTestCase {
     }
 
     public void testShowEvictedModule() throws Exception {
-        dependencyTree.setFile(new File("test/java/org/apache/ivy/ant/ivy-dyn-evicted.xml"));
+        dependencyTree.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-dyn-evicted.xml"));
         dependencyTree.setShowEvicted(true);
         dependencyTree.execute();
         assertLogContaining("Dependency tree for apache-resolve-latest");

--- a/test/java/org/apache/ivy/ant/IvyDependencyUpdateCheckerTest.java
+++ b/test/java/org/apache/ivy/ant/IvyDependencyUpdateCheckerTest.java
@@ -41,7 +41,7 @@ public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -59,7 +59,7 @@ public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
     public void testSimple() throws Exception {
         // depends on org="org1" name="mod1.1" rev="1.0"
         // has transitive dependency on org="org1" name="mod1.2" rev="2.0"
-        dependencyUpdateChecker.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple3.xml"));
+        dependencyUpdateChecker.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple3.xml"));
         dependencyUpdateChecker.execute();
 
         assertEquals("resolve-simple", getIvy().getVariable("ivy.module"));
@@ -73,7 +73,7 @@ public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
     public void testSimpleAndShowTransitiveDependencies() throws Exception {
         // depends on org="org1" name="mod1.1" rev="1.0"
         // has transitive dependency on org="org1" name="mod1.2" rev="2.0"
-        dependencyUpdateChecker.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple3.xml"));
+        dependencyUpdateChecker.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple3.xml"));
         dependencyUpdateChecker.setShowTransitive(true);
         dependencyUpdateChecker.execute();
 
@@ -88,7 +88,7 @@ public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
     public void testResolveWithoutIvyFile() throws Exception {
         // depends on org="org1" name="mod1.2" rev="2.0"
 
-        dependencyUpdateChecker.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        dependencyUpdateChecker.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         dependencyUpdateChecker.setConf("default");
         dependencyUpdateChecker.setHaltonfailure(false);
         dependencyUpdateChecker.execute();
@@ -127,7 +127,7 @@ public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
     public void testFailure() throws Exception {
         try {
             dependencyUpdateChecker
-                    .setFile(new File("test/java/org/apache/ivy/ant/ivy-failure.xml"));
+                    .setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-failure.xml"));
             dependencyUpdateChecker.execute();
             fail("failure didn't raised an exception with default haltonfailure setting");
         } catch (BuildException ex) {
@@ -138,7 +138,7 @@ public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
     public void testFailureWithMissingConfigurations() throws Exception {
         try {
             dependencyUpdateChecker
-                    .setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+                    .setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
             dependencyUpdateChecker.setConf("default,unknown");
             dependencyUpdateChecker.execute();
             fail("missing configurations didn't raised an exception");
@@ -149,7 +149,7 @@ public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
 
     public void testFailureOnBadDependencyIvyFile() throws Exception {
         try {
-            dependencyUpdateChecker.setFile(new File(
+            dependencyUpdateChecker.setFile(FileUtil.newFile(
                     "test/java/org/apache/ivy/ant/ivy-failure2.xml"));
             dependencyUpdateChecker.execute();
             fail("failure didn't raised an exception with default haltonfailure setting");
@@ -160,7 +160,7 @@ public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
 
     public void testFailureOnBadStatusInDependencyIvyFile() throws Exception {
         try {
-            dependencyUpdateChecker.setFile(new File(
+            dependencyUpdateChecker.setFile(FileUtil.newFile(
                     "test/java/org/apache/ivy/ant/ivy-failure3.xml"));
             dependencyUpdateChecker.execute();
             fail("failure didn't raised an exception with default haltonfailure setting");
@@ -172,7 +172,7 @@ public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
     public void testHaltOnFailure() throws Exception {
         try {
             dependencyUpdateChecker
-                    .setFile(new File("test/java/org/apache/ivy/ant/ivy-failure.xml"));
+                    .setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-failure.xml"));
             dependencyUpdateChecker.setHaltonfailure(false);
             dependencyUpdateChecker.execute();
         } catch (BuildException ex) {
@@ -182,7 +182,7 @@ public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
     }
 
     public void testExcludedConf() throws Exception {
-        dependencyUpdateChecker.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
+        dependencyUpdateChecker.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
         dependencyUpdateChecker.setConf("*,!default");
         dependencyUpdateChecker.execute();
 
@@ -200,7 +200,7 @@ public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
 
     public void testResolveWithAbsoluteFile() {
         // IVY-396
-        File ivyFile = new File("test/java/org/apache/ivy/ant/ivy-simple.xml");
+        File ivyFile = FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml");
         dependencyUpdateChecker.getProject().setProperty("ivy.dep.file", ivyFile.getAbsolutePath());
         dependencyUpdateChecker.execute();
 
@@ -226,7 +226,7 @@ public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
     }
 
     public void testSimpleExtends() throws Exception {
-        dependencyUpdateChecker.setFile(new File(
+        dependencyUpdateChecker.setFile(FileUtil.newFile(
                 "test/java/org/apache/ivy/ant/ivy-extends-multiconf.xml"));
         dependencyUpdateChecker.execute();
         assertEquals("1", dependencyUpdateChecker.getProject().getProperty("ivy.parents.count"));

--- a/test/java/org/apache/ivy/ant/IvyDependencyUpdateCheckerTest.java
+++ b/test/java/org/apache/ivy/ant/IvyDependencyUpdateCheckerTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 
 import org.apache.ivy.Ivy;
 import org.apache.ivy.ant.testutil.AntTaskTestCase;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;

--- a/test/java/org/apache/ivy/ant/IvyFindRevisionTest.java
+++ b/test/java/org/apache/ivy/ant/IvyFindRevisionTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 
 import junit.framework.TestCase;
 
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
 

--- a/test/java/org/apache/ivy/ant/IvyFindRevisionTest.java
+++ b/test/java/org/apache/ivy/ant/IvyFindRevisionTest.java
@@ -39,7 +39,7 @@ public class IvyFindRevisionTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 

--- a/test/java/org/apache/ivy/ant/IvyInfoRepositoryTest.java
+++ b/test/java/org/apache/ivy/ant/IvyInfoRepositoryTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 
 import junit.framework.TestCase;
 
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
 

--- a/test/java/org/apache/ivy/ant/IvyInfoRepositoryTest.java
+++ b/test/java/org/apache/ivy/ant/IvyInfoRepositoryTest.java
@@ -39,7 +39,7 @@ public class IvyInfoRepositoryTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 

--- a/test/java/org/apache/ivy/ant/IvyInfoTest.java
+++ b/test/java/org/apache/ivy/ant/IvyInfoTest.java
@@ -34,7 +34,7 @@ public class IvyInfoTest extends TestCase {
     }
 
     public void testSimple() throws Exception {
-        info.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        info.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         info.execute();
 
         assertEquals("apache", info.getProject().getProperty("ivy.organisation"));
@@ -45,7 +45,7 @@ public class IvyInfoTest extends TestCase {
     }
 
     public void testAll() throws Exception {
-        info.setFile(new File("test/java/org/apache/ivy/ant/ivy-info-all.xml"));
+        info.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-info-all.xml"));
         info.execute();
 
         assertEquals("apache", info.getProject().getProperty("ivy.organisation"));
@@ -66,14 +66,14 @@ public class IvyInfoTest extends TestCase {
     }
 
     public void testIVY726() throws Exception {
-        info.setFile(new File("test/java/org/apache/ivy/ant/ivy-info-all.xml"));
+        info.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-info-all.xml"));
         info.execute();
 
         assertTrue(info.getProject().getProperty("ivy.extra.branch") == null);
     }
 
     public void testIVY395() throws Exception {
-        info.setFile(new File("test/java/org/apache/ivy/ant/ivy-artifact-info.xml"));
+        info.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-artifact-info.xml"));
         info.execute();
 
         assertEquals("test", info.getProject().getProperty("ivy.artifact.1.name"));

--- a/test/java/org/apache/ivy/ant/IvyInfoTest.java
+++ b/test/java/org/apache/ivy/ant/IvyInfoTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 
 import junit.framework.TestCase;
 
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.Project;
 
 public class IvyInfoTest extends TestCase {

--- a/test/java/org/apache/ivy/ant/IvyInstallTest.java
+++ b/test/java/org/apache/ivy/ant/IvyInstallTest.java
@@ -44,7 +44,7 @@ public class IvyInstallTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -58,8 +58,8 @@ public class IvyInstallTest extends TestCase {
     }
 
     private void cleanInstall() {
-        FileUtil.forceDelete(new File("build/test/install"));
-        FileUtil.forceDelete(new File("build/test/install2"));
+        FileUtil.forceDelete(FileUtil.newFile("build/test/install"));
+        FileUtil.forceDelete(FileUtil.newFile("build/test/install2"));
     }
 
     public void testInstallDummyDefault() {
@@ -74,13 +74,13 @@ public class IvyInstallTest extends TestCase {
 
         install.execute();
 
-        assertTrue(new File("build/test/install/org1/mod1.4/ivy-1.0.1.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.4/ivy-1.0.1.xml").exists());
 
-        assertTrue(new File("build/test/install/org1/mod1.1/ivy-2.0.xml").exists());
-        assertTrue(new File("build/test/install/org1/mod1.1/mod1.1-2.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.1/ivy-2.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.1/mod1.1-2.0.jar").exists());
 
-        assertTrue(new File("build/test/install/org1/mod1.2/ivy-2.2.xml").exists());
-        assertTrue(new File("build/test/install/org1/mod1.2/mod1.2-2.2.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.2/ivy-2.2.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.2/mod1.2-2.2.jar").exists());
     }
 
     public void testInstallWithAnyType() {
@@ -95,7 +95,7 @@ public class IvyInstallTest extends TestCase {
 
         install.execute();
 
-        assertTrue(new File("build/test/install/org8/mod8.1/a-1.1.txt").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org8/mod8.1/a-1.1.txt").exists());
     }
 
     public void testInstallWithMultipleType() {
@@ -110,7 +110,7 @@ public class IvyInstallTest extends TestCase {
 
         install.execute();
 
-        assertTrue(new File("build/test/install/org8/mod8.1/a-1.1.txt").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org8/mod8.1/a-1.1.txt").exists());
     }
 
     /**
@@ -127,9 +127,9 @@ public class IvyInstallTest extends TestCase {
 
         install.execute();
 
-        assertTrue(new File("build/test/install/org1/mod1/jars/mod1-1.0.jar").exists());
-        assertTrue(new File("build/test/install/org1/mod2/jars/mod2-1.0.jar").exists());
-        assertTrue(new File("build/test/install/org1/mod3/jars/mod3-1.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1/jars/mod1-1.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod2/jars/mod2-1.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod3/jars/mod3-1.0.jar").exists());
     }
 
     /**
@@ -147,14 +147,14 @@ public class IvyInstallTest extends TestCase {
 
         install.execute();
 
-        assertTrue(new File("build/test/install/org1/mod1/jars/mod1-1.0.jar").exists());
-        assertTrue(new File("build/test/install/org1/mod2/jars/mod2-1.0.jar").exists());
-        assertFalse(new File("build/test/install/org1/mod3/jars/mod3-1.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1/jars/mod1-1.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod2/jars/mod2-1.0.jar").exists());
+        assertFalse(FileUtil.newFile("build/test/install/org1/mod3/jars/mod3-1.0.jar").exists());
     }
 
     public void testInstallWithClassifiers() throws Exception {
         // IVY-1324
-        project.setProperty("ivy.settings.url", new File("test/repositories/m2/ivysettings.xml")
+        project.setProperty("ivy.settings.url", FileUtil.newFile("test/repositories/m2/ivysettings.xml")
                 .toURI().toURL().toExternalForm());
         install.setOrganisation("org.apache");
         install.setModule("test-sources");
@@ -165,13 +165,13 @@ public class IvyInstallTest extends TestCase {
 
         install.execute();
 
-        assertTrue(new File(
+        assertTrue(FileUtil.newFile(
                 "build/test/install/org.apache/test-sources/test-sources-1.0-javadoc.jar").exists());
-        assertTrue(new File(
+        assertTrue(FileUtil.newFile(
                 "build/test/install/org.apache/test-sources/test-sources-1.0-sources.jar").exists());
-        assertTrue(new File("build/test/install/org.apache/test-sources/test-sources-1.0.jar")
+        assertTrue(FileUtil.newFile("build/test/install/org.apache/test-sources/test-sources-1.0.jar")
                 .exists());
-        assertTrue(new File("build/test/install/org.apache/test-sources/ivy-1.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org.apache/test-sources/ivy-1.0.xml").exists());
     }
 
     public void testInstallWithUnusedType() {
@@ -186,7 +186,7 @@ public class IvyInstallTest extends TestCase {
 
         install.execute();
 
-        assertFalse(new File("build/test/install/org8/mod8.1/a-1.1.txt").exists());
+        assertFalse(FileUtil.newFile("build/test/install/org8/mod8.1/a-1.1.txt").exists());
     }
 
     public void testInstallWithOriginalMetadata() {
@@ -204,7 +204,7 @@ public class IvyInstallTest extends TestCase {
             fail("unknown dependency, failure unexpected (haltonfailure=false). Failure: " + be);
         }
 
-        assertFalse(new File("build/test/install/org.apache/test/test-1.0.pom").exists());
+        assertFalse(FileUtil.newFile("build/test/install/org.apache/test/test-1.0.pom").exists());
 
         install.setInstallOriginalMetadata(true);
 
@@ -215,7 +215,7 @@ public class IvyInstallTest extends TestCase {
             fail("unknown dependency, failure unexpected (haltonfailure=false). Failure: " + be);
         }
 
-        assertTrue(new File("build/test/install/org.apache/test/test-1.0.pom").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org.apache/test/test-1.0.pom").exists());
     }
 
     public void testIVY843() {
@@ -234,7 +234,7 @@ public class IvyInstallTest extends TestCase {
         install.setTo("install2");
         install.execute();
 
-        assertTrue(new File("build/test/install2/org1/mod1.4/ivy-1.0.1.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install2/org1/mod1.4/ivy-1.0.1.xml").exists());
     }
 
     public void testInstallWithBranch() {
@@ -248,7 +248,7 @@ public class IvyInstallTest extends TestCase {
 
         install.execute();
 
-        assertTrue(new File("build/test/install/foo/foo1/branch1/ivy-2.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/foo/foo1/branch1/ivy-2.xml").exists());
     }
 
     public void testInstallWithNamespace() {
@@ -262,8 +262,8 @@ public class IvyInstallTest extends TestCase {
 
         install.execute();
 
-        assertTrue(new File("build/test/install/systemorg/systemmod2/ivy-1.0.xml").exists());
-        assertTrue(new File("build/test/install/systemorg/systemmod/ivy-1.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/systemorg/systemmod2/ivy-1.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/systemorg/systemmod/ivy-1.0.xml").exists());
     }
 
     public void testInstallWithNamespace2() {
@@ -294,8 +294,8 @@ public class IvyInstallTest extends TestCase {
 
         install.execute();
 
-        assertTrue(new File("build/test/install/systemorg/systemmod2/ivy-1.0.xml").exists());
-        assertTrue(new File("build/test/install/systemorg/systemmod/ivy-1.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/systemorg/systemmod2/ivy-1.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/systemorg/systemmod/ivy-1.0.xml").exists());
     }
 
     public void testDependencyNotFoundFailure() {

--- a/test/java/org/apache/ivy/ant/IvyListModulesTest.java
+++ b/test/java/org/apache/ivy/ant/IvyListModulesTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 
 import junit.framework.TestCase;
 
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
 

--- a/test/java/org/apache/ivy/ant/IvyListModulesTest.java
+++ b/test/java/org/apache/ivy/ant/IvyListModulesTest.java
@@ -39,7 +39,7 @@ public class IvyListModulesTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 

--- a/test/java/org/apache/ivy/ant/IvyPostResolveTaskTest.java
+++ b/test/java/org/apache/ivy/ant/IvyPostResolveTaskTest.java
@@ -52,7 +52,7 @@ public class IvyPostResolveTaskTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -63,7 +63,7 @@ public class IvyPostResolveTaskTest extends TestCase {
     public void testWithPreviousResolveInSameBuildAndLessConfs() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
         resolve.setConf("default,compile");
         resolve.execute();
 
@@ -81,7 +81,7 @@ public class IvyPostResolveTaskTest extends TestCase {
     public void testWithPreviousResolveInSameBuildAndSameConfs() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
         resolve.setConf("default");
         resolve.execute();
 
@@ -99,7 +99,7 @@ public class IvyPostResolveTaskTest extends TestCase {
     public void testWithPreviousResolveInSameBuildAndWildcard() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
         resolve.setConf("*");
         resolve.execute();
 
@@ -117,7 +117,7 @@ public class IvyPostResolveTaskTest extends TestCase {
     public void testWithPreviousResolveInSameBuildAndBothWildcard() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
         resolve.setConf("*");
         resolve.execute();
 
@@ -135,7 +135,7 @@ public class IvyPostResolveTaskTest extends TestCase {
     public void testWithPreviousResolveInSameBuildAndMoreConfs() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
         resolve.setConf("compile");
         resolve.execute();
 
@@ -156,7 +156,7 @@ public class IvyPostResolveTaskTest extends TestCase {
     public void testWithoutKeep() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
         resolve.setConf("compile");
         resolve.execute();
 
@@ -209,7 +209,7 @@ public class IvyPostResolveTaskTest extends TestCase {
     public void testWithResolveIdAndPreviousResolveInSameBuildAndLessConfs() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
         resolve.setConf("default,compile");
         resolve.setResolveId("testResolveId");
         resolve.execute();
@@ -220,7 +220,7 @@ public class IvyPostResolveTaskTest extends TestCase {
         // perform another resolve
         resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setConf("*");
         resolve.execute();
 
@@ -243,7 +243,7 @@ public class IvyPostResolveTaskTest extends TestCase {
     public void testWithResolveIdAndPreviousResolveInSameBuildAndSameConfs() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
         resolve.setConf("default");
         resolve.setResolveId("testResolveId");
         resolve.execute();
@@ -254,7 +254,7 @@ public class IvyPostResolveTaskTest extends TestCase {
         // perform another resolve
         resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setConf("*");
         resolve.execute();
 
@@ -277,7 +277,7 @@ public class IvyPostResolveTaskTest extends TestCase {
     public void testWithResolveIdAndPreviousResolveInSameBuildAndWildcard() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
         resolve.setConf("*");
         resolve.setResolveId("testResolveId");
         resolve.execute();
@@ -288,7 +288,7 @@ public class IvyPostResolveTaskTest extends TestCase {
         // perform another resolve
         resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setConf("*");
         resolve.execute();
 
@@ -311,7 +311,7 @@ public class IvyPostResolveTaskTest extends TestCase {
     public void testWithResolveIdAndPreviousResolveInSameBuildAndBothWildcard() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
         resolve.setConf("*");
         resolve.setResolveId("testResolveId");
         resolve.execute();
@@ -322,7 +322,7 @@ public class IvyPostResolveTaskTest extends TestCase {
         // perform another resolve
         resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setConf("*");
         resolve.execute();
 
@@ -345,7 +345,7 @@ public class IvyPostResolveTaskTest extends TestCase {
     public void testWithResolveIdAndPreviousResolveInSameBuildAndMoreConfs() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
         resolve.setConf("compile");
         resolve.setResolveId("testResolveId");
         resolve.execute();
@@ -358,7 +358,7 @@ public class IvyPostResolveTaskTest extends TestCase {
         // perform another resolve
         resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setConf("*");
         resolve.execute();
 

--- a/test/java/org/apache/ivy/ant/IvyPostResolveTaskTest.java
+++ b/test/java/org/apache/ivy/ant/IvyPostResolveTaskTest.java
@@ -25,6 +25,7 @@ import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.report.ResolveReport;
 import org.apache.ivy.util.CacheCleaner;
 import org.apache.ivy.util.DefaultMessageLogger;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;

--- a/test/java/org/apache/ivy/ant/IvyPublishTest.java
+++ b/test/java/org/apache/ivy/ant/IvyPublishTest.java
@@ -125,7 +125,7 @@ public class IvyPublishTest extends TestCase {
 
         int lineNo = 1;
 
-        BufferedReader merged = new BufferedReader(new FileReader(published));
+        BufferedReader merged = new BufferedReader(FileUtil.newReader(published));
         BufferedReader expected = new BufferedReader(new InputStreamReader(getClass()
                 .getResourceAsStream("ivy-extends-merged.xml")));
         for (String mergeLine = merged.readLine(), expectedLine = expected.readLine(); mergeLine != null
@@ -173,7 +173,7 @@ public class IvyPublishTest extends TestCase {
 
         int lineNo = 1;
 
-        BufferedReader merged = new BufferedReader(new FileReader(published));
+        BufferedReader merged = new BufferedReader(FileUtil.newReader(published));
         BufferedReader expected = new BufferedReader(new InputStreamReader(getClass()
                 .getResourceAsStream("ivy-extends-merged.xml")));
         for (String mergeLine = merged.readLine(), expectedLine = expected.readLine(); mergeLine != null
@@ -227,7 +227,7 @@ public class IvyPublishTest extends TestCase {
 
         int lineNo = 1;
 
-        BufferedReader merged = new BufferedReader(new FileReader(published));
+        BufferedReader merged = new BufferedReader(FileUtil.newReader(published));
         BufferedReader expected = new BufferedReader(new InputStreamReader(getClass()
                 .getResourceAsStream("ivy-extends-merged.xml")));
         for (String mergeLine = merged.readLine(), expectedLine = expected.readLine(); mergeLine != null
@@ -275,7 +275,7 @@ public class IvyPublishTest extends TestCase {
 
         int lineNo = 1;
 
-        BufferedReader merged = new BufferedReader(new FileReader(published));
+        BufferedReader merged = new BufferedReader(FileUtil.newReader(published));
         BufferedReader expected = new BufferedReader(new InputStreamReader(getClass()
                 .getResourceAsStream("extends/child1/ivy-child1-merged.xml")));
         for (String mergeLine = merged.readLine(), expectedLine = expected.readLine(); mergeLine != null
@@ -333,7 +333,7 @@ public class IvyPublishTest extends TestCase {
 
         int lineNo = 1;
 
-        BufferedReader merged = new BufferedReader(new FileReader(published));
+        BufferedReader merged = new BufferedReader(FileUtil.newReader(published));
         BufferedReader expected = new BufferedReader(new InputStreamReader(getClass()
                 .getResourceAsStream("ivy-extends-minimal-merged.xml")));
         for (String mergeLine = merged.readLine(), expectedLine = expected.readLine(); mergeLine != null
@@ -397,7 +397,7 @@ public class IvyPublishTest extends TestCase {
 
         int lineNo = 1;
 
-        BufferedReader merged = new BufferedReader(new FileReader(published));
+        BufferedReader merged = new BufferedReader(FileUtil.newReader(published));
         BufferedReader expected = new BufferedReader(new InputStreamReader(getClass()
                 .getResourceAsStream("ivy-extends-extra-attributes-merged.xml")));
         for (String mergeLine = merged.readLine(), expectedLine = expected.readLine(); mergeLine != null
@@ -462,7 +462,7 @@ public class IvyPublishTest extends TestCase {
 
         int lineNo = 1;
 
-        BufferedReader merged = new BufferedReader(new FileReader(published));
+        BufferedReader merged = new BufferedReader(FileUtil.newReader(published));
         BufferedReader expected = new BufferedReader(new InputStreamReader(getClass()
                 .getResourceAsStream("ivy-extends-extra-attributes-merged.xml")));
         for (String mergeLine = merged.readLine(), expectedLine = expected.readLine(); mergeLine != null
@@ -714,7 +714,7 @@ public class IvyPublishTest extends TestCase {
         // should respect the ivy file, with descriptions, ...
         String expected = FileUtil.readEntirely(new BufferedReader(new InputStreamReader(
                 IvyPublishTest.class.getResourceAsStream("published-ivy-custom.xml"))));
-        String updated = FileUtil.readEntirely(new BufferedReader(new FileReader(dest)));
+        String updated = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(dest)));
         assertEquals(expected, updated);
 
     }
@@ -878,7 +878,7 @@ public class IvyPublishTest extends TestCase {
             fail("by default, publish should fail when a readonly artifact already exist");
         } catch (Exception ex) {
             assertTrue(dest.exists());
-            BufferedReader reader = new BufferedReader(new FileReader(dest));
+            BufferedReader reader = new BufferedReader(FileUtil.newReader(dest));
             assertEquals("old version", reader.readLine());
             reader.close();
         }
@@ -914,7 +914,7 @@ public class IvyPublishTest extends TestCase {
         publish.setOverwrite(true);
         publish.execute();
         assertTrue(dest.exists());
-        BufferedReader reader = new BufferedReader(new FileReader(dest));
+        BufferedReader reader = new BufferedReader(FileUtil.newReader(dest));
         assertEquals("new version", reader.readLine());
         reader.close();
     }
@@ -951,7 +951,7 @@ public class IvyPublishTest extends TestCase {
         publish.setOverwrite(true);
         publish.execute();
         assertTrue(dest.exists());
-        BufferedReader reader = new BufferedReader(new FileReader(dest));
+        BufferedReader reader = new BufferedReader(FileUtil.newReader(dest));
         assertEquals("new version", reader.readLine());
         reader.close();
     }

--- a/test/java/org/apache/ivy/ant/IvyPublishTest.java
+++ b/test/java/org/apache/ivy/ant/IvyPublishTest.java
@@ -61,7 +61,7 @@ public class IvyPublishTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -76,14 +76,14 @@ public class IvyPublishTest extends TestCase {
     }
 
     private void cleanTestDir() {
-        FileUtil.forceDelete(new File("build/test/publish"));
-        FileUtil.forceDelete(new File("build/test/transactional"));
+        FileUtil.forceDelete(FileUtil.newFile("build/test/publish"));
+        FileUtil.forceDelete(FileUtil.newFile("build/test/transactional"));
     }
 
     private void cleanRep() {
         Delete del = new Delete();
         del.setProject(new Project());
-        del.setDir(new File("test/repositories/1/apache"));
+        del.setDir(FileUtil.newFile("test/repositories/1/apache"));
         del.execute();
     }
 
@@ -99,8 +99,8 @@ public class IvyPublishTest extends TestCase {
         pubParent.setProject(project);
         pubParent.setResolver("1");
         pubParent.setPubrevision("1.0");
-        File art = new File("build/test/publish/resolve-simple-1.0.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/resolve-simple-1.0.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
         pubParent.execute();
 
         // update=true implies merge=true
@@ -117,7 +117,7 @@ public class IvyPublishTest extends TestCase {
         publish.execute();
 
         // should have published the files with "1" resolver
-        File published = new File("test/repositories/1/apache/resolve-extends/ivys/ivy-1.2.xml");
+        File published = FileUtil.newFile("test/repositories/1/apache/resolve-extends/ivys/ivy-1.2.xml");
         assertTrue(published.exists());
 
         // do a text compare, since we want to test comments as well as structure.
@@ -165,7 +165,7 @@ public class IvyPublishTest extends TestCase {
         publish.execute();
 
         // should have published the files with "1" resolver
-        File published = new File("test/repositories/1/apache/resolve-extends/ivys/ivy-1.2.xml");
+        File published = FileUtil.newFile("test/repositories/1/apache/resolve-extends/ivys/ivy-1.2.xml");
         assertTrue(published.exists());
 
         // do a text compare, since we want to test comments as well as structure.
@@ -202,7 +202,7 @@ public class IvyPublishTest extends TestCase {
 
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-extends-multiconf.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-extends-multiconf.xml"));
         resolve.execute();
 
         // update=true implies merge=true
@@ -219,7 +219,7 @@ public class IvyPublishTest extends TestCase {
         publish.execute();
 
         // should have published the files with "1" resolver
-        File published = new File("test/repositories/1/apache/resolve-extends/ivys/ivy-1.2.xml");
+        File published = FileUtil.newFile("test/repositories/1/apache/resolve-extends/ivys/ivy-1.2.xml");
         assertTrue(published.exists());
 
         // do a text compare, since we want to test comments as well as structure.
@@ -253,7 +253,7 @@ public class IvyPublishTest extends TestCase {
 
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/extends/child1/ivy-child1.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/extends/child1/ivy-child1.xml"));
         resolve.execute();
 
         // update=true implies merge=true
@@ -267,7 +267,7 @@ public class IvyPublishTest extends TestCase {
         publish.execute();
 
         // should have published the files with "1" resolver
-        File published = new File("test/repositories/1/apache/child1/ivys/ivy-1.2.xml");
+        File published = FileUtil.newFile("test/repositories/1/apache/child1/ivys/ivy-1.2.xml");
         assertTrue(published.exists());
 
         // do a text compare, since we want to test comments as well as structure.
@@ -308,8 +308,8 @@ public class IvyPublishTest extends TestCase {
         pubParent.setProject(project);
         pubParent.setResolver("1");
         pubParent.setPubrevision("1.0");
-        File art = new File("build/test/publish/resolve-simple-1.0.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/resolve-simple-1.0.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
         pubParent.execute();
 
         // update=true implies merge=true
@@ -325,7 +325,7 @@ public class IvyPublishTest extends TestCase {
         publish.execute();
 
         // should have published the files with "1" resolver
-        File published = new File("test/repositories/1/apache/resolve-minimal/ivys/ivy-1.2.xml");
+        File published = FileUtil.newFile("test/repositories/1/apache/resolve-minimal/ivys/ivy-1.2.xml");
         assertTrue(published.exists());
 
         // do a text compare, since we want to test comments as well as structure.
@@ -366,8 +366,8 @@ public class IvyPublishTest extends TestCase {
         pubParent.setProject(project);
         pubParent.setResolver("1");
         pubParent.setPubrevision("1.0");
-        File art = new File("build/test/publish/resolve-simple-1.0.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/resolve-simple-1.0.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
         pubParent.execute();
 
         // update=true implies merge=true
@@ -389,7 +389,7 @@ public class IvyPublishTest extends TestCase {
         publish.execute();
 
         // should have published the files with "1" resolver
-        File published = new File("test/repositories/1/apache/resolve-minimal/ivys/ivy-1.2.xml");
+        File published = FileUtil.newFile("test/repositories/1/apache/resolve-minimal/ivys/ivy-1.2.xml");
         assertTrue(published.exists());
 
         // do a text compare, since we want to test comments as well as structure.
@@ -431,8 +431,8 @@ public class IvyPublishTest extends TestCase {
         pubParent.setProject(project);
         pubParent.setResolver("1");
         pubParent.setPubrevision("1.0");
-        File art = new File("build/test/publish/resolve-simple-1.0.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/resolve-simple-1.0.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
         pubParent.execute();
 
         // update=true implies merge=true
@@ -454,7 +454,7 @@ public class IvyPublishTest extends TestCase {
         publish.execute();
 
         // should have published the files with "1" resolver
-        File published = new File("test/repositories/1/apache/resolve-minimal/ivys/ivy-1.2.xml");
+        File published = FileUtil.newFile("test/repositories/1/apache/resolve-minimal/ivys/ivy-1.2.xml");
         assertTrue(published.exists());
 
         // do a text compare, since we want to test comments as well as structure.
@@ -491,22 +491,22 @@ public class IvyPublishTest extends TestCase {
 
         publish.setPubrevision("1.2");
         publish.setResolver("1");
-        File art = new File("build/test/publish/resolve-simple-1.2.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/resolve-simple-1.2.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
         publish.execute();
 
         // should have do the ivy delivering
-        assertTrue(new File("build/test/publish/ivy-1.2.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/publish/ivy-1.2.xml").exists());
 
         // should have published the files with "1" resolver
-        assertTrue(new File("test/repositories/1/apache/resolve-simple/ivys/ivy-1.2.xml").exists());
-        assertTrue(new File("test/repositories/1/apache/resolve-simple/jars/resolve-simple-1.2.jar")
+        assertTrue(FileUtil.newFile("test/repositories/1/apache/resolve-simple/ivys/ivy-1.2.xml").exists());
+        assertTrue(FileUtil.newFile("test/repositories/1/apache/resolve-simple/jars/resolve-simple-1.2.jar")
                 .exists());
 
         // should have updated published ivy version
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(),
-            new File("test/repositories/1/apache/resolve-simple/ivys/ivy-1.2.xml").toURI().toURL(),
+            FileUtil.newFile("test/repositories/1/apache/resolve-simple/ivys/ivy-1.2.xml").toURI().toURL(),
             false);
         assertEquals("1.2", md.getModuleRevisionId().getRevision());
     }
@@ -527,12 +527,12 @@ public class IvyPublishTest extends TestCase {
             assertTrue(ex.getMessage().indexOf("missing") != -1);
             assertTrue(ex.getMessage().indexOf("resolve-simple.jar") != -1);
             // should have do the ivy delivering
-            assertTrue(new File("build/test/publish/ivy-1.2.xml").exists());
+            assertTrue(FileUtil.newFile("build/test/publish/ivy-1.2.xml").exists());
 
             // should not have published the files with "1" resolver
-            assertFalse(new File("test/repositories/1/apache/resolve-simple/ivys/ivy-1.2.xml")
+            assertFalse(FileUtil.newFile("test/repositories/1/apache/resolve-simple/ivys/ivy-1.2.xml")
                     .exists());
-            assertFalse(new File(
+            assertFalse(FileUtil.newFile(
                     "test/repositories/1/apache/resolve-simple/jars/resolve-simple-1.2.jar")
                     .exists());
         }
@@ -546,8 +546,8 @@ public class IvyPublishTest extends TestCase {
 
         // in this test case one artifact is available, and the other one is missing
         // since we use a transactional resolver, no file should be published at all
-        File art = new File("build/test/publish/multi1-1.2.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/multi1-1.2.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
         publish.setPubrevision("1.2");
         publish.setResolver("transactional");
         publish.setHaltonmissing(true);
@@ -559,10 +559,10 @@ public class IvyPublishTest extends TestCase {
             assertTrue(ex.getMessage().indexOf("multi2.jar") != -1);
 
             // should have do the ivy delivering
-            assertTrue(new File("build/test/publish/ivy-1.2.xml").exists());
+            assertTrue(FileUtil.newFile("build/test/publish/ivy-1.2.xml").exists());
 
             // should not have published the files with "transactional" resolver
-            assertFalse(new File("build/test/transactional/apache/multi/1.2").exists());
+            assertFalse(FileUtil.newFile("build/test/transactional/apache/multi/1.2").exists());
         }
     }
 
@@ -574,8 +574,8 @@ public class IvyPublishTest extends TestCase {
 
         // in this test case one artifact is available, and the other one is missing
         // this should be detected early and no file should be published at all
-        File art = new File("build/test/publish/multi1-1.2.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/multi1-1.2.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
         publish.setPubrevision("1.2");
         publish.setResolver("1");
         publish.setHaltonmissing(true);
@@ -587,10 +587,10 @@ public class IvyPublishTest extends TestCase {
             assertTrue(ex.getMessage().indexOf("multi2.jar") != -1);
 
             // should have do the ivy delivering
-            assertTrue(new File("build/test/publish/ivy-1.2.xml").exists());
+            assertTrue(FileUtil.newFile("build/test/publish/ivy-1.2.xml").exists());
 
             // should not have published the files with "transactional" resolver
-            assertFalse(new File("test/repositories/1/apache/multi").exists());
+            assertFalse(FileUtil.newFile("test/repositories/1/apache/multi").exists());
         }
     }
 
@@ -604,22 +604,22 @@ public class IvyPublishTest extends TestCase {
         publish.setResolver("1");
         publish.setConf("compile");
         publish.setUpdate(true);
-        File art = new File("build/test/publish/resolve-simple-1.2.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/resolve-simple-1.2.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
         publish.execute();
 
         // should have do the ivy delivering
-        assertTrue(new File("build/test/publish/ivy-1.2.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/publish/ivy-1.2.xml").exists());
 
         // should have published the files with "1" resolver
-        assertTrue(new File("test/repositories/1/apache/resolve-simple/ivys/ivy-1.2.xml").exists());
-        assertTrue(new File("test/repositories/1/apache/resolve-simple/jars/resolve-simple-1.2.jar")
+        assertTrue(FileUtil.newFile("test/repositories/1/apache/resolve-simple/ivys/ivy-1.2.xml").exists());
+        assertTrue(FileUtil.newFile("test/repositories/1/apache/resolve-simple/jars/resolve-simple-1.2.jar")
                 .exists());
 
         // should have updated published ivy version
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(),
-            new File("test/repositories/1/apache/resolve-simple/ivys/ivy-1.2.xml").toURI().toURL(),
+            FileUtil.newFile("test/repositories/1/apache/resolve-simple/ivys/ivy-1.2.xml").toURI().toURL(),
             false);
         assertEquals("1.2", md.getModuleRevisionId().getRevision());
 
@@ -637,21 +637,21 @@ public class IvyPublishTest extends TestCase {
 
         publish.setPubrevision("1.2");
         publish.setResolver("1");
-        File art = new File("build/test/publish/1/multi1-1.2.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
-        art = new File("build/test/publish/2/multi2-1.2.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/1/multi1-1.2.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        art = FileUtil.newFile("build/test/publish/2/multi2-1.2.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
         publish.addArtifactspattern("build/test/publish/1/[artifact]-[revision].[ext]");
         publish.addArtifactspattern("build/test/publish/2/[artifact]-[revision].[ext]");
         publish.execute();
 
         // should have do the ivy delivering
-        assertTrue(new File("build/test/publish/1/ivy-1.2.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/publish/1/ivy-1.2.xml").exists());
 
         // should have published the files with "1" resolver
-        assertTrue(new File("test/repositories/1/apache/multi/ivys/ivy-1.2.xml").exists());
-        assertTrue(new File("test/repositories/1/apache/multi/jars/multi1-1.2.jar").exists());
-        assertTrue(new File("test/repositories/1/apache/multi/jars/multi2-1.2.jar").exists());
+        assertTrue(FileUtil.newFile("test/repositories/1/apache/multi/ivys/ivy-1.2.xml").exists());
+        assertTrue(FileUtil.newFile("test/repositories/1/apache/multi/jars/multi1-1.2.jar").exists());
+        assertTrue(FileUtil.newFile("test/repositories/1/apache/multi/jars/multi2-1.2.jar").exists());
     }
 
     public void testPublishPublicConfigsByWildcard() throws Exception {
@@ -663,17 +663,17 @@ public class IvyPublishTest extends TestCase {
         publish.setPubrevision("1.2");
         publish.setResolver("1");
         publish.setConf("*(public)");
-        File art = new File("build/test/publish/publish-public-1.2.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/publish-public-1.2.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
         publish.addArtifactspattern("build/test/publish/[artifact]-[revision].[ext]");
         publish.execute();
 
         // should have do the ivy delivering
-        assertTrue(new File("build/test/publish/ivy-1.2.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/publish/ivy-1.2.xml").exists());
 
         // should have published the files with "1" resolver
-        assertTrue(new File("test/repositories/1/apache/publish-public/ivys/ivy-1.2.xml").exists());
-        assertTrue(new File("test/repositories/1/apache/publish-public/jars/publish-public-1.2.jar")
+        assertTrue(FileUtil.newFile("test/repositories/1/apache/publish-public/ivys/ivy-1.2.xml").exists());
+        assertTrue(FileUtil.newFile("test/repositories/1/apache/publish-public/jars/publish-public-1.2.jar")
                 .exists());
     }
 
@@ -688,17 +688,17 @@ public class IvyPublishTest extends TestCase {
         publish.setPubdate("20060906141243");
         publish.setResolver("1");
         publish.setValidate(false);
-        File art = new File("build/test/publish/resolve-custom-1.2.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/resolve-custom-1.2.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
         publish.execute();
 
         // should have do the ivy delivering
-        assertTrue(new File("build/test/publish/ivy-1.2.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/publish/ivy-1.2.xml").exists());
 
-        File dest = new File("test/repositories/1/apache/resolve-custom/ivys/ivy-1.2.xml");
+        File dest = FileUtil.newFile("test/repositories/1/apache/resolve-custom/ivys/ivy-1.2.xml");
         // should have published the files with "1" resolver
         assertTrue(dest.exists());
-        assertTrue(new File("test/repositories/1/apache/resolve-custom/jars/resolve-custom-1.2.jar")
+        assertTrue(FileUtil.newFile("test/repositories/1/apache/resolve-custom/jars/resolve-custom-1.2.jar")
                 .exists());
 
         // should have updated published ivy version
@@ -729,22 +729,22 @@ public class IvyPublishTest extends TestCase {
         publish.setResolver("1");
         publish.setSrcivypattern("build/test/publish/ivy-1.3.xml");
 
-        FileUtil.copy(new File("test/java/org/apache/ivy/ant/ivy-publish.xml"), new File(
+        FileUtil.copy(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-publish.xml"), FileUtil.newFile(
                 "build/test/publish/ivy-1.3.xml"), null);
 
-        File art = new File("build/test/publish/resolve-latest-1.3.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/resolve-latest-1.3.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
         publish.execute();
 
         // should have published the files with "1" resolver
-        assertTrue(new File("test/repositories/1/apache/resolve-latest/ivys/ivy-1.3.xml").exists());
-        assertTrue(new File("test/repositories/1/apache/resolve-latest/jars/resolve-latest-1.3.jar")
+        assertTrue(FileUtil.newFile("test/repositories/1/apache/resolve-latest/ivys/ivy-1.3.xml").exists());
+        assertTrue(FileUtil.newFile("test/repositories/1/apache/resolve-latest/jars/resolve-latest-1.3.jar")
                 .exists());
 
         // the published ivy version should be ok (ok in ivy-publish file)
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(),
-            new File("test/repositories/1/apache/resolve-latest/ivys/ivy-1.3.xml").toURI().toURL(),
+            FileUtil.newFile("test/repositories/1/apache/resolve-latest/ivys/ivy-1.3.xml").toURI().toURL(),
             false);
         assertEquals("1.3", md.getModuleRevisionId().getRevision());
 
@@ -765,22 +765,22 @@ public class IvyPublishTest extends TestCase {
         publish.setResolver("1");
         publish.setSrcivypattern("build/test/publish/ivy-1.3.xml");
 
-        FileUtil.copy(new File("test/java/org/apache/ivy/ant/ivy-publish.xml"), new File(
+        FileUtil.copy(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-publish.xml"), FileUtil.newFile(
                 "build/test/publish/ivy-1.3.xml"), null);
 
-        File art = new File("build/test/publish/resolve-latest-1.3.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/resolve-latest-1.3.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
         publish.execute();
 
         // should have published the files with "1" resolver
-        assertTrue(new File("test/repositories/1/apache/resolve-latest/ivys/ivy-1.3.xml").exists());
-        assertTrue(new File("test/repositories/1/apache/resolve-latest/jars/resolve-latest-1.3.jar")
+        assertTrue(FileUtil.newFile("test/repositories/1/apache/resolve-latest/ivys/ivy-1.3.xml").exists());
+        assertTrue(FileUtil.newFile("test/repositories/1/apache/resolve-latest/jars/resolve-latest-1.3.jar")
                 .exists());
 
         // the published ivy version should be ok (ok in ivy-publish file)
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(),
-            new File("test/repositories/1/apache/resolve-latest/ivys/ivy-1.3.xml").toURI().toURL(),
+            FileUtil.newFile("test/repositories/1/apache/resolve-latest/ivys/ivy-1.3.xml").toURI().toURL(),
             false);
         assertEquals("BRANCH1", md.getModuleRevisionId().getBranch());
         assertEquals("1.3", md.getModuleRevisionId().getRevision());
@@ -801,22 +801,22 @@ public class IvyPublishTest extends TestCase {
         publish.setSrcivypattern("build/test/publish/ivy-1.3.xml");
         publish.setForcedeliver(true);
 
-        FileUtil.copy(new File("test/java/org/apache/ivy/ant/ivy-latest.xml"), new File(
+        FileUtil.copy(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-latest.xml"), FileUtil.newFile(
                 "build/test/publish/ivy-1.3.xml"), null);
 
-        File art = new File("build/test/publish/resolve-latest-1.3.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/resolve-latest-1.3.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
         publish.execute();
 
         // should have published the files with "1" resolver
-        assertTrue(new File("test/repositories/1/apache/resolve-latest/ivys/ivy-1.3.xml").exists());
-        assertTrue(new File("test/repositories/1/apache/resolve-latest/jars/resolve-latest-1.3.jar")
+        assertTrue(FileUtil.newFile("test/repositories/1/apache/resolve-latest/ivys/ivy-1.3.xml").exists());
+        assertTrue(FileUtil.newFile("test/repositories/1/apache/resolve-latest/jars/resolve-latest-1.3.jar")
                 .exists());
 
         // should have updated published ivy version
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(),
-            new File("test/repositories/1/apache/resolve-latest/ivys/ivy-1.3.xml").toURI().toURL(),
+            FileUtil.newFile("test/repositories/1/apache/resolve-latest/ivys/ivy-1.3.xml").toURI().toURL(),
             false);
         assertEquals("1.3", md.getModuleRevisionId().getRevision());
     }
@@ -831,11 +831,11 @@ public class IvyPublishTest extends TestCase {
         publish.setResolver("1");
         publish.setSrcivypattern("build/test/publish/ivy-1.3.xml");
 
-        FileUtil.copy(new File("test/java/org/apache/ivy/ant/ivy-latest.xml"), new File(
+        FileUtil.copy(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-latest.xml"), FileUtil.newFile(
                 "build/test/publish/ivy-1.3.xml"), null);
 
-        File art = new File("build/test/publish/resolve-latest-1.3.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/resolve-latest-1.3.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
         try {
             publish.execute();
             fail("shouldn't publish ivy file with bad revision");
@@ -852,8 +852,8 @@ public class IvyPublishTest extends TestCase {
 
         publish.setPubrevision("1.2");
         publish.setResolver("1");
-        File art = new File("build/test/publish/resolve-simple-1.2.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/resolve-simple-1.2.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
 
         Echo echo = new Echo();
         echo.setProject(project);
@@ -861,9 +861,9 @@ public class IvyPublishTest extends TestCase {
         echo.setFile(art);
         echo.execute();
 
-        File dest = new File(
+        File dest = FileUtil.newFile(
                 "test/repositories/1/apache/resolve-simple/jars/resolve-simple-1.2.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), dest, null);
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), dest, null);
 
         echo = new Echo();
         echo.setProject(project);
@@ -892,8 +892,8 @@ public class IvyPublishTest extends TestCase {
 
         publish.setPubrevision("1.2");
         publish.setResolver("1");
-        File art = new File("build/test/publish/resolve-simple-1.2.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/resolve-simple-1.2.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
 
         Echo echo = new Echo();
         echo.setProject(project);
@@ -901,9 +901,9 @@ public class IvyPublishTest extends TestCase {
         echo.setFile(art);
         echo.execute();
 
-        File dest = new File(
+        File dest = FileUtil.newFile(
                 "test/repositories/1/apache/resolve-simple/jars/resolve-simple-1.2.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), dest, null);
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), dest, null);
 
         echo = new Echo();
         echo.setProject(project);
@@ -927,8 +927,8 @@ public class IvyPublishTest extends TestCase {
 
         publish.setPubrevision("1.2");
         publish.setResolver("1");
-        File art = new File("build/test/publish/resolve-simple-1.2.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
+        File art = FileUtil.newFile("build/test/publish/resolve-simple-1.2.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
 
         Echo echo = new Echo();
         echo.setProject(project);
@@ -936,9 +936,9 @@ public class IvyPublishTest extends TestCase {
         echo.setFile(art);
         echo.execute();
 
-        File dest = new File(
+        File dest = FileUtil.newFile(
                 "test/repositories/1/apache/resolve-simple/jars/resolve-simple-1.2.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), dest, null);
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), dest, null);
 
         echo = new Echo();
         echo.setProject(project);

--- a/test/java/org/apache/ivy/ant/IvyReportTest.java
+++ b/test/java/org/apache/ivy/ant/IvyReportTest.java
@@ -72,12 +72,12 @@ public class IvyReportTest extends TestCase {
             res.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
             res.execute();
 
-            report.setTodir(new File(cache, "report"));
+            report.setTodir(FileUtil.newFile(cache, "report"));
             report.execute();
 
-            assertTrue(new File(cache, "report/apache-resolve-simple-default.html").exists());
-            assertTrue(new File(cache, "report/ivy-report.css").exists()); // IVY-826
-            assertTrue(new File(cache, "report/apache-resolve-simple-default.graphml").exists());
+            assertTrue(FileUtil.newFile(cache, "report/apache-resolve-simple-default.html").exists());
+            assertTrue(FileUtil.newFile(cache, "report/ivy-report.css").exists()); // IVY-826
+            assertTrue(FileUtil.newFile(cache, "report/apache-resolve-simple-default.graphml").exists());
         } finally {
             Locale.setDefault(oldLocale);
         }
@@ -95,11 +95,11 @@ public class IvyReportTest extends TestCase {
             res.setFile(new File("test/repositories/1/org6/mod6.2/ivys/ivy-0.7.xml"));
             res.execute();
 
-            report.setTodir(new File(cache, "report"));
+            report.setTodir(FileUtil.newFile(cache, "report"));
             report.setXml(true);
             report.execute();
 
-            File xmlReport = new File(cache, "report/org6-mod6.2-default.xml");
+            File xmlReport = FileUtil.newFile(cache, "report/org6-mod6.2-default.xml");
             assertTrue(xmlReport.exists());
             // check that revision 2.2 of mod1.2 is only present once
             String reportContent = FileUtil.readEntirely(xmlReport);
@@ -148,13 +148,13 @@ public class IvyReportTest extends TestCase {
             res.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
             res.execute();
 
-            report.setTodir(new File(cache, "report"));
+            report.setTodir(FileUtil.newFile(cache, "report"));
             report.setOutputpattern("[organisation]-[module]-[revision].[ext]");
             report.setConf("default");
             report.execute();
 
-            assertTrue(new File(cache, "report/apache-resolve-simple-1.0.html").exists());
-            assertTrue(new File(cache, "report/apache-resolve-simple-1.0.graphml").exists());
+            assertTrue(FileUtil.newFile(cache, "report/apache-resolve-simple-1.0.html").exists());
+            assertTrue(FileUtil.newFile(cache, "report/apache-resolve-simple-1.0.graphml").exists());
         } finally {
             Locale.setDefault(oldLocale);
         }
@@ -172,13 +172,13 @@ public class IvyReportTest extends TestCase {
             res.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
             res.execute();
 
-            report.setTodir(new File(cache, "report"));
+            report.setTodir(FileUtil.newFile(cache, "report"));
             report.execute();
 
-            assertTrue(new File(cache, "report/apache-resolve-simple-default.html").exists());
-            assertTrue(new File(cache, "report/apache-resolve-simple-default.graphml").exists());
-            assertTrue(new File(cache, "report/apache-resolve-simple-compile.html").exists());
-            assertTrue(new File(cache, "report/apache-resolve-simple-compile.graphml").exists());
+            assertTrue(FileUtil.newFile(cache, "report/apache-resolve-simple-default.html").exists());
+            assertTrue(FileUtil.newFile(cache, "report/apache-resolve-simple-default.graphml").exists());
+            assertTrue(FileUtil.newFile(cache, "report/apache-resolve-simple-compile.html").exists());
+            assertTrue(FileUtil.newFile(cache, "report/apache-resolve-simple-compile.graphml").exists());
         } finally {
             Locale.setDefault(oldLocale);
         }
@@ -196,13 +196,13 @@ public class IvyReportTest extends TestCase {
             res.setProject(project);
             res.execute();
 
-            report.setTodir(new File(cache, "report"));
+            report.setTodir(FileUtil.newFile(cache, "report"));
             report.setXml(true);
 
             report.execute();
 
-            assertTrue(new File(cache, "report/org11-mod11.1-compile.xml").exists());
-            assertTrue(new File(cache, "report/org11-mod11.1-compile.html").exists());
+            assertTrue(FileUtil.newFile(cache, "report/org11-mod11.1-compile.xml").exists());
+            assertTrue(FileUtil.newFile(cache, "report/org11-mod11.1-compile.html").exists());
         } finally {
             Locale.setDefault(oldLocale);
         }

--- a/test/java/org/apache/ivy/ant/IvyReportTest.java
+++ b/test/java/org/apache/ivy/ant/IvyReportTest.java
@@ -45,7 +45,7 @@ public class IvyReportTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -69,7 +69,7 @@ public class IvyReportTest extends TestCase {
 
             IvyResolve res = new IvyResolve();
             res.setProject(project);
-            res.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+            res.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
             res.execute();
 
             report.setTodir(FileUtil.newFile(cache, "report"));
@@ -92,7 +92,7 @@ public class IvyReportTest extends TestCase {
 
             IvyResolve res = new IvyResolve();
             res.setProject(project);
-            res.setFile(new File("test/repositories/1/org6/mod6.2/ivys/ivy-0.7.xml"));
+            res.setFile(FileUtil.newFile("test/repositories/1/org6/mod6.2/ivys/ivy-0.7.xml"));
             res.execute();
 
             report.setTodir(FileUtil.newFile(cache, "report"));
@@ -121,18 +121,18 @@ public class IvyReportTest extends TestCase {
 
             IvyResolve res = new IvyResolve();
             res.setProject(project);
-            res.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+            res.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
             res.execute();
 
             report.setGraph(false);
             report.execute();
 
-            assertTrue(new File("apache-resolve-simple-default.html").exists());
-            assertTrue(new File("ivy-report.css").exists()); // IVY-826
+            assertTrue(FileUtil.newFile("apache-resolve-simple-default.html").exists());
+            assertTrue(FileUtil.newFile("ivy-report.css").exists()); // IVY-826
         } finally {
             Locale.setDefault(oldLocale);
-            new File("apache-resolve-simple-default.html").delete();
-            new File("ivy-report.css").delete();
+            FileUtil.newFile("apache-resolve-simple-default.html").delete();
+            FileUtil.newFile("ivy-report.css").delete();
         }
     }
 
@@ -145,7 +145,7 @@ public class IvyReportTest extends TestCase {
 
             IvyResolve res = new IvyResolve();
             res.setProject(project);
-            res.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+            res.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
             res.execute();
 
             report.setTodir(FileUtil.newFile(cache, "report"));
@@ -169,7 +169,7 @@ public class IvyReportTest extends TestCase {
 
             IvyResolve res = new IvyResolve();
             res.setProject(project);
-            res.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
+            res.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
             res.execute();
 
             report.setTodir(FileUtil.newFile(cache, "report"));

--- a/test/java/org/apache/ivy/ant/IvyRepositoryReportTest.java
+++ b/test/java/org/apache/ivy/ant/IvyRepositoryReportTest.java
@@ -43,7 +43,7 @@ public class IvyRepositoryReportTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 

--- a/test/java/org/apache/ivy/ant/IvyRepositoryReportTest.java
+++ b/test/java/org/apache/ivy/ant/IvyRepositoryReportTest.java
@@ -64,7 +64,7 @@ public class IvyRepositoryReportTest extends TestCase {
         report.setTodir(cache);
         report.execute();
 
-        File reportFile = new File(cache, "testsimple.xml");
+        File reportFile = FileUtil.newFile(cache, "testsimple.xml");
         assertTrue(reportFile.exists());
         String g = FileUtil.readEntirely(new BufferedReader(new FileReader(reportFile)));
 
@@ -84,7 +84,7 @@ public class IvyRepositoryReportTest extends TestCase {
         report.setTodir(cache);
         report.execute();
 
-        File reportFile = new File(cache, "testbranch.xml");
+        File reportFile = FileUtil.newFile(cache, "testbranch.xml");
         assertTrue(reportFile.exists());
         String g = FileUtil.readEntirely(new BufferedReader(new FileReader(reportFile)));
 
@@ -103,7 +103,7 @@ public class IvyRepositoryReportTest extends TestCase {
         report.setTodir(cache);
         report.execute();
 
-        File reportFile = new File(cache, "test-no-org.xml");
+        File reportFile = FileUtil.newFile(cache, "test-no-org.xml");
         assertTrue(reportFile.exists());
         String g = FileUtil.readEntirely(new BufferedReader(new FileReader(reportFile)));
 

--- a/test/java/org/apache/ivy/ant/IvyRepositoryReportTest.java
+++ b/test/java/org/apache/ivy/ant/IvyRepositoryReportTest.java
@@ -66,7 +66,7 @@ public class IvyRepositoryReportTest extends TestCase {
 
         File reportFile = FileUtil.newFile(cache, "testsimple.xml");
         assertTrue(reportFile.exists());
-        String g = FileUtil.readEntirely(new BufferedReader(new FileReader(reportFile)));
+        String g = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(reportFile)));
 
         // check presence of the modules
         assertTrue(g.indexOf("<module organisation=\"org1\" name=\"mod1.1\"") != -1);
@@ -86,7 +86,7 @@ public class IvyRepositoryReportTest extends TestCase {
 
         File reportFile = FileUtil.newFile(cache, "testbranch.xml");
         assertTrue(reportFile.exists());
-        String g = FileUtil.readEntirely(new BufferedReader(new FileReader(reportFile)));
+        String g = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(reportFile)));
 
         // check presence of the modules
         assertTrue(g.indexOf("<module organisation=\"org1\" name=\"mod1.1\"") != -1);
@@ -105,7 +105,7 @@ public class IvyRepositoryReportTest extends TestCase {
 
         File reportFile = FileUtil.newFile(cache, "test-no-org.xml");
         assertTrue(reportFile.exists());
-        String g = FileUtil.readEntirely(new BufferedReader(new FileReader(reportFile)));
+        String g = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(reportFile)));
 
         // check presence of the modules
         assertTrue(g.indexOf("<module organisation=\"null\" name=\"a\"") != -1);

--- a/test/java/org/apache/ivy/ant/IvyResolveTest.java
+++ b/test/java/org/apache/ivy/ant/IvyResolveTest.java
@@ -48,7 +48,7 @@ public class IvyResolveTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -65,7 +65,7 @@ public class IvyResolveTest extends TestCase {
 
     public void testIVY1455() throws Exception {
         project.setProperty("ivy.settings.file", "test/repositories/IVY-1455/ivysettings.xml");
-        resolve.setFile(new File("test/repositories/IVY-1455/ivy.xml"));
+        resolve.setFile(FileUtil.newFile("test/repositories/IVY-1455/ivy.xml"));
         resolve.execute();
     }
 
@@ -74,7 +74,7 @@ public class IvyResolveTest extends TestCase {
         // run init in parent thread, then resolve in children
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings-with-nio.xml");
         project.setProperty("ivy.log.locking", "true");
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
 
         Parallel parallel = new Parallel();
         parallel.setThreadCount(4);
@@ -88,13 +88,13 @@ public class IvyResolveTest extends TestCase {
     public void testIVY779() throws Exception {
         Project project = new Project();
         project.setProperty("ivy.local.default.root",
-            new File("test/repositories/norev").getAbsolutePath());
+            FileUtil.newFile("test/repositories/norev").getAbsolutePath());
         project.setProperty("ivy.local.default.ivy.pattern", "[module]/[artifact].[ext]");
         project.setProperty("ivy.local.default.artifact.pattern", "[module]/[artifact].[ext]");
 
         resolve.setProject(project);
         project.setProperty("ivy.cache.dir", cache.getAbsolutePath());
-        resolve.setFile(new File("test/repositories/norev/ivy.xml"));
+        resolve.setFile(FileUtil.newFile("test/repositories/norev/ivy.xml"));
         resolve.setKeep(true);
         resolve.execute();
 
@@ -106,7 +106,7 @@ public class IvyResolveTest extends TestCase {
 
     public void testSimple() throws Exception {
         // depends on org="org1" name="mod1.2" rev="2.0"
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.execute();
 
         assertTrue(getResolvedIvyFileInCache(
@@ -123,7 +123,7 @@ public class IvyResolveTest extends TestCase {
         resolve.getProject().setProperty("ivy.settings.file",
             "test/repositories/IVY-630/ivysettings.xml");
 
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-630.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-630.xml"));
         resolve.setConf("default");
         resolve.setHaltonfailure(false);
         resolve.execute();
@@ -193,7 +193,7 @@ public class IvyResolveTest extends TestCase {
     }
 
     public void testWithSlashes() throws Exception {
-        resolve.setFile(new File("test/java/org/apache/ivy/core/resolve/ivy-198.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/core/resolve/ivy-198.xml"));
         resolve.execute();
 
         File resolvedIvyFileInCache = getResolvedIvyFileInCache(ModuleRevisionId.newInstance(
@@ -212,7 +212,7 @@ public class IvyResolveTest extends TestCase {
     }
 
     public void testDepsChanged() throws Exception {
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.execute();
 
         assertEquals("true", getIvy().getVariable("ivy.deps.changed"));
@@ -223,7 +223,7 @@ public class IvyResolveTest extends TestCase {
     }
 
     public void testDontCheckIfChanged() throws Exception {
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setCheckIfChanged(false);
         resolve.execute();
         assertNull(getIvy().getVariable("ivy.deps.changed"));
@@ -234,7 +234,7 @@ public class IvyResolveTest extends TestCase {
     }
 
     public void testConflictingDepsChanged() throws Exception {
-        resolve.setFile(new File("test/repositories/2/mod4.1/ivy-4.1.xml"));
+        resolve.setFile(FileUtil.newFile("test/repositories/2/mod4.1/ivy-4.1.xml"));
         resolve.execute();
 
         assertEquals("true", getIvy().getVariable("ivy.deps.changed"));
@@ -245,13 +245,13 @@ public class IvyResolveTest extends TestCase {
     }
 
     public void testDouble() throws Exception {
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.execute();
 
         assertEquals("resolve-simple", getIvy().getVariable("ivy.module"));
         assertEquals("1.0", getIvy().getVariable("ivy.revision"));
 
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-double.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-double.xml"));
         resolve.execute();
 
         assertEquals("resolve-double", getIvy().getVariable("ivy.module"));
@@ -260,7 +260,7 @@ public class IvyResolveTest extends TestCase {
 
     public void testFailure() throws Exception {
         try {
-            resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-failure.xml"));
+            resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-failure.xml"));
             resolve.execute();
             fail("failure didn't raised an exception with default haltonfailure setting");
         } catch (BuildException ex) {
@@ -270,7 +270,7 @@ public class IvyResolveTest extends TestCase {
 
     public void testIvyLogModulesInUseWithFailure() throws Exception {
         resolve.getProject().setProperty("ivy.log.modules.in.use", "true");
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-failure.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-failure.xml"));
         resolve.setHaltonfailure(false);
         resolve.execute();
 
@@ -279,7 +279,7 @@ public class IvyResolveTest extends TestCase {
 
     public void testFailureWithMissingConfigurations() throws Exception {
         try {
-            resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+            resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
             resolve.setConf("default,unknown");
             resolve.execute();
             fail("missing configurations didn't raised an exception");
@@ -290,7 +290,7 @@ public class IvyResolveTest extends TestCase {
 
     public void testFailureOnBadDependencyIvyFile() throws Exception {
         try {
-            resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-failure2.xml"));
+            resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-failure2.xml"));
             resolve.execute();
             fail("failure didn't raised an exception with default haltonfailure setting");
         } catch (BuildException ex) {
@@ -300,7 +300,7 @@ public class IvyResolveTest extends TestCase {
 
     public void testFailureOnBadStatusInDependencyIvyFile() throws Exception {
         try {
-            resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-failure3.xml"));
+            resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-failure3.xml"));
             resolve.execute();
             fail("failure didn't raised an exception with default haltonfailure setting");
         } catch (BuildException ex) {
@@ -310,7 +310,7 @@ public class IvyResolveTest extends TestCase {
 
     public void testHaltOnFailure() throws Exception {
         try {
-            resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-failure.xml"));
+            resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-failure.xml"));
             resolve.setHaltonfailure(false);
             resolve.execute();
         } catch (BuildException ex) {
@@ -320,7 +320,7 @@ public class IvyResolveTest extends TestCase {
     }
 
     public void testWithResolveId() throws Exception {
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setResolveId("testWithResolveId");
         resolve.execute();
 
@@ -358,13 +358,13 @@ public class IvyResolveTest extends TestCase {
     }
 
     public void testDoubleResolveWithResolveId() throws Exception {
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setResolveId("testWithResolveId");
         resolve.execute();
 
         IvyResolve newResolve = new IvyResolve();
         newResolve.setProject(resolve.getProject());
-        newResolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple2.xml"));
+        newResolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple2.xml"));
         newResolve.execute();
 
         // test the properties
@@ -391,13 +391,13 @@ public class IvyResolveTest extends TestCase {
     }
 
     public void testDifferentResolveWithSameResolveId() throws Exception {
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setResolveId("testWithResolveId");
         resolve.execute();
 
         IvyResolve newResolve = new IvyResolve();
         newResolve.setProject(resolve.getProject());
-        newResolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple2.xml"));
+        newResolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple2.xml"));
         newResolve.setResolveId("testWithResolveId");
         newResolve.execute();
 
@@ -425,7 +425,7 @@ public class IvyResolveTest extends TestCase {
     }
 
     public void testExcludedConf() throws Exception {
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
         resolve.setConf("*,!default");
         resolve.execute();
 
@@ -441,7 +441,7 @@ public class IvyResolveTest extends TestCase {
 
     public void testResolveWithAbsoluteFile() {
         // IVY-396
-        File ivyFile = new File("test/java/org/apache/ivy/ant/ivy-simple.xml");
+        File ivyFile = FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-simple.xml");
         resolve.getProject().setProperty("ivy.dep.file", ivyFile.getAbsolutePath());
         resolve.execute();
 
@@ -613,7 +613,7 @@ public class IvyResolveTest extends TestCase {
     }
 
     public void testSimpleExtends() throws Exception {
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-extends-multiconf.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-extends-multiconf.xml"));
         resolve.execute();
         assertEquals("1", resolve.getProject().getProperty("ivy.parents.count"));
         assertEquals("apache", resolve.getProject().getProperty("ivy.parent[0].organisation"));

--- a/test/java/org/apache/ivy/ant/IvyResolveTest.java
+++ b/test/java/org/apache/ivy/ant/IvyResolveTest.java
@@ -25,6 +25,7 @@ import org.apache.ivy.Ivy;
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.report.ResolveReport;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;

--- a/test/java/org/apache/ivy/ant/IvyResourcesTest.java
+++ b/test/java/org/apache/ivy/ant/IvyResourcesTest.java
@@ -26,6 +26,7 @@ import junit.framework.TestCase;
 
 import org.apache.ivy.Ivy;
 import org.apache.ivy.TestHelper;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DefaultLogger;
 import org.apache.tools.ant.Project;

--- a/test/java/org/apache/ivy/ant/IvyResourcesTest.java
+++ b/test/java/org/apache/ivy/ant/IvyResourcesTest.java
@@ -54,7 +54,7 @@ public class IvyResourcesTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 

--- a/test/java/org/apache/ivy/ant/IvyRetrieveTest.java
+++ b/test/java/org/apache/ivy/ant/IvyRetrieveTest.java
@@ -25,6 +25,7 @@ import junit.framework.TestCase;
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.IvyPatternHelper;
 import org.apache.ivy.util.CacheCleaner;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 
@@ -73,7 +74,7 @@ public class IvyRetrieveTest extends TestCase {
         retrieve.setConf("*");
         retrieve.execute();
         assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "1.1",
-            "mod1.2", "jar", "jar", "public")).exists());
+                "mod1.2", "jar", "jar", "public")).exists());
         assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org3", "mod3.2", "1.4",
             "mod3.2", "jar", "jar", "private")).exists());
     }

--- a/test/java/org/apache/ivy/ant/IvyRetrieveTest.java
+++ b/test/java/org/apache/ivy/ant/IvyRetrieveTest.java
@@ -64,7 +64,7 @@ public class IvyRetrieveTest extends TestCase {
     public void testSimple() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
         retrieve.execute();
-        assertTrue(new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.0",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.0",
             "mod1.2", "jar", "jar")).exists());
     }
 
@@ -72,9 +72,9 @@ public class IvyRetrieveTest extends TestCase {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-381.xml");
         retrieve.setConf("*");
         retrieve.execute();
-        assertTrue(new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "1.1",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "1.1",
             "mod1.2", "jar", "jar", "public")).exists());
-        assertTrue(new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org3", "mod3.2", "1.4",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org3", "mod3.2", "1.4",
             "mod3.2", "jar", "jar", "private")).exists());
     }
 
@@ -84,7 +84,7 @@ public class IvyRetrieveTest extends TestCase {
         retrieve.getSettings().setValidate(false);
         retrieve.execute();
 
-        assertTrue(new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.2",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.2",
             "mod1.2", "jar", "jar", "default")).exists());
     }
 
@@ -103,7 +103,7 @@ public class IvyRetrieveTest extends TestCase {
         retrieve.setRevision("2.0");
         retrieve.setInline(true);
         retrieve.execute();
-        assertTrue(new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.0",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.0",
             "mod1.2", "jar", "jar")).exists());
     }
 
@@ -111,11 +111,11 @@ public class IvyRetrieveTest extends TestCase {
         project.setProperty("ivy.dep.file", "test/repositories/1/org6/mod6.2/ivys/ivy-0.4.xml");
         retrieve.execute();
 
-        assertTrue(new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
             "mod6.1", "jar", "jar", "default")).exists());
-        assertTrue(new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
             "mod6.1", "jar", "jar", "extension")).exists());
-        assertTrue(new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.1",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.1",
             "mod1.2", "jar", "jar", "extension")).exists());
     }
 
@@ -124,13 +124,13 @@ public class IvyRetrieveTest extends TestCase {
         retrieve.setSync(true);
 
         File[] old = new File[] {
-                new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
+                FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
                     "mod6.1", "jar", "jar", "unknown")), // unknown configuration
-                new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
+                FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
                     "mod6.1", "unknown", "unknown", "default")), // unknown type
-                new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
+                FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
                     "unknown", "jar", "jar", "default")), // unknown artifact
-                new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "unknown",
+                FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "unknown",
                     "mod6.1", "jar", "jar", "default")), // unknown revision
         };
         for (int i = 0; i < old.length; i++) {
@@ -138,11 +138,11 @@ public class IvyRetrieveTest extends TestCase {
         }
         retrieve.execute();
 
-        assertTrue(new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
             "mod6.1", "jar", "jar", "default")).exists());
-        assertTrue(new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
             "mod6.1", "jar", "jar", "extension")).exists());
-        assertTrue(new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.1",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.1",
             "mod1.2", "jar", "jar", "extension")).exists());
         for (int i = 0; i < old.length; i++) {
             assertFalse(old[i] + " should have been deleted by sync", old[i].exists());
@@ -179,7 +179,7 @@ public class IvyRetrieveTest extends TestCase {
         retrieve.setConf("default");
         retrieve.execute();
 
-        assertTrue(new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.0",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.0",
             "mod1.2", "jar", "jar")).exists());
     }
 
@@ -200,7 +200,7 @@ public class IvyRetrieveTest extends TestCase {
         retrieve.setResolveId("testWithAPreviousResolveAndResolveId");
         retrieve.execute();
 
-        assertTrue(new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.0",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.0",
             "mod1.2", "jar", "jar")).exists());
     }
 
@@ -223,7 +223,7 @@ public class IvyRetrieveTest extends TestCase {
         retrieve.setUseOrigin(false);
         retrieve.execute();
 
-        assertTrue(new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.0",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.0",
             "mod1.2", "jar", "jar")).exists());
     }
 
@@ -238,13 +238,13 @@ public class IvyRetrieveTest extends TestCase {
         retrieve.setUseOrigin(true);
         retrieve.execute();
 
-        assertTrue(new File(IvyPatternHelper.substitute(ivyPattern, "org2", "mod2.3", "0.4.1",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(ivyPattern, "org2", "mod2.3", "0.4.1",
             "ivy", "ivy", "xml")).exists());
-        assertTrue(new File(IvyPatternHelper.substitute(ivyPattern, "org2", "mod2.1", "0.3", "ivy",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(ivyPattern, "org2", "mod2.1", "0.3", "ivy",
             "ivy", "xml")).exists());
-        assertTrue(new File(IvyPatternHelper.substitute(ivyPattern, "org1", "mod1.1", "1.0", "ivy",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(ivyPattern, "org1", "mod1.1", "1.0", "ivy",
             "ivy", "xml")).exists());
-        assertFalse(new File(IvyPatternHelper.substitute(ivyPattern, "org1", "mod1.2", "2.0",
+        assertFalse(FileUtil.newFile(IvyPatternHelper.substitute(ivyPattern, "org1", "mod1.2", "2.0",
             "ivy", "ivy", "xml")).exists());
     }
 
@@ -302,13 +302,13 @@ public class IvyRetrieveTest extends TestCase {
         retrieve.setIvypattern(ivyPattern);
         retrieve.execute();
 
-        assertTrue(new File(IvyPatternHelper.substitute(ivyPattern, "org2", "mod2.3", "0.4.1",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(ivyPattern, "org2", "mod2.3", "0.4.1",
             "ivy", "ivy", "xml")).exists());
-        assertTrue(new File(IvyPatternHelper.substitute(ivyPattern, "org2", "mod2.1", "0.3", "ivy",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(ivyPattern, "org2", "mod2.1", "0.3", "ivy",
             "ivy", "xml")).exists());
-        assertTrue(new File(IvyPatternHelper.substitute(ivyPattern, "org1", "mod1.1", "1.0", "ivy",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(ivyPattern, "org1", "mod1.1", "1.0", "ivy",
             "ivy", "xml")).exists());
-        assertFalse(new File(IvyPatternHelper.substitute(ivyPattern, "org1", "mod1.2", "2.0",
+        assertFalse(FileUtil.newFile(IvyPatternHelper.substitute(ivyPattern, "org1", "mod1.2", "2.0",
             "ivy", "ivy", "xml")).exists());
     }
 
@@ -320,11 +320,11 @@ public class IvyRetrieveTest extends TestCase {
         retrieve.setIvypattern(ivyPattern);
         retrieve.execute();
 
-        assertTrue(new File(IvyPatternHelper.substitute(ivyPattern, "org6", "mod6.1", "0.4", "ivy",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(ivyPattern, "org6", "mod6.1", "0.4", "ivy",
             "ivy", "xml", "default")).exists());
-        assertTrue(new File(IvyPatternHelper.substitute(ivyPattern, "org6", "mod6.1", "0.4", "ivy",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(ivyPattern, "org6", "mod6.1", "0.4", "ivy",
             "ivy", "xml", "extension")).exists());
-        assertFalse(new File(IvyPatternHelper.substitute(ivyPattern, "org1", "mod1.2", "2.1",
+        assertFalse(FileUtil.newFile(IvyPatternHelper.substitute(ivyPattern, "org1", "mod1.2", "2.1",
             "ivy", "ivy", "xml", "extension")).exists());
     }
 
@@ -338,13 +338,13 @@ public class IvyRetrieveTest extends TestCase {
         retrieve.setSync(true);
 
         File[] old = new File[] {
-                new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
+                FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
                     "mod6.1", "jar", "jar", "unknown")), // unknown configuration
-                new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
+                FileUtil.newFile(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "0.4",
                     "mod6.1", "unknown", "unknown", "default")), // unknown type
-                new File(IvyPatternHelper.substitute(ivyPattern, "org6", "mod6.1", "0.4", "ivy",
+                FileUtil.newFile(IvyPatternHelper.substitute(ivyPattern, "org6", "mod6.1", "0.4", "ivy",
                     "ivy", "xml", "unk")), // unknown conf for ivy
-                new File(IvyPatternHelper.substitute(ivyPattern, "unknown", "mod6.1", "0.4", "ivy",
+                FileUtil.newFile(IvyPatternHelper.substitute(ivyPattern, "unknown", "mod6.1", "0.4", "ivy",
                     "ivy", "xml", "default")), // unknown organisation for ivy
         };
         for (int i = 0; i < old.length; i++) {
@@ -353,11 +353,11 @@ public class IvyRetrieveTest extends TestCase {
 
         retrieve.execute();
 
-        assertTrue(new File(IvyPatternHelper.substitute(ivyPattern, "org6", "mod6.1", "0.4", "ivy",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(ivyPattern, "org6", "mod6.1", "0.4", "ivy",
             "ivy", "xml", "default")).exists());
-        assertTrue(new File(IvyPatternHelper.substitute(ivyPattern, "org6", "mod6.1", "0.4", "ivy",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(ivyPattern, "org6", "mod6.1", "0.4", "ivy",
             "ivy", "xml", "extension")).exists());
-        assertFalse(new File(IvyPatternHelper.substitute(ivyPattern, "org1", "mod1.2", "2.1",
+        assertFalse(FileUtil.newFile(IvyPatternHelper.substitute(ivyPattern, "org1", "mod1.2", "2.1",
             "ivy", "ivy", "xml", "extension")).exists());
         for (int i = 0; i < old.length; i++) {
             assertFalse(old[i] + " should have been deleted by sync", old[i].exists());

--- a/test/java/org/apache/ivy/ant/IvyRetrieveTest.java
+++ b/test/java/org/apache/ivy/ant/IvyRetrieveTest.java
@@ -42,7 +42,7 @@ public class IvyRetrieveTest extends TestCase {
 
     protected void setUp() throws Exception {
         createCache();
-        CacheCleaner.deleteDir(new File("build/test/lib"));
+        CacheCleaner.deleteDir(FileUtil.newFile("build/test/lib"));
         project = new Project();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
 
@@ -53,13 +53,13 @@ public class IvyRetrieveTest extends TestCase {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
     protected void tearDown() throws Exception {
         CacheCleaner.deleteDir(cache);
-        CacheCleaner.deleteDir(new File("build/test/lib"));
+        CacheCleaner.deleteDir(FileUtil.newFile("build/test/lib"));
     }
 
     public void testSimple() throws Exception {
@@ -93,7 +93,7 @@ public class IvyRetrieveTest extends TestCase {
         // we first resolve another ivy file
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
-        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-latest.xml"));
+        resolve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-latest.xml"));
         resolve.execute();
 
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.2", "mod1.2", "jar", "jar").exists());
@@ -148,7 +148,7 @@ public class IvyRetrieveTest extends TestCase {
         for (int i = 0; i < old.length; i++) {
             assertFalse(old[i] + " should have been deleted by sync", old[i].exists());
         }
-        assertFalse(new File("build/test/lib/unknown").exists()); // even conf directory should
+        assertFalse(FileUtil.newFile("build/test/lib/unknown").exists()); // even conf directory should
         // have been deleted
     }
 
@@ -156,13 +156,13 @@ public class IvyRetrieveTest extends TestCase {
         project.setProperty("ivy.dep.file", "test/repositories/1/org6/mod6.2/ivys/ivy-0.4.xml");
         retrieve.setSync(true);
 
-        new File("build/test/lib/.svn").mkdirs();
-        new File("build/test/lib/.svn/test.txt").createNewFile();
-        assertTrue(new File("build/test/lib/.svn/test.txt").exists());
+        FileUtil.newFile("build/test/lib/.svn").mkdirs();
+        FileUtil.newFile("build/test/lib/.svn/test.txt").createNewFile();
+        assertTrue(FileUtil.newFile("build/test/lib/.svn/test.txt").exists());
 
         retrieve.execute();
 
-        assertTrue(new File("build/test/lib/.svn/test.txt").exists());
+        assertTrue(FileUtil.newFile("build/test/lib/.svn/test.txt").exists());
     }
 
     public void testWithAPreviousResolve() throws Exception {
@@ -250,13 +250,13 @@ public class IvyRetrieveTest extends TestCase {
     }
 
     public void testRetrieveWithOriginalNamePattern() throws Exception {
-        retrieve.setFile(new File("test/java/org/apache/ivy/ant/ivy-631.xml"));
+        retrieve.setFile(FileUtil.newFile("test/java/org/apache/ivy/ant/ivy-631.xml"));
         retrieve.setConf("default");
         retrieve.setPattern("build/test/lib/[conf]/[originalname].[ext]");
         retrieve.setSync(true);
         retrieve.execute();
 
-        assertTrue(new File("build/test/lib/default/mod1.2-2.2.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/lib/default/mod1.2-2.2.jar").exists());
     }
 
     public void testFailureWithoutAPreviousResolve() throws Exception {
@@ -363,9 +363,9 @@ public class IvyRetrieveTest extends TestCase {
         for (int i = 0; i < old.length; i++) {
             assertFalse(old[i] + " should have been deleted by sync", old[i].exists());
         }
-        assertFalse(new File("build/test/lib/unknown").exists());
-        assertFalse(new File("build/test/lib/unk").exists());
-        assertFalse(new File("build/test/lib/default/unknown").exists());
+        assertFalse(FileUtil.newFile("build/test/lib/unknown").exists());
+        assertFalse(FileUtil.newFile("build/test/lib/unk").exists());
+        assertFalse(FileUtil.newFile("build/test/lib/default/unknown").exists());
     }
 
     public void testDoubleRetrieveWithDifferentConfigurations() {

--- a/test/java/org/apache/ivy/ant/IvyTaskTest.java
+++ b/test/java/org/apache/ivy/ant/IvyTaskTest.java
@@ -49,7 +49,7 @@ public class IvyTaskTest extends TestCase {
             settings.getDefaultCache());
         // The next test doesn't always works on windows (mix C: and c: drive)
         assertEquals(new File("test/repositories/ivysettings.xml").getAbsolutePath().toUpperCase(),
-            new File(settings.getVariables().getVariable("ivy.settings.file")).getAbsolutePath()
+            FileUtil.newFile(settings.getVariables().getVariable("ivy.settings.file")).getAbsolutePath()
                     .toUpperCase());
         assertEquals(new File("test/repositories/ivysettings.xml").toURI().toURL().toExternalForm()
                 .toUpperCase(), settings.getVariables().getVariable("ivy.settings.url")

--- a/test/java/org/apache/ivy/ant/IvyTaskTest.java
+++ b/test/java/org/apache/ivy/ant/IvyTaskTest.java
@@ -24,6 +24,7 @@ import junit.framework.TestCase;
 
 import org.apache.ivy.Ivy;
 import org.apache.ivy.core.settings.IvySettings;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.Reference;

--- a/test/java/org/apache/ivy/ant/IvyTaskTest.java
+++ b/test/java/org/apache/ivy/ant/IvyTaskTest.java
@@ -46,16 +46,16 @@ public class IvyTaskTest extends TestCase {
         IvySettings settings = ivy.getSettings();
         assertNotNull(settings);
 
-        assertEquals(new File("test/repositories/build/cache").getAbsoluteFile(),
+        assertEquals(FileUtil.newFile("test/repositories/build/cache").getAbsoluteFile(),
             settings.getDefaultCache());
         // The next test doesn't always works on windows (mix C: and c: drive)
-        assertEquals(new File("test/repositories/ivysettings.xml").getAbsolutePath().toUpperCase(),
+        assertEquals(FileUtil.newFile("test/repositories/ivysettings.xml").getAbsolutePath().toUpperCase(),
             FileUtil.newFile(settings.getVariables().getVariable("ivy.settings.file")).getAbsolutePath()
                     .toUpperCase());
-        assertEquals(new File("test/repositories/ivysettings.xml").toURI().toURL().toExternalForm()
+        assertEquals(FileUtil.newFile("test/repositories/ivysettings.xml").toURI().toURL().toExternalForm()
                 .toUpperCase(), settings.getVariables().getVariable("ivy.settings.url")
                 .toUpperCase());
-        assertEquals(new File("test/repositories").getAbsolutePath().toUpperCase(), settings
+        assertEquals(FileUtil.newFile("test/repositories").getAbsolutePath().toUpperCase(), settings
                 .getVariables().getVariable("ivy.settings.dir").toUpperCase());
         assertEquals("myvalue", settings.getVariables().getVariable("myproperty"));
     }
@@ -67,7 +67,7 @@ public class IvyTaskTest extends TestCase {
         IvyAntSettings antSettings = new IvyAntSettings();
         antSettings.setProject(p);
         // antSettings.setId("mySettings");
-        antSettings.setFile(new File("test/repositories/ivysettings.xml"));
+        antSettings.setFile(FileUtil.newFile("test/repositories/ivysettings.xml"));
         p.addReference("mySettings", antSettings);
 
         IvyTask task = new IvyTask() {
@@ -81,13 +81,13 @@ public class IvyTaskTest extends TestCase {
         IvySettings settings = ivy.getSettings();
         assertNotNull(settings);
 
-        assertEquals(new File("build/cache").getAbsoluteFile(), settings.getDefaultCache());
-        assertEquals(new File("test/repositories/ivysettings.xml").getAbsolutePath(), settings
+        assertEquals(FileUtil.newFile("build/cache").getAbsoluteFile(), settings.getDefaultCache());
+        assertEquals(FileUtil.newFile("test/repositories/ivysettings.xml").getAbsolutePath(), settings
                 .getVariables().getVariable("ivy.settings.file"));
         assertEquals(
-            new File("test/repositories/ivysettings.xml").toURI().toURL().toExternalForm(),
+            FileUtil.newFile("test/repositories/ivysettings.xml").toURI().toURL().toExternalForm(),
             settings.getVariables().getVariable("ivy.settings.url"));
-        assertEquals(new File("test/repositories").getAbsolutePath(), settings.getVariables()
+        assertEquals(FileUtil.newFile("test/repositories").getAbsolutePath(), settings.getVariables()
                 .getVariable("ivy.settings.dir"));
         assertEquals("myvalue", settings.getVariables().getVariable("myproperty"));
     }

--- a/test/java/org/apache/ivy/core/NormalRelativeUrlResolverTest.java
+++ b/test/java/org/apache/ivy/core/NormalRelativeUrlResolverTest.java
@@ -44,7 +44,7 @@ public class NormalRelativeUrlResolverTest extends TestCase {
 
     public void testFileAndUrlWithAbsoluteFile() throws MalformedURLException {
         URL base = new URL("file://xxx/file.txt");
-        File absFile = new File(".").getAbsoluteFile();
+        File absFile = FileUtil.newFile(".").getAbsoluteFile();
         assertEquals(absFile.toURI().toURL(), t.getURL(base, absFile.toString(), null));
         assertEquals(absFile.toURI().toURL(), t.getURL(base, absFile.toString(), ""));
         assertEquals(absFile.toURI().toURL(), t.getURL(base, absFile.toString(), "somthing.txt"));

--- a/test/java/org/apache/ivy/core/NormalRelativeUrlResolverTest.java
+++ b/test/java/org/apache/ivy/core/NormalRelativeUrlResolverTest.java
@@ -22,6 +22,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import junit.framework.TestCase;
+import org.apache.ivy.util.FileUtil;
 
 public class NormalRelativeUrlResolverTest extends TestCase {
 

--- a/test/java/org/apache/ivy/core/TestPerformance.java
+++ b/test/java/org/apache/ivy/core/TestPerformance.java
@@ -62,7 +62,7 @@ public class TestPerformance {
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -80,7 +80,7 @@ public class TestPerformance {
     private void cleanRepo() {
         Delete del = new Delete();
         del.setProject(new Project());
-        del.setDir(new File("build/test/perf"));
+        del.setDir(FileUtil.newFile("build/test/perf"));
         del.execute();
     }
 
@@ -122,10 +122,10 @@ public class TestPerformance {
                     dd.addDependencyConfiguration("default", "default");
                     md.addDependency(dd);
                 }
-                XmlModuleDescriptorWriter.write(md, new File("build/test/perf/mod" + nb + "/ivy-1."
+                XmlModuleDescriptorWriter.write(md, FileUtil.newFile("build/test/perf/mod" + nb + "/ivy-1."
                         + ver + ".xml"));
-                FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"),
-                    new File("build/test/perf/mod" + nb + "/mod" + nb + "-1." + ver + ".jar"), null);
+                FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"),
+                    FileUtil.newFile("build/test/perf/mod" + nb + "/mod" + nb + "-1." + ver + ".jar"), null);
             }
             nb++;
         }
@@ -135,7 +135,7 @@ public class TestPerformance {
         generateModules(70, 2, 5, 2, 15);
 
         long start = System.currentTimeMillis();
-        ResolveReport report = ivy.resolve(new File("build/test/perf/mod0/ivy-1.0.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("build/test/perf/mod0/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}).setRevision("1.0"));
         long end = System.currentTimeMillis();
         System.out.println("resolve " + report.getConfigurationReport("default").getNodesNumber()

--- a/test/java/org/apache/ivy/core/cache/ModuleDescriptorMemoryCacheTest.java
+++ b/test/java/org/apache/ivy/core/cache/ModuleDescriptorMemoryCacheTest.java
@@ -29,6 +29,7 @@ import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.parser.ParserSettings;
+import org.apache.ivy.util.FileUtil;
 
 public class ModuleDescriptorMemoryCacheTest extends TestCase {
 

--- a/test/java/org/apache/ivy/core/cache/ModuleDescriptorMemoryCacheTest.java
+++ b/test/java/org/apache/ivy/core/cache/ModuleDescriptorMemoryCacheTest.java
@@ -38,11 +38,11 @@ public class ModuleDescriptorMemoryCacheTest extends TestCase {
 
     IvySettings ivySettings2 = new IvySettings();
 
-    File url1 = new File("file://cached/file.txt");;
+    File url1 = FileUtil.newFile("file://cached/file.txt");;
 
-    File url2 = new File("file://cached/file2.txt");;
+    File url2 = FileUtil.newFile("file://cached/file2.txt");;
 
-    File url3 = new File("file://cached/file3.txt");;
+    File url3 = FileUtil.newFile("file://cached/file3.txt");;
 
     ModuleRevisionId mrid1 = ModuleRevisionId.newInstance("org", "name", "rev");
 

--- a/test/java/org/apache/ivy/core/deliver/DeliverTest.java
+++ b/test/java/org/apache/ivy/core/deliver/DeliverTest.java
@@ -38,11 +38,11 @@ public class DeliverTest extends TestCase {
     private IvyDeliver ivyDeliver;
 
     protected void setUp() throws Exception {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         System.setProperty("ivy.cache.dir", cache.getAbsolutePath());
         createCache();
 
-        deliverDir = new File("build/test/deliver");
+        deliverDir = FileUtil.newFile("build/test/deliver");
         deliverDir.mkdirs();
 
         Project project = new Project();

--- a/test/java/org/apache/ivy/core/deliver/DeliverTest.java
+++ b/test/java/org/apache/ivy/core/deliver/DeliverTest.java
@@ -66,7 +66,7 @@ public class DeliverTest extends TestCase {
     public void testIVY1111() throws Exception {
         Project project = ivyDeliver.getProject();
         project.setProperty("ivy.settings.file", "test/repositories/IVY-1111/ivysettings.xml");
-        File ivyFile = new File(new URI(DeliverTest.class.getResource("ivy-1111.xml").toString()));
+        File ivyFile = FileUtil.newFile(new URI(DeliverTest.class.getResource("ivy-1111.xml").toString()));
 
         resolve(ivyFile);
 
@@ -88,7 +88,7 @@ public class DeliverTest extends TestCase {
     private String readFile(String fileName) throws IOException {
         StringBuffer retval = new StringBuffer();
 
-        File ivyFile = new File(fileName);
+        File ivyFile = FileUtil.newFile(fileName);
         BufferedReader reader = new BufferedReader(new FileReader(ivyFile));
 
         String line = null;

--- a/test/java/org/apache/ivy/core/deliver/DeliverTest.java
+++ b/test/java/org/apache/ivy/core/deliver/DeliverTest.java
@@ -89,7 +89,7 @@ public class DeliverTest extends TestCase {
         StringBuffer retval = new StringBuffer();
 
         File ivyFile = FileUtil.newFile(fileName);
-        BufferedReader reader = new BufferedReader(new FileReader(ivyFile));
+        BufferedReader reader = new BufferedReader(FileUtil.newReader(ivyFile));
 
         String line = null;
         while ((line = reader.readLine()) != null) {

--- a/test/java/org/apache/ivy/core/install/InstallTest.java
+++ b/test/java/org/apache/ivy/core/install/InstallTest.java
@@ -25,6 +25,7 @@ import org.apache.ivy.Ivy;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.report.ResolveReport;
 import org.apache.ivy.plugins.matcher.PatternMatcher;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
 

--- a/test/java/org/apache/ivy/core/install/InstallTest.java
+++ b/test/java/org/apache/ivy/core/install/InstallTest.java
@@ -32,156 +32,156 @@ public class InstallTest extends TestCase {
 
     public void testSimple() throws Exception {
         Ivy ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
 
         ivy.install(ModuleRevisionId.newInstance("org1", "mod1.2", "2.0"), ivy.getSettings()
                 .getDefaultResolver().getName(), "install", new InstallOptions());
 
-        assertTrue(new File("build/test/install/org1/mod1.2/ivy-2.0.xml").exists());
-        assertTrue(new File("build/test/install/org1/mod1.2/mod1.2-2.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.2/ivy-2.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.2/mod1.2-2.0.jar").exists());
     }
 
     public void testValidate() throws Exception {
         Ivy ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
 
         ivy.install(ModuleRevisionId.newInstance("orgfailure", "modfailure", "1.0"), ivy
                 .getSettings().getDefaultResolver().getName(), "install", new InstallOptions());
 
-        assertFalse(new File("build/test/install/orgfailure/modfailure/ivy-1.0.xml").exists());
-        assertFalse(new File("build/test/install/orgfailure/modfailure/modfailure-1.0.jar")
+        assertFalse(FileUtil.newFile("build/test/install/orgfailure/modfailure/ivy-1.0.xml").exists());
+        assertFalse(FileUtil.newFile("build/test/install/orgfailure/modfailure/modfailure-1.0.jar")
                 .exists());
     }
 
     public void testMaven() throws Exception {
         Ivy ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
 
         ResolveReport rr = ivy.install(ModuleRevisionId.newInstance("org.apache", "test", "1.0"),
             ivy.getSettings().getDefaultResolver().getName(), "install", new InstallOptions());
 
-        assertTrue(new File("build/test/install/org.apache/test/ivy-1.0.xml").exists());
-        assertTrue(new File("build/test/install/org.apache/test/test-1.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org.apache/test/ivy-1.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org.apache/test/test-1.0.jar").exists());
 
         // the original descriptor is not installed
-        assertFalse(new File("build/test/install/org.apache/test/test-1.0.pom").exists());
+        assertFalse(FileUtil.newFile("build/test/install/org.apache/test/test-1.0.pom").exists());
 
         ivy.install(ModuleRevisionId.newInstance("org.apache", "test", "1.0"), ivy.getSettings()
                 .getDefaultResolver().getName(), "install", new InstallOptions()
                 .setInstallOriginalMetadata(true).setOverwrite(true));
 
         // the original descriptor is installed now, too
-        assertTrue(new File("build/test/install/org.apache/test/test-1.0.pom").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org.apache/test/test-1.0.pom").exists());
     }
 
     public void testNoValidate() throws Exception {
         Ivy ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
 
         ivy.install(ModuleRevisionId.newInstance("orgfailure", "modfailure", "1.0"), ivy
                 .getSettings().getDefaultResolver().getName(), "install",
             new InstallOptions().setValidate(false));
 
-        assertTrue(new File("build/test/install/orgfailure/modfailure/ivy-1.0.xml").exists());
-        assertTrue(new File("build/test/install/orgfailure/modfailure/modfailure-1.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/orgfailure/modfailure/ivy-1.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/orgfailure/modfailure/modfailure-1.0.jar").exists());
     }
 
     public void testSimpleWithoutDefaultResolver() throws Exception {
         Ivy ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/ivysettings-nodefaultresolver.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings-nodefaultresolver.xml"));
 
         ivy.install(ModuleRevisionId.newInstance("org1", "mod1.2", "2.0"), "test", "install",
             new InstallOptions());
 
-        assertTrue(new File("build/test/install/org1/mod1.2/ivy-2.0.xml").exists());
-        assertTrue(new File("build/test/install/org1/mod1.2/mod1.2-2.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.2/ivy-2.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.2/mod1.2-2.0.jar").exists());
     }
 
     public void testDependencies() throws Exception {
         Ivy ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
 
         ivy.install(ModuleRevisionId.newInstance("org1", "mod1.1", "1.0"), ivy.getSettings()
                 .getDefaultResolver().getName(), "install", new InstallOptions());
 
-        assertTrue(new File("build/test/install/org1/mod1.1/ivy-1.0.xml").exists());
-        assertTrue(new File("build/test/install/org1/mod1.1/mod1.1-1.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.1/ivy-1.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.1/mod1.1-1.0.jar").exists());
 
-        assertTrue(new File("build/test/install/org1/mod1.2/ivy-2.0.xml").exists());
-        assertTrue(new File("build/test/install/org1/mod1.2/mod1.2-2.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.2/ivy-2.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.2/mod1.2-2.0.jar").exists());
     }
 
     public void testLatestDependenciesNoDefaultResolver() throws Exception {
         Ivy ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/ivysettings-nodefaultresolver.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings-nodefaultresolver.xml"));
 
         ivy.install(ModuleRevisionId.newInstance("org1", "mod1.4", "1.0.1"), "test", "install",
             new InstallOptions());
 
-        assertTrue(new File("build/test/install/org1/mod1.4/ivy-1.0.1.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.4/ivy-1.0.1.xml").exists());
 
-        assertTrue(new File("build/test/install/org1/mod1.1/ivy-2.0.xml").exists());
-        assertTrue(new File("build/test/install/org1/mod1.1/mod1.1-2.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.1/ivy-2.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.1/mod1.1-2.0.jar").exists());
 
-        assertTrue(new File("build/test/install/org1/mod1.2/ivy-2.2.xml").exists());
-        assertTrue(new File("build/test/install/org1/mod1.2/mod1.2-2.2.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.2/ivy-2.2.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.2/mod1.2-2.2.jar").exists());
     }
 
     public void testLatestDependenciesDummyDefaultResolver() throws Exception {
         Ivy ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/ivysettings-dummydefaultresolver.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings-dummydefaultresolver.xml"));
 
         ivy.install(ModuleRevisionId.newInstance("org1", "mod1.4", "1.0.1"), "test", "install",
             new InstallOptions());
 
-        assertTrue(new File("build/test/install/org1/mod1.4/ivy-1.0.1.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.4/ivy-1.0.1.xml").exists());
 
-        assertTrue(new File("build/test/install/org1/mod1.1/ivy-2.0.xml").exists());
-        assertTrue(new File("build/test/install/org1/mod1.1/mod1.1-2.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.1/ivy-2.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.1/mod1.1-2.0.jar").exists());
 
-        assertTrue(new File("build/test/install/org1/mod1.2/ivy-2.2.xml").exists());
-        assertTrue(new File("build/test/install/org1/mod1.2/mod1.2-2.2.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.2/ivy-2.2.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.2/mod1.2-2.2.jar").exists());
     }
 
     public void testNotTransitive() throws Exception {
         Ivy ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
 
         ivy.install(ModuleRevisionId.newInstance("org1", "mod1.1", "1.0"), ivy.getSettings()
                 .getDefaultResolver().getName(), "install",
             new InstallOptions().setTransitive(false));
 
-        assertTrue(new File("build/test/install/org1/mod1.1/ivy-1.0.xml").exists());
-        assertTrue(new File("build/test/install/org1/mod1.1/mod1.1-1.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.1/ivy-1.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.1/mod1.1-1.0.jar").exists());
 
-        assertFalse(new File("build/test/install/org1/mod1.2/ivy-2.0.xml").exists());
-        assertFalse(new File("build/test/install/org1/mod1.2/mod1.2-2.0.jar").exists());
+        assertFalse(FileUtil.newFile("build/test/install/org1/mod1.2/ivy-2.0.xml").exists());
+        assertFalse(FileUtil.newFile("build/test/install/org1/mod1.2/mod1.2-2.0.jar").exists());
     }
 
     public void testRegexpMatcher() throws Exception {
         Ivy ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
 
         ivy.install(ModuleRevisionId.newInstance("org1", ".*", ".*"), "1", "install",
             new InstallOptions().setMatcherName(PatternMatcher.REGEXP).setOverwrite(true));
 
-        assertTrue(new File("build/test/install/org1/mod1.1/ivy-1.0.xml").exists());
-        assertTrue(new File("build/test/install/org1/mod1.1/mod1.1-1.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.1/ivy-1.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.1/mod1.1-1.0.jar").exists());
 
-        assertTrue(new File("build/test/install/org1/mod1.1/ivy-1.1.xml").exists());
-        assertTrue(new File("build/test/install/org1/mod1.1/mod1.1-1.1.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.1/ivy-1.1.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.1/mod1.1-1.1.jar").exists());
 
-        assertTrue(new File("build/test/install/org1/mod1.2/ivy-2.0.xml").exists());
-        assertTrue(new File("build/test/install/org1/mod1.2/mod1.2-2.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.2/ivy-2.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.2/mod1.2-2.0.jar").exists());
 
         // mod1.3 is split because Ivy thinks there are two versions of the module:
         // this is the normal behaviour in this case
-        assertTrue(new File("build/test/install/org1/mod1.3/ivy-B-3.0.xml").exists());
-        assertTrue(new File("build/test/install/org1/mod1.3/ivy-A-3.0.xml").exists());
-        assertTrue(new File("build/test/install/org1/mod1.3/mod1.3-A-3.0.jar").exists());
-        assertTrue(new File("build/test/install/org1/mod1.3/mod1.3-B-3.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.3/ivy-B-3.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.3/ivy-A-3.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.3/mod1.3-A-3.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.3/mod1.3-B-3.0.jar").exists());
 
-        assertTrue(new File("build/test/install/org1/mod1.4/ivy-1.0.1.xml").exists());
+        assertTrue(FileUtil.newFile("build/test/install/org1/mod1.4/ivy-1.0.1.xml").exists());
     }
 
     private File _cache;
@@ -191,7 +191,7 @@ public class InstallTest extends TestCase {
     }
 
     private void createCache() {
-        _cache = new File("build/cache");
+        _cache = FileUtil.newFile("build/cache");
         _cache.mkdirs();
     }
 
@@ -210,7 +210,7 @@ public class InstallTest extends TestCase {
     private void cleanInstall() {
         Delete del = new Delete();
         del.setProject(new Project());
-        del.setDir(new File("build/test/install"));
+        del.setDir(FileUtil.newFile("build/test/install"));
         del.execute();
     }
 }

--- a/test/java/org/apache/ivy/core/publish/PublishEngineTest.java
+++ b/test/java/org/apache/ivy/core/publish/PublishEngineTest.java
@@ -41,12 +41,12 @@ import org.apache.ivy.util.FileUtil;
 
 public class PublishEngineTest extends TestCase {
     protected void setUp() throws Exception {
-        System.setProperty("ivy.cache.dir", new File("build/test/publish/cache").getAbsolutePath());
-        FileUtil.forceDelete(new File("build/test/publish"));
+        System.setProperty("ivy.cache.dir", FileUtil.newFile("build/test/publish/cache").getAbsolutePath());
+        FileUtil.forceDelete(FileUtil.newFile("build/test/publish"));
     }
 
     protected void tearDown() throws Exception {
-        FileUtil.forceDelete(new File("build/test/publish"));
+        FileUtil.forceDelete(FileUtil.newFile("build/test/publish"));
     }
 
     public void testAtomicity() throws Exception {
@@ -70,13 +70,13 @@ public class PublishEngineTest extends TestCase {
         };
         resolver.setName("test");
         resolver.setSettings(settings);
-        String publishRepoDir = new File("build/test/publish/repo").getAbsolutePath();
+        String publishRepoDir = FileUtil.newFile("build/test/publish/repo").getAbsolutePath();
         resolver.addIvyPattern(publishRepoDir + "/[module]/[revision]/[artifact].[ext]");
         resolver.addArtifactPattern(publishRepoDir + "/[module]/[revision]/[artifact].[ext]");
 
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), new File(
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), FileUtil.newFile(
                 "build/test/publish/module/A.jar"), null);
-        XmlModuleDescriptorWriter.write(md, new File("build/test/publish/module/ivy.xml"));
+        XmlModuleDescriptorWriter.write(md, FileUtil.newFile("build/test/publish/module/ivy.xml"));
 
         resolveAndAssertNotFound(settings, resolver, "#A;latest.integration", "before publishing");
 

--- a/test/java/org/apache/ivy/core/publish/PublishEventsTest.java
+++ b/test/java/org/apache/ivy/core/publish/PublishEventsTest.java
@@ -102,7 +102,7 @@ public class PublishEventsTest extends TestCase {
         // we don't really care whether the file actually gets published. we just want to make sure
         // that the engine calls the correct methods in the correct order, and fires required
         // events.
-        ivyFile = new File("test/java/org/apache/ivy/core/publish/ivy-1.0-dev.xml");
+        ivyFile = FileUtil.newFile("test/java/org/apache/ivy/core/publish/ivy-1.0-dev.xml");
         assertTrue("path to ivy file not found in test environment", ivyFile.exists());
         // the contents of the data file don't matter.
         dataFile = File.createTempFile("ivydata", ".jar");

--- a/test/java/org/apache/ivy/core/publish/PublishEventsTest.java
+++ b/test/java/org/apache/ivy/core/publish/PublishEventsTest.java
@@ -39,6 +39,7 @@ import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
 import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorParser;
 import org.apache.ivy.plugins.resolver.MockResolver;
 import org.apache.ivy.plugins.trigger.AbstractTrigger;
+import org.apache.ivy.util.FileUtil;
 
 public class PublishEventsTest extends TestCase {
 

--- a/test/java/org/apache/ivy/core/publish/PublishEventsTest.java
+++ b/test/java/org/apache/ivy/core/publish/PublishEventsTest.java
@@ -353,7 +353,7 @@ public class PublishEventsTest extends TestCase {
                 // filesystem
                 String filePath = event.getAttributes().get("file").toString();
                 assertEquals("event declares correct value for file",
-                    expectedData.getCanonicalPath(), new File(filePath).getCanonicalPath());
+                    expectedData.getCanonicalPath(), FileUtil.newFile(filePath).getCanonicalPath());
             } catch (IOException ioe) {
                 throw new RuntimeException(ioe);
             }

--- a/test/java/org/apache/ivy/core/report/ResolveReportTest.java
+++ b/test/java/org/apache/ivy/core/report/ResolveReportTest.java
@@ -44,18 +44,18 @@ public class ResolveReportTest extends TestCase {
     private File workDir;
 
     protected void setUp() throws Exception {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         System.setProperty("ivy.cache.dir", cache.getAbsolutePath());
         createCache();
 
-        deliverDir = new File("build/test/deliver");
+        deliverDir = FileUtil.newFile("build/test/deliver");
         deliverDir.mkdirs();
 
-        workDir = new File("build/test/work");
+        workDir = FileUtil.newFile("build/test/work");
         workDir.mkdirs();
 
         ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
     }
 
     private void createCache() {
@@ -85,7 +85,7 @@ public class ResolveReportTest extends TestCase {
     }
 
     public void testFixedMdSimple() throws Exception {
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -105,7 +105,7 @@ public class ResolveReportTest extends TestCase {
 
     public void testFixedMdTransitiveDependencies() throws Exception {
         // mod2.1 depends on mod1.1 which depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.1/ivys/ivy-0.3.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -133,7 +133,7 @@ public class ResolveReportTest extends TestCase {
         // mod6.1 has two confs default and extension
         // mod6.1 depends on mod1.2 2.0 in conf (default->default)
         // conf extension extends default
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org6/mod6.2/ivys/ivy-0.3.xml"),
             getResolveOptions(new String[] {"default", "extension"}));
         assertNotNull(report);
@@ -159,7 +159,7 @@ public class ResolveReportTest extends TestCase {
     }
 
     public void testFixedMdRange() throws Exception {
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -188,7 +188,7 @@ public class ResolveReportTest extends TestCase {
     }
 
     public void testFixedMdKeep() throws Exception {
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);

--- a/test/java/org/apache/ivy/core/resolve/ResolveEngineTest.java
+++ b/test/java/org/apache/ivy/core/resolve/ResolveEngineTest.java
@@ -31,6 +31,7 @@ import org.apache.ivy.core.report.ArtifactDownloadReport;
 import org.apache.ivy.core.report.DownloadStatus;
 import org.apache.ivy.core.report.ResolveReport;
 import org.apache.ivy.util.CacheCleaner;
+import org.apache.ivy.util.FileUtil;
 
 public class ResolveEngineTest extends TestCase {
 

--- a/test/java/org/apache/ivy/core/resolve/ResolveEngineTest.java
+++ b/test/java/org/apache/ivy/core/resolve/ResolveEngineTest.java
@@ -40,12 +40,12 @@ public class ResolveEngineTest extends TestCase {
     private File cache;
 
     protected void setUp() throws Exception {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         System.setProperty("ivy.cache.dir", cache.getAbsolutePath());
         createCache();
 
         ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
     }
 
     protected void tearDown() throws Exception {
@@ -72,10 +72,10 @@ public class ResolveEngineTest extends TestCase {
 
         testLocateThenDownload(engine,
             DefaultArtifact.newIvyArtifact(ModuleRevisionId.parse("org1#mod1.1;1.0"), new Date()),
-            new File("test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"));
+            FileUtil.newFile("test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"));
         testLocateThenDownload(engine,
             new DefaultArtifact(ModuleRevisionId.parse("org1#mod1.1;1.0"), new Date(), "mod1.1",
-                    "jar", "jar"), new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"));
+                    "jar", "jar"), FileUtil.newFile("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"));
     }
 
     private void testLocateThenDownload(ResolveEngine engine, Artifact artifact, File artifactFile) {

--- a/test/java/org/apache/ivy/core/resolve/ResolveEngineTest.java
+++ b/test/java/org/apache/ivy/core/resolve/ResolveEngineTest.java
@@ -82,7 +82,7 @@ public class ResolveEngineTest extends TestCase {
         assertNotNull(origin);
         assertTrue(origin.isLocal());
         assertEquals(artifactFile.getAbsolutePath(),
-            new File(origin.getLocation()).getAbsolutePath());
+            FileUtil.newFile(origin.getLocation()).getAbsolutePath());
 
         ArtifactDownloadReport r = engine.download(origin, new DownloadOptions());
         assertNotNull(r);

--- a/test/java/org/apache/ivy/core/resolve/ResolveTest.java
+++ b/test/java/org/apache/ivy/core/resolve/ResolveTest.java
@@ -89,18 +89,18 @@ public class ResolveTest extends TestCase {
     }
 
     protected void setUp() throws Exception {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         System.setProperty("ivy.cache.dir", cache.getAbsolutePath());
         createCache();
 
-        deliverDir = new File("build/test/deliver");
+        deliverDir = FileUtil.newFile("build/test/deliver");
         deliverDir.mkdirs();
 
-        workDir = new File("build/test/work");
+        workDir = FileUtil.newFile("build/test/work");
         workDir.mkdirs();
 
         ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
     }
 
     private void createCache() {
@@ -116,7 +116,7 @@ public class ResolveTest extends TestCase {
     public void testResolveWithRetainingArtifactName() throws Exception {
         ((DefaultRepositoryCacheManager) ivy.getSettings().getDefaultRepositoryCacheManager())
                 .setArtifactPattern(ivy.substitute("[module]/[originalname].[ext]"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod15.2/ivy-1.1.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod15.2/ivy-1.1.xml"),
             getResolveOptions(new String[] {"default"}));
         assertNotNull(report);
 
@@ -148,7 +148,7 @@ public class ResolveTest extends TestCase {
     public void testResolveWithRetainingArtifactNameAndExtraAttributes() throws Exception {
         ((DefaultRepositoryCacheManager) ivy.getSettings().getDefaultRepositoryCacheManager())
                 .setArtifactPattern(ivy.substitute("[module]/[originalname].[ext]"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod15.4/ivy-1.1.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod15.4/ivy-1.1.xml"),
             getResolveOptions(new String[] {"default"}).setValidate(false));
         assertNotNull(report);
 
@@ -180,7 +180,7 @@ public class ResolveTest extends TestCase {
     }
 
     public void testArtifactOrigin() throws Exception {
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
             getResolveOptions(new String[] {"default"}));
         assertNotNull(report);
@@ -193,7 +193,7 @@ public class ResolveTest extends TestCase {
         Artifact artifact = dReports[0].getArtifact();
         assertNotNull(artifact);
 
-        String expectedLocation = new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar")
+        String expectedLocation = FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar")
                 .getAbsolutePath();
 
         // verify the origin in the report
@@ -211,7 +211,7 @@ public class ResolveTest extends TestCase {
 
         // now resolve the same artifact again and verify the origin of the (not-downloaded)
         // artifact
-        report = ivy.resolve(new File("test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
             getResolveOptions(new String[] {"default"}));
         assertNotNull(report);
 
@@ -232,7 +232,7 @@ public class ResolveTest extends TestCase {
         ((DefaultRepositoryCacheManager) ivy.getSettings().getDefaultRepositoryCacheManager())
                 .setUseOrigin(true);
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
             getResolveOptions(new String[] {"default"}));
         assertNotNull(report);
@@ -248,7 +248,7 @@ public class ResolveTest extends TestCase {
         Artifact artifact = dReports[0].getArtifact();
         assertNotNull(artifact);
 
-        String expectedLocation = new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar")
+        String expectedLocation = FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar")
                 .getAbsolutePath();
 
         ArtifactOrigin origin = getSavedArtifactOrigin(artifact);
@@ -260,7 +260,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveSimple() throws Exception {
         // mod1.1 depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -279,7 +279,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveBadStatus() throws Exception {
         // mod1.4 depends on modfailure, modfailure has a bad status
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.4/ivys/ivy-1.1.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -290,8 +290,8 @@ public class ResolveTest extends TestCase {
         Ivy ivy = new Ivy();
         Throwable th = null;
         try {
-            ivy.configure(new File("test/repositories/xml-entities/ivysettings.xml"));
-            ResolveReport report = ivy.resolve(new File("test/repositories/xml-entities/ivy.xml"),
+            ivy.configure(FileUtil.newFile("test/repositories/xml-entities/ivysettings.xml"));
+            ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/xml-entities/ivy.xml"),
                 getResolveOptions(new String[] {"*"}));
             assertNotNull(report);
             assertFalse(report.hasError());
@@ -305,8 +305,8 @@ public class ResolveTest extends TestCase {
         // module1 depends on latest version of module2, for which there is no revision in the
         // pattern
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/norev/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/norev/ivy.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/norev/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/norev/ivy.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         assertFalse(report.hasError());
@@ -314,8 +314,8 @@ public class ResolveTest extends TestCase {
 
     public void testResolveLatestWithNoRevisionInPattern() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/norev/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/norev/ivy-latest.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/norev/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/norev/ivy-latest.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         assertFalse(report.hasError());
@@ -323,7 +323,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveNoRevisionInDep() throws Exception {
         // mod1.4 depends on mod1.6, in which the ivy file has no revision
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.4/ivys/ivy-1.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -335,13 +335,13 @@ public class ResolveTest extends TestCase {
         // module1 depends on latest version of module2, which contains no revision in its ivy file,
         // nor in the pattern
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-258/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-258/ivy.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-258/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-258/ivy.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
         ((BasicResolver) ivy.getSettings().getResolver("myresolver")).setCheckconsistency(false);
-        report = ivy.resolve(new File("test/repositories/IVY-258/ivy.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-258/ivy.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
     }
@@ -357,8 +357,8 @@ public class ResolveTest extends TestCase {
         // settings use 'all' as default conflict manager, and latest-revision for modules from
         // myorg
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-448/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-448/ivy.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-448/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-448/ivy.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
@@ -375,7 +375,7 @@ public class ResolveTest extends TestCase {
         // #M2;1.0 -> {org1#mod1.2;1.1 org1#mod1.2;2.0} with
         // <conflict org="org1" module="mod1.2" rev="1.1,2.0" />
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/IVY-465/M1/ivys/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
@@ -390,10 +390,10 @@ public class ResolveTest extends TestCase {
     public void testResolveRequiresDescriptor() throws Exception {
         // mod1.1 depends on mod1.2, mod1.2 has no ivy file
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
         ((FileSystemResolver) ivy.getSettings().getResolver("1"))
                 .setDescriptor(FileSystemResolver.DESCRIPTOR_REQUIRED);
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -439,16 +439,16 @@ public class ResolveTest extends TestCase {
         // mod1.1 depends on mod1.2
 
         // we first do a simple resolve so that module is in cache
-        ivy.resolve(new File("test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
 
         // we now use a badly configured ivy, so that it can't find module in repository
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/bugIVY-56/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/bugIVY-56/ivysettings.xml"));
         ivy.getSettings().setDefaultCache(cache);
         ivy.getSettings().validate();
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
             getResolveOptions(ivy.getSettings(), new String[] {"*"}));
         assertFalse(report.hasError());
@@ -472,21 +472,21 @@ public class ResolveTest extends TestCase {
         Ivy ivy = ivyTestCache();
 
         // set up repository
-        FileUtil.forceDelete(new File("build/testCache2"));
-        File art = new File("build/testCache2/mod1.2-2.0.jar");
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), art, null);
+        FileUtil.forceDelete(FileUtil.newFile("build/testCache2"));
+        File art = FileUtil.newFile("build/testCache2/mod1.2-2.0.jar");
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), art, null);
 
         // we first do a simple resolve so that module is in cache
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
         // now we clean the repository to simulate repo not available (network pb for instance)
-        FileUtil.forceDelete(new File("build/testCache2"));
+        FileUtil.forceDelete(FileUtil.newFile("build/testCache2"));
 
         // now do a new resolve: it should use cached data
-        report = ivy.resolve(new File("test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
@@ -510,12 +510,12 @@ public class ResolveTest extends TestCase {
         ivy.getSettings().setVariable("ivy.cache.ttl.default", "10s", true);
 
         // set up repository
-        FileUtil.forceDelete(new File("build/testCache2"));
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), new File(
+        FileUtil.forceDelete(FileUtil.newFile("build/testCache2"));
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), FileUtil.newFile(
                 "build/testCache2/mod1.2-1.5.jar"), null);
 
         // we first do a simple resolve so that module is in cache
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
@@ -526,10 +526,10 @@ public class ResolveTest extends TestCase {
                     .getModuleRevisionIds());
 
         // now we clean the repository to simulate repo not available (network pb for instance)
-        FileUtil.forceDelete(new File("build/testCache2"));
+        FileUtil.forceDelete(FileUtil.newFile("build/testCache2"));
 
         // now do a new resolve: it should use cached data
-        report = ivy.resolve(new File("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
@@ -547,14 +547,14 @@ public class ResolveTest extends TestCase {
         ivy.getSettings().setVariable("ivy.cache.ttl.default", "10s", true);
 
         // set up repository
-        FileUtil.forceDelete(new File("build/testCache2"));
-        FileUtil.copy(ResolveTest.class.getResourceAsStream("ivy-mod1.2-1.5.xml"), new File(
+        FileUtil.forceDelete(FileUtil.newFile("build/testCache2"));
+        FileUtil.copy(ResolveTest.class.getResourceAsStream("ivy-mod1.2-1.5.xml"), FileUtil.newFile(
                 "build/testCache2/ivy-mod1.2-1.5.xml"), null);
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), new File(
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), FileUtil.newFile(
                 "build/testCache2/mod1.2-1.5.jar"), null);
 
         // we first do a simple resolve so that module is in cache
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
@@ -565,10 +565,10 @@ public class ResolveTest extends TestCase {
                     .getModuleRevisionIds());
 
         // now we clean the repository to simulate repo not available (network pb for instance)
-        FileUtil.forceDelete(new File("build/testCache2"));
+        FileUtil.forceDelete(FileUtil.newFile("build/testCache2"));
 
         // now do a new resolve: it should use cached data
-        report = ivy.resolve(new File("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
@@ -587,14 +587,14 @@ public class ResolveTest extends TestCase {
         ivy.getSettings().setVariable("ivy.cache.ttl.default", "500ms", true);
 
         // set up repository
-        FileUtil.forceDelete(new File("build/testCache2"));
-        FileUtil.copy(ResolveTest.class.getResourceAsStream("ivy-mod1.2-1.5.xml"), new File(
+        FileUtil.forceDelete(FileUtil.newFile("build/testCache2"));
+        FileUtil.copy(ResolveTest.class.getResourceAsStream("ivy-mod1.2-1.5.xml"), FileUtil.newFile(
                 "build/testCache2/ivy-mod1.2-1.5.xml"), null);
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), new File(
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), FileUtil.newFile(
                 "build/testCache2/mod1.2-1.5.jar"), null);
 
         // we first do a simple resolve so that module is in cache
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
@@ -608,7 +608,7 @@ public class ResolveTest extends TestCase {
         Thread.sleep(700);
 
         // we resolve again, it should work fine
-        report = ivy.resolve(new File("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
@@ -618,10 +618,10 @@ public class ResolveTest extends TestCase {
                     .getModuleRevisionIds());
 
         // now we clean the repository to simulate repo not available (network pb for instance)
-        FileUtil.forceDelete(new File("build/testCache2"));
+        FileUtil.forceDelete(FileUtil.newFile("build/testCache2"));
 
         // now do a new resolve: it should use cached data
-        report = ivy.resolve(new File("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
@@ -638,12 +638,12 @@ public class ResolveTest extends TestCase {
         ivy.getSettings().setVariable("ivy.cache.ttl.default", "0ms", true);
 
         // set up repository
-        FileUtil.forceDelete(new File("build/testCache2"));
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), new File(
+        FileUtil.forceDelete(FileUtil.newFile("build/testCache2"));
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), FileUtil.newFile(
                 "build/testCache2/mod1.2-1.5.jar"), null);
 
         // we first do a simple resolve so that module is in cache
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
@@ -654,11 +654,11 @@ public class ResolveTest extends TestCase {
                     .getModuleRevisionIds());
 
         // now we update the repository
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), new File(
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), FileUtil.newFile(
                 "build/testCache2/mod1.2-1.6.jar"), null);
 
         // now do a new resolve: it should not use cached data
-        report = ivy.resolve(new File("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
@@ -677,22 +677,22 @@ public class ResolveTest extends TestCase {
                     ExactPatternMatcher.INSTANCE, 500);
 
         // set up repository
-        FileUtil.forceDelete(new File("build/testCache2"));
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), new File(
+        FileUtil.forceDelete(FileUtil.newFile("build/testCache2"));
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), FileUtil.newFile(
                 "build/testCache2/mod1.2-1.5.jar"), null);
 
         // we first do a simple resolve so that module is in cache
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
         // now we update the repository
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), new File(
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), FileUtil.newFile(
                 "build/testCache2/mod1.2-1.6.jar"), null);
 
         // now do a new resolve: it should use cached data
-        report = ivy.resolve(new File("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
@@ -705,7 +705,7 @@ public class ResolveTest extends TestCase {
         Thread.sleep(700);
 
         // now do a new resolve: it should resolve the dynamic revision again
-        report = ivy.resolve(new File("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
@@ -721,22 +721,22 @@ public class ResolveTest extends TestCase {
         ivy.getSettings().setVariable("ivy.cache.ttl.default", "10s", true);
 
         // set up repository
-        FileUtil.forceDelete(new File("build/testCache2"));
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), new File(
+        FileUtil.forceDelete(FileUtil.newFile("build/testCache2"));
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), FileUtil.newFile(
                 "build/testCache2/mod1.2-1.5.jar"), null);
 
         // we first do a simple resolve so that module is in cache
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
         // now we update the repository
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), new File(
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), FileUtil.newFile(
                 "build/testCache2/mod1.2-1.6.jar"), null);
 
         // now do a new resolve: it should use cached data
-        report = ivy.resolve(new File("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
@@ -746,7 +746,7 @@ public class ResolveTest extends TestCase {
                     .getModuleRevisionIds());
 
         // resolve again with refresh: it should find the new version
-        report = ivy.resolve(new File("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"*"}).setRefresh(true));
         assertFalse(report.hasError());
 
@@ -755,7 +755,7 @@ public class ResolveTest extends TestCase {
                 "mod1.2", "1.6")})), report.getConfigurationReport("default")
                     .getModuleRevisionIds());
 
-        FileUtil.forceDelete(new File("build/testCache2"));
+        FileUtil.forceDelete(FileUtil.newFile("build/testCache2"));
     }
 
     /**
@@ -786,7 +786,7 @@ public class ResolveTest extends TestCase {
 
     public void testFromCacheOnly() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/bugIVY-56/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/bugIVY-56/ivysettings.xml"));
         ivy.getSettings().setDefaultCache(cache);
 
         // ResolveReport report = ivy.resolve(new
@@ -799,9 +799,9 @@ public class ResolveTest extends TestCase {
         File ivyfile = getIvyFileInCache(ModuleRevisionId.newInstance("org1", "mod1.2", "2.0"));
         File art = getArchiveFileInCache(ivy, "org1", "mod1.2", "2.0", "mod1.2", "jar", "jar");
         FileUtil.copy(ResolveTest.class.getResource("ivy-mod1.2.xml"), ivyfile, null);
-        FileUtil.copy(new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), art, null);
+        FileUtil.copy(FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), art, null);
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
             getResolveOptions(ivy.getSettings(), new String[] {"*"}));
         assertFalse(report.hasError());
@@ -809,7 +809,7 @@ public class ResolveTest extends TestCase {
 
     public void testChangeCacheLayout() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
         DefaultRepositoryCacheManager cacheMgr = (DefaultRepositoryCacheManager) ivy.getSettings()
                 .getDefaultRepositoryCacheManager();
 
@@ -817,7 +817,7 @@ public class ResolveTest extends TestCase {
         cacheMgr.setArtifactPattern("[artifact].[ext]");
 
         // mod1.1 depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
             getResolveOptions(ivy.getSettings(), new String[] {"*"}));
         assertNotNull(report);
@@ -839,7 +839,7 @@ public class ResolveTest extends TestCase {
 
     public void testChangeCacheLayout2() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
         ivy.getSettings().setDefaultRepositoryCacheBasedir(
             FileUtil.newFile(ivy.getSettings().getDefaultCache(), "repository").getAbsolutePath());
         ivy.getSettings().setDefaultResolutionCacheBasedir(
@@ -852,7 +852,7 @@ public class ResolveTest extends TestCase {
         cacheMgr.setArtifactPattern("[artifact].[ext]");
 
         // mod1.1 depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
             getResolveOptions(ivy.getSettings(), new String[] {"*"}));
         assertNotNull(report);
@@ -879,10 +879,10 @@ public class ResolveTest extends TestCase {
 
     public void testMultipleCache() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/ivysettings-multicache.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings-multicache.xml"));
 
         // mod2.1 depends on mod1.1 which depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.1/ivys/ivy-0.3.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -913,8 +913,8 @@ public class ResolveTest extends TestCase {
         // mod2.1 depends on mod1.1 which depends on mod1.2
         // a local build for mod1.2 is available
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/ivysettings-local.xml"));
-        ResolveReport report = ivy.resolve(new File(
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings-local.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.1/ivys/ivy-0.3.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
@@ -941,8 +941,8 @@ public class ResolveTest extends TestCase {
         // mod2.3 -> mod2.1;[0.0,0.4] -> mod1.1 -> mod1.2
         // a local build for mod2.1 and mod1.2 is available
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/ivysettings-local.xml"));
-        ResolveReport report = ivy.resolve(new File(
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings-local.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.3/ivys/ivy-0.8.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
@@ -976,7 +976,7 @@ public class ResolveTest extends TestCase {
         // mod2.1 depends on mod1.1 which depends on mod1.2
         // a local build for mod1.2 is available
         // we do a first resolve without local build so that cache contains mod1.2;2.0 module
-        ivy.resolve(new File("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.xml"),
             getResolveOptions(new String[] {"*"}));
 
         assertTrue(getIvyFileInCache(ModuleRevisionId.newInstance("org1", "mod1.2", "2.0"))
@@ -984,8 +984,8 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
 
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/ivysettings-local.xml"));
-        ResolveReport report = ivy.resolve(new File(
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings-local.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.1/ivys/ivy-0.3.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
@@ -1006,7 +1006,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveExtends() throws Exception {
         // mod6.1 depends on mod1.2 2.0 in conf default, and conf extension extends default
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org6/mod6.1/ivys/ivy-0.3.xml"),
             getResolveOptions(new String[] {"extension"}));
         assertNotNull(report);
@@ -1025,7 +1025,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveExtended() throws Exception {
         // mod6.1 depends on mod1.2 2.0 in conf default, and conf extension extends default
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org6/mod6.1/ivys/ivy-0.3.xml"),
             getResolveOptions(new String[] {"default"}));
         assertNotNull(report);
@@ -1044,7 +1044,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveExtendedAndExtends() throws Exception {
         // mod6.1 depends on mod1.2 2.0 in conf default, and conf extension extends default
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org6/mod6.1/ivys/ivy-0.3.xml"),
             getResolveOptions(new String[] {"default", "extension"}));
         assertNotNull(report);
@@ -1073,7 +1073,7 @@ public class ResolveTest extends TestCase {
         // mod6.1 has two confs default and extension
         // mod6.1 depends on mod1.2 2.0 in conf (default->default)
         // conf extension extends default
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org6/mod6.2/ivys/ivy-0.3.xml"),
             getResolveOptions(new String[] {"default", "extension"}));
         assertNotNull(report);
@@ -1110,7 +1110,7 @@ public class ResolveTest extends TestCase {
         // mod6.2 2.0 depends on mod6.1 2.0 in conf (default->standalone)
         // mod6.1 2.0 has two confs default and standalone
         // mod6.1 2.0 depends on mod1.2 2.2 in conf (default->default)
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod6.3/ivy-1.1.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod6.3/ivy-1.1.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         assertFalse(report.hasError());
@@ -1143,7 +1143,7 @@ public class ResolveTest extends TestCase {
         // depends on mod1.2 latest (which is 2.2) in conf (run->default)
         // mod6.1
         // depends on mod1.2 2.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org6/mod6.2/ivys/ivy-0.6.xml"),
             getResolveOptions(new String[] {"compile", "run"}));
         assertNotNull(report);
@@ -1172,7 +1172,7 @@ public class ResolveTest extends TestCase {
         // depends on mod1.2 2.1
         // mod1.1
         // depends on mod1.2 2.0
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org6/mod6.2/ivys/ivy-0.5.xml"),
             getResolveOptions(new String[] {"compile", "run"}));
         assertNotNull(report);
@@ -1208,7 +1208,7 @@ public class ResolveTest extends TestCase {
     public void testResolveMultipleExtends2() throws Exception {
         // same as before, except that mod6.2 depends on mod1.2 2.1 extension->default
         // so mod1.2 2.0 should be evicted in conf extension
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org6/mod6.2/ivys/ivy-0.4.xml"),
             getResolveOptions(new String[] {"default", "extension"}));
         assertNotNull(report);
@@ -1253,7 +1253,7 @@ public class ResolveTest extends TestCase {
         // mod1.6 depends on
         // mod1.4, which depends on mod1.3 and selects one of its artifacts
         // mod1.3 and selects two of its artifacts
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.6/ivys/ivy-1.0.3.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
@@ -1272,7 +1272,7 @@ public class ResolveTest extends TestCase {
         // #mod2.5;0.6.2 -> #mod1.3;3.1 artifact C
         // #mod1.3;3.1 has only A and C artifacts, not B.
         // Both A and C should be downloaded, and a message should tell that B was not available.
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.6/ivys/ivy-0.12.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
@@ -1287,8 +1287,8 @@ public class ResolveTest extends TestCase {
     public void testResolveSeveralDefaultWithArtifactsAndConfs() throws Exception {
         // test case for IVY-283
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-283/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-283/ivy.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-283/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-283/ivy.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
@@ -1309,8 +1309,8 @@ public class ResolveTest extends TestCase {
     public void testResolveSeveralDefaultWithArtifactsAndConfs2() throws Exception {
         // second test case for IVY-283
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-283/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-283/ivy-d.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-283/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-283/ivy-d.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
@@ -1343,7 +1343,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveWithStartPublicConf() throws Exception {
         // mod2.2 depends on mod1.3 and selects its artifacts
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.2/ivys/ivy-0.8.xml"),
             getResolveOptions(new String[] {"*(public)"}));
         assertNotNull(report);
@@ -1366,7 +1366,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveWithPrivateConf() throws Exception {
         // mod2.2 depends on mod1.3 and selects its artifacts
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.2/ivys/ivy-0.8.xml"),
             getResolveOptions(new String[] {"*(private)"}));
         assertNotNull(report);
@@ -1388,7 +1388,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveDefaultWithArtifactsConf1() throws Exception {
         // mod2.2 depends on mod1.3 and selects its artifacts
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.2/ivys/ivy-0.5.xml"),
             getResolveOptions(new String[] {"myconf1"}));
         assertNotNull(report);
@@ -1411,7 +1411,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveDefaultWithArtifactsConf2() throws Exception {
         // mod2.2 depends on mod1.3 and selects its artifacts
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.2/ivys/ivy-0.5.xml"),
             getResolveOptions(new String[] {"myconf2"}));
         assertNotNull(report);
@@ -1433,7 +1433,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveDefaultWithArtifactsAndConfMapping() throws Exception {
         // mod2.2 depends on mod1.3 and specify its artifacts and a conf mapping
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.2/ivys/ivy-0.5.1.xml"),
             getResolveOptions(new String[] {"myconf1"}));
         assertNotNull(report);
@@ -1456,7 +1456,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveWithIncludeArtifactsConf1() throws Exception {
         // mod2.3 depends on mod2.1 and selects its artifacts in myconf1
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.3/ivys/ivy-0.4.xml"),
             getResolveOptions(new String[] {"myconf1"}));
         assertNotNull(report);
@@ -1476,7 +1476,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveWithIncludeArtifactsConf2() throws Exception {
         // mod2.3 depends on mod2.1 and selects its artifacts in myconf1
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.3/ivys/ivy-0.4.xml"),
             getResolveOptions(new String[] {"myconf2"}));
         assertNotNull(report);
@@ -1496,7 +1496,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveWithIncludeArtifactsWithoutConf() throws Exception {
         // mod2.3 depends on mod2.1 and selects its artifacts
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.3/ivys/ivy-0.5.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -1518,7 +1518,7 @@ public class ResolveTest extends TestCase {
         // test case for IVY-541
         // mod2.6 depends on mod2.3 and mod2.1
         // mod2.3 depends on mod2.1 and selects its artifacts
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.6/ivys/ivy-0.5.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
@@ -1531,7 +1531,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveWithExcludesArtifacts() throws Exception {
         // mod2.3 depends on mod2.1 and selects its artifacts
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.3/ivys/ivy-0.6.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -1551,7 +1551,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveWithExcludesArtifacts2() throws Exception {
         // mod2.3 depends on mod2.1 and badly excludes artifacts with incorrect matcher
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.3/ivys/ivy-0.6.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -1571,7 +1571,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveWithExcludesArtifacts3() throws Exception {
         // mod2.3 depends on mod2.1 and excludes artifacts with exact matcher
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.3/ivys/ivy-0.6.3.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -1591,7 +1591,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveWithExcludesArtifacts4() throws Exception {
         // mod2.3 depends on mod2.1 and excludes artifacts with regexp matcher
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.3/ivys/ivy-0.6.4.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -1611,7 +1611,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveWithExcludesArtifacts5() throws Exception {
         // mod2.3 depends on mod2.1 and excludes artifacts with glob matcher
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.3/ivys/ivy-0.6.5.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -1631,7 +1631,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveTransitiveDependencies() throws Exception {
         // mod2.1 depends on mod1.1 which depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.1/ivys/ivy-0.3.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -1654,7 +1654,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveTransitiveDependenciesWithOverride() throws Exception {
         // mod2.1 depends on mod1.1 which depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.1/ivys/ivy-0.6.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -1681,7 +1681,7 @@ public class ResolveTest extends TestCase {
     public void testResolveTransitiveDependenciesWithOverrideAndDynamicResolveMode()
             throws Exception {
         // mod2.1 depends on mod1.1 which depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.1/ivys/ivy-0.6.xml"),
             getResolveOptions(new String[] {"*"})
                     .setResolveMode(ResolveOptions.RESOLVEMODE_DYNAMIC));
@@ -1705,7 +1705,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveTransitiveDisabled() throws Exception {
         // mod2.1 depends on mod1.1 which depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.1/ivys/ivy-0.3.xml"),
             getResolveOptions(new String[] {"*"}).setTransitive(false));
         assertNotNull(report);
@@ -1751,7 +1751,7 @@ public class ResolveTest extends TestCase {
         // compile conf is not transitive
 
         // first we resolve compile conf only
-        ivy.resolve(new File("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.1.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.1.xml"),
             getResolveOptions(new String[] {"compile"}));
 
         // dependencies
@@ -1764,7 +1764,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
 
         // then we resolve runtime conf
-        ivy.resolve(new File("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.1.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.1.xml"),
             getResolveOptions(new String[] {"runtime"}));
 
         // dependencies
@@ -1774,7 +1774,7 @@ public class ResolveTest extends TestCase {
 
         // same as before, but resolve both confs in one call
         ResolveReport r = ivy.resolve(
-            new File("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.1.xml"),
+            FileUtil.newFile("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.1.xml"),
             getResolveOptions(new String[] {"runtime", "compile"}));
         assertFalse(r.hasError());
         assertEquals(1, r.getConfigurationReport("compile").getArtifactsNumber());
@@ -1787,7 +1787,7 @@ public class ResolveTest extends TestCase {
         // compile extends runtime
 
         // first we resolve compile conf only
-        ivy.resolve(new File("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.2.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.2.xml"),
             getResolveOptions(new String[] {"compile"}));
 
         // dependencies
@@ -1800,7 +1800,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
 
         // then we resolve runtime conf
-        ivy.resolve(new File("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.2.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.2.xml"),
             getResolveOptions(new String[] {"runtime"}));
 
         // dependencies
@@ -1810,7 +1810,7 @@ public class ResolveTest extends TestCase {
 
         // same as before, but resolve both confs in one call
         ResolveReport r = ivy.resolve(
-            new File("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.2.xml"),
+            FileUtil.newFile("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.2.xml"),
             getResolveOptions(new String[] {"runtime", "compile"}));
         assertFalse(r.hasError());
         assertEquals(1, r.getConfigurationReport("compile").getArtifactsNumber());
@@ -1823,7 +1823,7 @@ public class ResolveTest extends TestCase {
         // runtime extends compile
 
         // first we resolve compile conf only
-        ivy.resolve(new File("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.3.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.3.xml"),
             getResolveOptions(new String[] {"compile"}));
 
         // dependencies
@@ -1836,7 +1836,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
 
         // then we resolve runtime conf
-        ivy.resolve(new File("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.3.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.3.xml"),
             getResolveOptions(new String[] {"runtime"}));
 
         // dependencies
@@ -1846,7 +1846,7 @@ public class ResolveTest extends TestCase {
 
         // same as before, but resolve both confs in one call
         ResolveReport r = ivy.resolve(
-            new File("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.3.xml"),
+            FileUtil.newFile("test/repositories/1/org2/mod2.1/ivys/ivy-0.3.3.xml"),
             getResolveOptions(new String[] {"runtime", "compile"}));
         assertFalse(r.hasError());
         assertEquals(1, r.getConfigurationReport("compile").getArtifactsNumber());
@@ -1860,7 +1860,7 @@ public class ResolveTest extends TestCase {
         // mod2.1 (compile, runtime) depends on mod1.1 which depends on mod1.2
         // compile conf is not transitive and extends runtime
 
-        ResolveReport r = ivy.resolve(new File("test/repositories/1/org2/mod2.2/ivys/ivy-0.6.xml"),
+        ResolveReport r = ivy.resolve(FileUtil.newFile("test/repositories/1/org2/mod2.2/ivys/ivy-0.6.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(r.hasError());
 
@@ -1894,7 +1894,7 @@ public class ResolveTest extends TestCase {
         // mod2.1 (compile, runtime) depends on mod1.1 1.0 which depends on mod1.2 2.0
         // compile conf is not transitive and extends runtime
 
-        ResolveReport r = ivy.resolve(new File("test/repositories/1/org2/mod2.2/ivys/ivy-0.7.xml"),
+        ResolveReport r = ivy.resolve(FileUtil.newFile("test/repositories/1/org2/mod2.2/ivys/ivy-0.7.xml"),
             getResolveOptions(new String[] {"A", "B", "compile"}));
         assertFalse(r.hasError());
 
@@ -1925,7 +1925,7 @@ public class ResolveTest extends TestCase {
         // mod4.1 depends on
         // - mod1.1 which depends on mod1.2
         // - mod3.1 which depends on mod1.2
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod4.1/ivy-4.0.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod4.1/ivy-4.0.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -1953,7 +1953,7 @@ public class ResolveTest extends TestCase {
         // mod4.1 v 4.1 depends on
         // - mod1.1 v 1.0 which depends on mod1.2 v 2.0
         // - mod3.1 v 1.1 which depends on mod1.2 v 2.1
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod4.1/ivy-4.1.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod4.1/ivy-4.1.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -2006,7 +2006,7 @@ public class ResolveTest extends TestCase {
         // - mod1.1 v 1.0 which depends on mod1.2 v 2.0
         // - mod3.1 v 1.1 which depends on mod1.2 v 2.1
         // - mod6.1 v 0.3 which depends on mod1.2 v 2.0
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod4.1/ivy-4.14.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod4.1/ivy-4.14.xml"),
             getResolveOptions(new String[] {"*"}));
 
         // dependencies
@@ -2054,8 +2054,8 @@ public class ResolveTest extends TestCase {
         // x and z depends on commons-lang 1.0.1
         // y depends on commons-lang 2.0
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-264/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-264/ivy.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-264/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-264/ivy.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
@@ -2082,7 +2082,7 @@ public class ResolveTest extends TestCase {
         // mod20.2;1.0 -> mod20.1;1.1 (transitive false)
         // mod20.1;1.0 -> mod1.2;1.0
         // mod20.1;1.1 -> mod1.2;1.0
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org20/mod20.4/ivys/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
 
@@ -2101,7 +2101,7 @@ public class ResolveTest extends TestCase {
      * Test IVY-618.
      */
     public void testResolveConflictFromPoms() throws Exception {
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod17.1/ivy-1.0.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod17.1/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         assertFalse(report.hasError());
@@ -2112,7 +2112,7 @@ public class ResolveTest extends TestCase {
         // mod7.2 v1.0 depends on mod7.1 v1.0 (which then should be evicted)
         // mod7.1 v1.0 depends on mod 1.2 v2.0 (which should be evicted by transitivity)
 
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod7.3/ivy-1.0.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod7.3/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -2142,7 +2142,7 @@ public class ResolveTest extends TestCase {
         // - mod3.2 v 1.2.1 which depends on
         // - mod3.1 v 1.0 which depends on mod1.2 v 2.0
         // - mod1.2 v 2.1
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod4.1/ivy-4.13.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod4.1/ivy-4.13.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
 
@@ -2183,7 +2183,7 @@ public class ResolveTest extends TestCase {
 
         // mod2.1 conf A depends on mod1.1 which depends on mod1.2 2.0
         // mod2.1 conf B depends on mod1.2 2.1
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.1/ivys/ivy-0.4.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -2216,7 +2216,7 @@ public class ResolveTest extends TestCase {
         // mod5.2 r1.0 which depends on mod5.1 r4.0 conf B
         //
         // mod5.1 r4.2 conf B depends on mod1.2 r2.0
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod6.1/ivy-1.0.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod6.1/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -2257,7 +2257,7 @@ public class ResolveTest extends TestCase {
         // mod5.1 r4.2 conf A
         //
         // mod5.1 r4.2 conf B depends on mod1.2 r2.0
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod6.1/ivy-1.1.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod6.1/ivy-1.1.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -2296,7 +2296,7 @@ public class ResolveTest extends TestCase {
         // mod5.2 r1.0 which depends on mod5.1 r4.0 conf B
         //
         // mod5.1 r4.3 has only conf A, not B
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod6.1/ivy-1.4.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod6.1/ivy-1.4.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
@@ -2318,7 +2318,7 @@ public class ResolveTest extends TestCase {
 
         // mod6.1 r1.5 depends on
         // mod5.1 [1.0,4.3] conf unknown which doesn't exist in mod5.1;4.3
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod6.1/ivy-1.5.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod6.1/ivy-1.5.xml"),
             getResolveOptions(new String[] {"*"}));
         assertTrue("missing conf should have raised an error in report", report.hasError());
         assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").indexOf(
@@ -2334,7 +2334,7 @@ public class ResolveTest extends TestCase {
         // mod5.1 r4.2 conf A
         //
         // mod5.1 r4.2 conf B depends on mod1.2 r2.0
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod6.1/ivy-1.2.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod6.1/ivy-1.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -2387,7 +2387,7 @@ public class ResolveTest extends TestCase {
         // mod5.1 r4.2 conf A
         //
         // mod5.1 r4.2 conf B depends on mod1.2 r2.0
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod6.1/ivy-1.3.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod6.1/ivy-1.3.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -2430,7 +2430,7 @@ public class ResolveTest extends TestCase {
 
     public void testMultipleEviction() throws Exception {
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/IVY-644/M1/ivys/ivy-1.0.xml"), getResolveOptions(new String[] {
                 "test", "runtime"})); // NB the order impact the bug
         assertFalse(report.hasError());
@@ -2440,7 +2440,7 @@ public class ResolveTest extends TestCase {
         // mod4.1 v 4.2 depends on
         // - mod1.2 v 2.0 and forces it
         // - mod3.1 v 1.1 which depends on mod1.2 v 2.1
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod4.1/ivy-4.2.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod4.1/ivy-4.2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -2470,7 +2470,7 @@ public class ResolveTest extends TestCase {
         // - mod3.2 v 1.1 which depends on mod1.2 v 2.0
         // - mod3.1 v 1.1 which depends on mod1.2 v 2.1
         // - mod1.2 v 2.0 and forces it
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod4.1/ivy-4.9.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod4.1/ivy-4.9.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -2493,7 +2493,7 @@ public class ResolveTest extends TestCase {
         // mod4.1 v 4.10 depends on
         // - mod3.1 v 1.0.1 which depends on mod1.2 v 2.0 and forces it
         // - mod3.2 v 1.2 which depends on mod1.2 v 2.1 and on mod3.1 v1.0.1
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod4.1/ivy-4.10.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod4.1/ivy-4.10.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
 
@@ -2513,7 +2513,7 @@ public class ResolveTest extends TestCase {
         // - mod3.1 v1.1 which depends on
         // - mod1.2 v 2.1
         // - mod1.2 v 1.0 and forces it
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod4.1/ivy-4.11.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod4.1/ivy-4.11.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
 
@@ -2535,7 +2535,7 @@ public class ResolveTest extends TestCase {
         // - mod1.2 v 2.0 and forces it
         // - mod3.1 v1.1 which depends on
         // - mod1.2 v 2.1
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod4.1/ivy-4.12.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod4.1/ivy-4.12.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
 
@@ -2552,8 +2552,8 @@ public class ResolveTest extends TestCase {
         // - mod1.2 v 1+ and forces it
         // - mod3.1 v 1.2 which depends on mod1.2 v 2+
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/ivysettings-artifact-lock.xml"));
-        ivy.resolve(new File("test/repositories/2/mod4.1/ivy-4.5.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings-artifact-lock.xml"));
+        ivy.resolve(FileUtil.newFile("test/repositories/2/mod4.1/ivy-4.5.xml"),
             getResolveOptions(new String[] {"*"}));
 
         List lockFiles = new ArrayList();
@@ -2576,7 +2576,7 @@ public class ResolveTest extends TestCase {
         // mod4.1 v 4.5 depends on
         // - mod1.2 v 1+ and forces it
         // - mod3.1 v 1.2 which depends on mod1.2 v 2+
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod4.1/ivy-4.5.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod4.1/ivy-4.5.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -2604,7 +2604,7 @@ public class ResolveTest extends TestCase {
         // mod4.1 v 4.6 (conf compile, runtime extends compile, test extends runtime) depends on
         // - mod1.2 v 1+ and forces it in conf compile
         // - mod3.1 v 1.2 in conf test which depends on mod1.2 v 2+
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod4.1/ivy-4.6.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod4.1/ivy-4.6.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -2634,7 +2634,7 @@ public class ResolveTest extends TestCase {
         // - mod3.1 v 1.3 in conf test->runtime
         // which defines confs compile, runtime extends compile
         // which depends on mod1.2 v 2+ in conf compile->default
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod4.1/ivy-4.7.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod4.1/ivy-4.7.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -2697,7 +2697,7 @@ public class ResolveTest extends TestCase {
         // mod4.1 v 4.1 depends on
         // - mod1.1 v 1.0 which depends on mod1.2 v 2.0
         // - mod3.1 v 1.1 which depends on mod1.2 v 2.1
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod10.1/ivy-1.0.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod10.1/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -2725,7 +2725,7 @@ public class ResolveTest extends TestCase {
         // mod4.1 v 4.3 depends on
         // - mod1.2 v 2.1
         // - mod3.1 v 1.1 which depends on mod1.2 v 2.1
-        ivy.resolve(new File("test/repositories/2/mod10.1/ivy-1.1.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/2/mod10.1/ivy-1.1.xml"),
             getResolveOptions(new String[] {"*"}));
 
         // conflicting dependencies
@@ -2747,7 +2747,7 @@ public class ResolveTest extends TestCase {
         // mod4.1 v 4.4 depends on
         // - mod1.2 v 2.0 but selects mod1.2 v 2.1
         // - mod3.1 v 1.1 which depends on mod1.2 v 2.1
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod10.1/ivy-1.3.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod10.1/ivy-1.3.xml"),
             getResolveOptions(new String[] {"*"}));
 
         IvyNode[] evicted = report.getConfigurationReport("default").getEvictedNodes();
@@ -2761,7 +2761,7 @@ public class ResolveTest extends TestCase {
         // mod5.1 conf B publishes art51B
         // mod5.1 conf B extends conf A
         // mod5.1 conf A publishes art51A
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod5.2/ivy-1.0.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod5.2/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -2782,7 +2782,7 @@ public class ResolveTest extends TestCase {
         // mod 5.2 depends on mod5.1 conf B in its conf B and conf A in its conf A
         // mod5.1 conf B publishes art51B
         // mod5.1 conf A publishes art51A
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod5.2/ivy-2.0.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod5.2/ivy-2.0.xml"),
             getResolveOptions(new String[] {"B", "A"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -2819,7 +2819,7 @@ public class ResolveTest extends TestCase {
     }
 
     public void testThisConfiguration() throws Exception {
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod14.4/ivy-1.1.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod14.4/ivy-1.1.xml"),
             getResolveOptions(new String[] {"compile"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -2843,7 +2843,7 @@ public class ResolveTest extends TestCase {
 
         CacheCleaner.deleteDir(cache);
         createCache();
-        report = ivy.resolve(new File("test/repositories/2/mod14.4/ivy-1.1.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod14.4/ivy-1.1.xml"),
             getResolveOptions(new String[] {"standalone"}));
         crr = report.getConfigurationReport("standalone");
         assertNotNull(crr);
@@ -2869,7 +2869,7 @@ public class ResolveTest extends TestCase {
 
     public void testLatest() throws Exception {
         // mod1.4 depends on latest mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.4/ivys/ivy-1.0.1.xml"),
             getResolveOptions(new String[] {"default"}));
         assertNotNull(report);
@@ -2910,7 +2910,7 @@ public class ResolveTest extends TestCase {
         // mod1.5 depends on
         // latest mod1.4, which depends on mod1.2 2.2
         // latest mod1.2 (which is 2.2)
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.5/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"default"}));
         assertFalse(report.hasError());
@@ -2943,9 +2943,9 @@ public class ResolveTest extends TestCase {
 
         // mod9.2 depends on latest.integration of mod6.2
         Ivy ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/ivysettings-IVY602.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings-IVY602.xml"));
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org9/mod9.2/ivys/ivy-1.3.xml"),
             getResolveOptions(new String[] {"default"}));
         assertNotNull(report);
@@ -2957,7 +2957,7 @@ public class ResolveTest extends TestCase {
     public void testResolveModeDynamic1() throws Exception {
         // mod1.1;1.0.1 -> mod1.2;2.0|latest.integration
         ResolveReport report = ivy.resolve(
-            new File("test/repositories/1/org1/mod1.1/ivys/ivy-1.0.1.xml"),
+            FileUtil.newFile("test/repositories/1/org1/mod1.1/ivys/ivy-1.0.1.xml"),
             getResolveOptions(new String[] {"default"}).setResolveMode(
                 ResolveOptions.RESOLVEMODE_DYNAMIC));
         assertNotNull(report);
@@ -2978,7 +2978,7 @@ public class ResolveTest extends TestCase {
         attributes.put("module", "mod1.2");
         ivy.getSettings().addModuleConfiguration(attributes, ExactPatternMatcher.INSTANCE, null,
             null, null, ResolveOptions.RESOLVEMODE_DYNAMIC);
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.1.xml"),
             getResolveOptions(new String[] {"default"}));
         assertNotNull(report);
@@ -2995,9 +2995,9 @@ public class ResolveTest extends TestCase {
     public void testResolveModeDynamicWithBranch1() throws Exception {
         // bar1;5 -> foo1#branch1|;2|[0,4]
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/branches/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/branches/ivysettings.xml"));
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/branches/bar/bar1/trunk/5/ivy.xml"),
             getResolveOptions(new String[] {"*"})
                     .setResolveMode(ResolveOptions.RESOLVEMODE_DYNAMIC));
@@ -3009,9 +3009,9 @@ public class ResolveTest extends TestCase {
     public void testResolveModeDynamicWithBranch2() throws Exception {
         // bar1;5 -> foo1#trunk|branch1;3|[0,4]
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/branches/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/branches/ivysettings.xml"));
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/branches/bar/bar1/trunk/6/ivy.xml"),
             getResolveOptions(new String[] {"*"})
                     .setResolveMode(ResolveOptions.RESOLVEMODE_DYNAMIC));
@@ -3029,7 +3029,7 @@ public class ResolveTest extends TestCase {
         ivy.getSettings().addModuleConfiguration(attributes, ExactPatternMatcher.INSTANCE, null,
             null, null, ResolveOptions.RESOLVEMODE_DYNAMIC);
         ResolveReport report = ivy.resolve(
-            new File("test/repositories/1/org1/mod1.1/ivys/ivy-1.0.1.xml"),
+            FileUtil.newFile("test/repositories/1/org1/mod1.1/ivys/ivy-1.0.1.xml"),
             getResolveOptions(new String[] {"default"}).setResolveMode(
                 ResolveOptions.RESOLVEMODE_DEFAULT));
         assertNotNull(report);
@@ -3045,7 +3045,7 @@ public class ResolveTest extends TestCase {
 
     public void testVersionRange1() throws Exception {
         // mod 1.4 depends on mod1.2 [1.0,2.0[
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
             getResolveOptions(new String[] {"default"}));
         assertFalse(report.hasError());
@@ -3063,8 +3063,8 @@ public class ResolveTest extends TestCase {
     public void testVersionRange2() throws Exception {
         // mod 1.4 depends on mod1.2 [1.5,2.0[
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File(
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.4/ivys/ivy-1.0.3.xml"),
             getResolveOptions(new String[] {"default"}));
         assertTrue(report.hasError());
@@ -3072,7 +3072,7 @@ public class ResolveTest extends TestCase {
 
     public void testLatestMilestone() throws Exception {
         // mod9.2 depends on latest.milestone of mod6.4
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org9/mod9.2/ivys/ivy-1.1.xml"),
             getResolveOptions(new String[] {"default"}));
         assertFalse(report.hasError());
@@ -3090,7 +3090,7 @@ public class ResolveTest extends TestCase {
     public void testLatestMilestone2() throws Exception {
         // mod9.2 depends on latest.milestone of mod6.2, but there is no milestone
         // test case for IVY-318
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org9/mod9.2/ivys/ivy-1.2.xml"),
             getResolveOptions(new String[] {"default"}));
         // we should have an error since there is no milestone version, it should be considered as a
@@ -3105,7 +3105,7 @@ public class ResolveTest extends TestCase {
 
     public void testIVY56() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/bugIVY-56/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/bugIVY-56/ivysettings.xml"));
 
         try {
             ResolveReport report = ivy.resolve(ResolveTest.class.getResource("ivy-56.xml"),
@@ -3140,9 +3140,9 @@ public class ResolveTest extends TestCase {
 
     public void testIVY729() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-729/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-729/ivysettings.xml"));
 
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-729/ivy.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-729/ivy.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
     }
@@ -3150,26 +3150,26 @@ public class ResolveTest extends TestCase {
     public void testCircular() throws Exception {
         // mod6.3 depends on mod6.2, which itself depends on mod6.3
 
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod6.3/ivy-1.0.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod6.3/ivy-1.0.xml"),
             getResolveOptions(new String[] {"default"}));
         assertFalse(report.hasError());
 
         ivy.getSettings().setCircularDependencyStrategy(
             IgnoreCircularDependencyStrategy.getInstance());
-        report = ivy.resolve(new File("test/repositories/2/mod6.3/ivy-1.0.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod6.3/ivy-1.0.xml"),
             getResolveOptions(new String[] {"default"}));
         assertFalse(report.hasError());
 
         ivy.getSettings().setCircularDependencyStrategy(
             WarnCircularDependencyStrategy.getInstance());
-        report = ivy.resolve(new File("test/repositories/2/mod6.3/ivy-1.0.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod6.3/ivy-1.0.xml"),
             getResolveOptions(new String[] {"default"}));
         assertFalse(report.hasError());
 
         ivy.getSettings().setCircularDependencyStrategy(
             ErrorCircularDependencyStrategy.getInstance());
         try {
-            ivy.resolve(new File("test/repositories/2/mod6.3/ivy-1.0.xml"),
+            ivy.resolve(FileUtil.newFile("test/repositories/2/mod6.3/ivy-1.0.xml"),
                 getResolveOptions(new String[] {"default"}));
             fail("no exception with circular dependency strategy set to error");
         } catch (CircularDependencyException ex) {
@@ -3181,14 +3181,14 @@ public class ResolveTest extends TestCase {
     public void testCircular2() throws Exception {
         // mod 9.1 (no revision) depends on mod9.2, which depends on mod9.1 2.+
 
-        ResolveReport report = ivy.resolve(new File("test/repositories/circular/ivy.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/circular/ivy.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
         ivy.getSettings().setCircularDependencyStrategy(
             ErrorCircularDependencyStrategy.getInstance());
         try {
-            ivy.resolve(new File("test/repositories/circular/ivy.xml"),
+            ivy.resolve(FileUtil.newFile("test/repositories/circular/ivy.xml"),
                 getResolveOptions(new String[] {"*"}));
             fail("no exception with circular dependency strategy set to error");
         } catch (CircularDependencyException ex) {
@@ -3202,7 +3202,7 @@ public class ResolveTest extends TestCase {
         // mod6.3 depends on mod6.2, which itself depends on mod6.3,
         // in both configuration default and test
 
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod6.3/ivy-1.2.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod6.3/ivy-1.2.xml"),
             getResolveOptions(new String[] {"default", "test"}));
         assertFalse(report.hasError());
         // we should have mod 6.2 artifact in both configurations
@@ -3211,7 +3211,7 @@ public class ResolveTest extends TestCase {
 
         ivy.getSettings().setCircularDependencyStrategy(
             IgnoreCircularDependencyStrategy.getInstance());
-        report = ivy.resolve(new File("test/repositories/2/mod6.3/ivy-1.2.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod6.3/ivy-1.2.xml"),
             getResolveOptions(new String[] {"default", "test"}));
         assertFalse(report.hasError());
         assertEquals(1, report.getConfigurationReport("default").getArtifactsNumber());
@@ -3219,7 +3219,7 @@ public class ResolveTest extends TestCase {
 
         ivy.getSettings().setCircularDependencyStrategy(
             WarnCircularDependencyStrategy.getInstance());
-        report = ivy.resolve(new File("test/repositories/2/mod6.3/ivy-1.2.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod6.3/ivy-1.2.xml"),
             getResolveOptions(new String[] {"default", "test"}));
         assertFalse(report.hasError());
         assertEquals(1, report.getConfigurationReport("default").getArtifactsNumber());
@@ -3228,7 +3228,7 @@ public class ResolveTest extends TestCase {
         ivy.getSettings().setCircularDependencyStrategy(
             ErrorCircularDependencyStrategy.getInstance());
         try {
-            ivy.resolve(new File("test/repositories/2/mod6.3/ivy-1.2.xml"),
+            ivy.resolve(FileUtil.newFile("test/repositories/2/mod6.3/ivy-1.2.xml"),
                 getResolveOptions(new String[] {"default", "test"}));
             fail("no exception with circular dependency strategy set to error");
         } catch (CircularDependencyException ex) {
@@ -3241,7 +3241,7 @@ public class ResolveTest extends TestCase {
         // mod11.2 depends on mod11.1
         ivy.getSettings().setCircularDependencyStrategy(
             ErrorCircularDependencyStrategy.getInstance());
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod11.1/ivy-1.0.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod11.1/ivy-1.0.xml"),
             getResolveOptions(new String[] {"test"}));
 
         assertNotNull(report);
@@ -3270,56 +3270,56 @@ public class ResolveTest extends TestCase {
         ivy.resolve(ResolveTest.class.getResource("ivy-dualchainresolver.xml"),
             getResolveOptions(new String[] {"default"}));
 
-        assertTrue(new File("build/cache/xerces/xerces/ivy-2.6.2.xml").exists());
-        assertTrue(new File("build/cache/xerces/xerces/jars/xmlParserAPIs-2.6.2.jar").exists());
-        assertTrue(new File("build/cache/xerces/xerces/jars/xercesImpl-2.6.2.jar").exists());
+        assertTrue(FileUtil.newFile("build/cache/xerces/xerces/ivy-2.6.2.xml").exists());
+        assertTrue(FileUtil.newFile("build/cache/xerces/xerces/jars/xmlParserAPIs-2.6.2.jar").exists());
+        assertTrue(FileUtil.newFile("build/cache/xerces/xerces/jars/xercesImpl-2.6.2.jar").exists());
 
         // second with cache for ivy file only
-        new File("build/cache/xerces/xerces/jars/xmlParserAPIs-2.6.2.jar").delete();
-        new File("build/cache/xerces/xerces/jars/xercesImpl-2.6.2.jar").delete();
-        assertFalse(new File("build/cache/xerces/xerces/jars/xmlParserAPIs-2.6.2.jar").exists());
-        assertFalse(new File("build/cache/xerces/xerces/jars/xercesImpl-2.6.2.jar").exists());
+        FileUtil.newFile("build/cache/xerces/xerces/jars/xmlParserAPIs-2.6.2.jar").delete();
+        FileUtil.newFile("build/cache/xerces/xerces/jars/xercesImpl-2.6.2.jar").delete();
+        assertFalse(FileUtil.newFile("build/cache/xerces/xerces/jars/xmlParserAPIs-2.6.2.jar").exists());
+        assertFalse(FileUtil.newFile("build/cache/xerces/xerces/jars/xercesImpl-2.6.2.jar").exists());
         ivy.resolve(ResolveTest.class.getResource("ivy-dualchainresolver.xml"),
             getResolveOptions(new String[] {"default"}));
 
-        assertTrue(new File("build/cache/xerces/xerces/ivy-2.6.2.xml").exists());
-        assertTrue(new File("build/cache/xerces/xerces/jars/xmlParserAPIs-2.6.2.jar").exists());
-        assertTrue(new File("build/cache/xerces/xerces/jars/xercesImpl-2.6.2.jar").exists());
+        assertTrue(FileUtil.newFile("build/cache/xerces/xerces/ivy-2.6.2.xml").exists());
+        assertTrue(FileUtil.newFile("build/cache/xerces/xerces/jars/xmlParserAPIs-2.6.2.jar").exists());
+        assertTrue(FileUtil.newFile("build/cache/xerces/xerces/jars/xercesImpl-2.6.2.jar").exists());
     }
 
     public void testBug148() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/bug148/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/bug148/ivysettings.xml"));
         ivy.getSettings().setDefaultCache(cache);
 
         ivy.resolve(ResolveTest.class.getResource("ivy-148.xml"),
             getResolveOptions(new String[] {"*"}));
 
-        assertTrue(new File("build/cache/jtv-foo/bar/ivy-1.1.0.0.xml").exists());
-        assertTrue(new File("build/cache/jtv-foo/bar/jars/bar-1.1.0.0.jar").exists());
-        assertTrue(new File("build/cache/idautomation/barcode/ivy-4.10.xml").exists());
-        assertTrue(new File("build/cache/idautomation/barcode/jars/LinearBarCode-4.10.jar")
+        assertTrue(FileUtil.newFile("build/cache/jtv-foo/bar/ivy-1.1.0.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/cache/jtv-foo/bar/jars/bar-1.1.0.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/cache/idautomation/barcode/ivy-4.10.xml").exists());
+        assertTrue(FileUtil.newFile("build/cache/idautomation/barcode/jars/LinearBarCode-4.10.jar")
                 .exists());
     }
 
     public void testBug148b() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/bug148/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/bug148/ivysettings.xml"));
         ivy.getSettings().setDefaultCache(cache);
 
         ivy.resolve(ResolveTest.class.getResource("ivy-148b.xml"),
             getResolveOptions(new String[] {"*"}));
 
-        assertTrue(new File("build/cache/jtv-foo/bar/ivy-1.1.0.0.xml").exists());
-        assertTrue(new File("build/cache/jtv-foo/bar/jars/bar-1.1.0.0.jar").exists());
-        assertTrue(new File("build/cache/idautomation/barcode/ivy-4.10.xml").exists());
-        assertTrue(new File("build/cache/idautomation/barcode/jars/LinearBarCode-4.10.jar")
+        assertTrue(FileUtil.newFile("build/cache/jtv-foo/bar/ivy-1.1.0.0.xml").exists());
+        assertTrue(FileUtil.newFile("build/cache/jtv-foo/bar/jars/bar-1.1.0.0.jar").exists());
+        assertTrue(FileUtil.newFile("build/cache/idautomation/barcode/ivy-4.10.xml").exists());
+        assertTrue(FileUtil.newFile("build/cache/idautomation/barcode/jars/LinearBarCode-4.10.jar")
                 .exists());
     }
 
     public void testIVY1178() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-1178/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-1178/ivysettings.xml"));
         ResolveReport report = ivy.resolve(ResolveTest.class.getResource("ivy-1178.xml"),
             getResolveOptions(new String[] {"*"}));
 
@@ -3345,8 +3345,8 @@ public class ResolveTest extends TestCase {
 
     public void testIVY1236() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-1236/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-1236/ivy.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-1236/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-1236/ivy.xml"),
             getResolveOptions(new String[] {"*"}));
 
         assertNotNull(report);
@@ -3362,10 +3362,10 @@ public class ResolveTest extends TestCase {
 
     public void testIVY1233() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-1233/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-1233/ivysettings.xml"));
         ivy.getSettings().setDefaultCache(cache);
 
-        ResolveReport rr = ivy.resolve(new File("test/repositories/IVY-1233/ivy.xml"),
+        ResolveReport rr = ivy.resolve(FileUtil.newFile("test/repositories/IVY-1233/ivy.xml"),
             getResolveOptions(new String[] {"*"}));
         ConfigurationResolveReport crr = rr.getConfigurationReport("default");
         Set modRevIds = crr.getModuleRevisionIds();
@@ -3377,10 +3377,10 @@ public class ResolveTest extends TestCase {
 
     public void testIVY1333() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-1333/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-1333/ivysettings.xml"));
         ivy.getSettings().setDefaultCache(cache);
 
-        ResolveReport rr = ivy.resolve(new File("test/repositories/IVY-1333/ivy.xml"),
+        ResolveReport rr = ivy.resolve(FileUtil.newFile("test/repositories/IVY-1333/ivy.xml"),
             getResolveOptions(new String[] {"*"}));
         ConfigurationResolveReport crr = rr.getConfigurationReport("default");
         Set modRevIds = crr.getModuleRevisionIds();
@@ -3396,10 +3396,10 @@ public class ResolveTest extends TestCase {
 
     public void testIVY1347() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-1347/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-1347/ivysettings.xml"));
         ivy.getSettings().setDefaultCache(cache);
 
-        ResolveReport rr = ivy.resolve(new File(
+        ResolveReport rr = ivy.resolve(FileUtil.newFile(
                 "test/repositories/IVY-1347/childone/childtwo/ivy.xml"),
             getResolveOptions(new String[] {"*"}));
         ModuleDescriptor md = rr.getModuleDescriptor();
@@ -3415,7 +3415,7 @@ public class ResolveTest extends TestCase {
 
     public void testIVY999() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-999/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-999/ivysettings.xml"));
         ivy.getSettings().setDefaultCache(cache);
 
         ResolveReport rr = ivy.resolve(ResolveTest.class.getResource("ivy-999.xml"),
@@ -3429,9 +3429,9 @@ public class ResolveTest extends TestCase {
 
     public void testIVY1366() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-1366/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-1366/ivysettings.xml"));
 
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-1366/ivy.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-1366/ivy.xml"),
             new ResolveOptions().setConfs(new String[] {"runtime"}));
         assertFalse(report.hasError());
 
@@ -3444,34 +3444,34 @@ public class ResolveTest extends TestCase {
 
     public void testBadFiles() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/badfile/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/badfile/ivysettings.xml"));
 
         ResolveReport report = ivy.resolve(
-            new File("test/repositories/badfile/ivys/ivy-badorg.xml"),
+            FileUtil.newFile("test/repositories/badfile/ivys/ivy-badorg.xml"),
             getResolveOptions(new String[] {"*"}));
         assertTrue("bad org should have raised an error in report", report.hasError());
         assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").indexOf(
             "'badorg'") != -1);
 
-        report = ivy.resolve(new File("test/repositories/badfile/ivys/ivy-badmodule.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/badfile/ivys/ivy-badmodule.xml"),
             getResolveOptions(new String[] {"*"}));
         assertTrue("bad module should have raised an error in report", report.hasError());
         assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").indexOf(
             "'badmodule'") != -1);
 
-        report = ivy.resolve(new File("test/repositories/badfile/ivys/ivy-badbranch.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/badfile/ivys/ivy-badbranch.xml"),
             getResolveOptions(new String[] {"*"}));
         assertTrue("bad branch should have raised an error in report", report.hasError());
         assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").indexOf(
             "'badbranch'") != -1);
 
-        report = ivy.resolve(new File("test/repositories/badfile/ivys/ivy-badrevision.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/badfile/ivys/ivy-badrevision.xml"),
             getResolveOptions(new String[] {"*"}));
         assertTrue("bad revision should have raised an error in report", report.hasError());
         assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").indexOf(
             "'badrevision'") != -1);
 
-        report = ivy.resolve(new File("test/repositories/badfile/ivys/ivy-badxml.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/badfile/ivys/ivy-badxml.xml"),
             getResolveOptions(new String[] {"*"}));
         assertTrue("bad xml should have raised an error in report", report.hasError());
         assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").indexOf(
@@ -3481,7 +3481,7 @@ public class ResolveTest extends TestCase {
     public void testTransitiveSetting() throws Exception {
         // mod2.4 depends on mod1.1 with transitive set to false
         // mod1.1 depends on mod1.2, which should not be resolved because of the transitive setting
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.4/ivys/ivy-0.3.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -3507,7 +3507,7 @@ public class ResolveTest extends TestCase {
         // mod2.7 depends on mod1.1 and mod2.4
         // mod2.4 depends on mod1.1 with transitive set to false
         // mod1.1 depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.7/ivys/ivy-0.6.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
@@ -3531,7 +3531,7 @@ public class ResolveTest extends TestCase {
         // fake
         // dependency
         // file in cache
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.4/ivys/ivy-0.3.xml"),
             getResolveOptions(new String[] {"*"}));
 
@@ -3550,7 +3550,7 @@ public class ResolveTest extends TestCase {
     }
 
     public void testVisibility1() throws Exception {
-        ivy.resolve(new File("test/repositories/2/mod8.2/ivy-1.0.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/2/mod8.2/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
 
         assertFalse(getArchiveFileInCache("org8", "mod8.1", "1.0", "a-private", "txt", "txt")
@@ -3558,7 +3558,7 @@ public class ResolveTest extends TestCase {
     }
 
     public void testVisibility2() throws Exception {
-        ivy.resolve(new File("test/repositories/2/mod8.3/ivy-1.0.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/2/mod8.3/ivy-1.0.xml"),
             getResolveOptions(new String[] {"private"}));
 
         assertFalse(getArchiveFileInCache("org8", "mod8.1", "1.0", "a-private", "txt", "txt")
@@ -3567,7 +3567,7 @@ public class ResolveTest extends TestCase {
     }
 
     public void testVisibility3() throws Exception {
-        ivy.resolve(new File("test/repositories/2/mod8.4/ivy-1.0.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/2/mod8.4/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
 
         assertFalse(getArchiveFileInCache("org8", "mod8.1", "1.0", "a-private", "txt", "txt")
@@ -3576,7 +3576,7 @@ public class ResolveTest extends TestCase {
     }
 
     public void testVisibility4() throws Exception {
-        ivy.resolve(new File("test/repositories/2/mod8.4/ivy-1.1.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/2/mod8.4/ivy-1.1.xml"),
             getResolveOptions(new String[] {"*"}));
 
         assertTrue(getArchiveFileInCache("org8", "mod8.1", "1.1", "a-private", "txt", "txt")
@@ -3591,8 +3591,8 @@ public class ResolveTest extends TestCase {
 
     public void testConfigurationMapping1() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-84/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-84/tests/1/ivy.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-84/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-84/tests/1/ivy.xml"),
             getResolveOptions(new String[] {"*"}));
 
         ConfigurationResolveReport conf = report.getConfigurationReport("default");
@@ -3607,8 +3607,8 @@ public class ResolveTest extends TestCase {
 
     public void testConfigurationMapping2() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-84/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-84/tests/2/ivy.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-84/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-84/tests/2/ivy.xml"),
             getResolveOptions(new String[] {"*"}));
 
         ConfigurationResolveReport conf = report.getConfigurationReport("default");
@@ -3623,8 +3623,8 @@ public class ResolveTest extends TestCase {
 
     public void testConfigurationMapping3() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-84/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-84/tests/3/ivy.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-84/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-84/tests/3/ivy.xml"),
             getResolveOptions(new String[] {"buildtime"}));
 
         ConfigurationResolveReport conf = report.getConfigurationReport("buildtime");
@@ -3639,8 +3639,8 @@ public class ResolveTest extends TestCase {
 
     public void testConfigurationMapping4() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-84/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-84/tests/4/ivy.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-84/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-84/tests/4/ivy.xml"),
             getResolveOptions(new String[] {"default"}));
 
         ConfigurationResolveReport conf = report.getConfigurationReport("default");
@@ -3655,8 +3655,8 @@ public class ResolveTest extends TestCase {
 
     public void testConfigurationMapping5() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-84/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-84/tests/5/ivy.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-84/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-84/tests/5/ivy.xml"),
             getResolveOptions(new String[] {"*"}));
 
         ConfigurationResolveReport conf = report.getConfigurationReport("default");
@@ -3671,8 +3671,8 @@ public class ResolveTest extends TestCase {
 
     public void testConfigurationMapping6() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-84/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-84/tests/6/ivy.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-84/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-84/tests/6/ivy.xml"),
             getResolveOptions(new String[] {"default", "buildtime"}));
 
         ConfigurationResolveReport conf = report.getConfigurationReport("default");
@@ -3687,8 +3687,8 @@ public class ResolveTest extends TestCase {
 
     public void testConfigurationMapping7() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/IVY-84/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-84/tests/7/ivy.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-84/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-84/tests/7/ivy.xml"),
             getResolveOptions(new String[] {"buildtime", "default"}));
 
         ConfigurationResolveReport conf = report.getConfigurationReport("default");
@@ -3704,7 +3704,7 @@ public class ResolveTest extends TestCase {
     public void testIVY97() throws Exception {
         // mod9.2 depends on mod9.1 and mod1.2
         // mod9.1 depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org9/mod9.2/ivys/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -3726,7 +3726,7 @@ public class ResolveTest extends TestCase {
     }
 
     public void testResolveMultipleSameDependency() throws Exception {
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/multiple-same-deps/mod1/ivys/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
 
@@ -3756,7 +3756,7 @@ public class ResolveTest extends TestCase {
     public void testResolveTransitiveExcludesSimple() throws Exception {
         // mod2.5 depends on mod2.3 and excludes one artifact from mod2.1
         // mod2.3 depends on mod2.1
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.5/ivys/ivy-0.6.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -3781,7 +3781,7 @@ public class ResolveTest extends TestCase {
         // mod2.6 depends on mod2.3 and mod2.5
         // mod2.3 depends on mod2.1 and excludes art21B
         // mod2.5 depends on mod2.1 and excludes art21A
-        ivy.resolve(new File("test/repositories/1/org2/mod2.6/ivys/ivy-0.6.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/1/org2/mod2.6/ivys/ivy-0.6.xml"),
             getResolveOptions(new String[] {"*"}));
 
         assertTrue(getArchiveFileInCache("org2", "mod2.1", "0.3", "art21A", "jar", "jar").exists());
@@ -3792,7 +3792,7 @@ public class ResolveTest extends TestCase {
         // mod2.6 depends on mod2.3 and mod2.5
         // mod2.3 depends on mod2.1 and excludes art21B
         // mod2.5 depends on mod2.1 and excludes art21B
-        ivy.resolve(new File("test/repositories/1/org2/mod2.6/ivys/ivy-0.7.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/1/org2/mod2.6/ivys/ivy-0.7.xml"),
             getResolveOptions(new String[] {"*"}));
 
         assertTrue(getArchiveFileInCache("org2", "mod2.1", "0.3", "art21A", "jar", "jar").exists());
@@ -3803,7 +3803,7 @@ public class ResolveTest extends TestCase {
         // mod2.6 depends on mod2.3 and mod2.5 and on mod2.1 for which it excludes art21A
         // mod2.3 depends on mod2.1 and excludes art21B
         // mod2.5 depends on mod2.1 and excludes art21B
-        ivy.resolve(new File("test/repositories/1/org2/mod2.6/ivys/ivy-0.8.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/1/org2/mod2.6/ivys/ivy-0.8.xml"),
             getResolveOptions(new String[] {"*"}));
 
         assertTrue(getArchiveFileInCache("org2", "mod2.1", "0.3", "art21A", "jar", "jar").exists());
@@ -3813,7 +3813,7 @@ public class ResolveTest extends TestCase {
     public void testResolveTransitiveExcludes2() throws Exception {
         // mod2.6 depends on mod2.3 for which it excludes art21A
         // mod2.3 depends on mod2.1 and excludes art21B
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.6/ivys/ivy-0.9.xml"),
             getResolveOptions(new String[] {"*"}));
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -3827,7 +3827,7 @@ public class ResolveTest extends TestCase {
     public void testResolveExcludesModule() throws Exception {
         // mod2.6 depends on mod2.1 and excludes mod1.1
         // mod2.1 depends on mod1.1 which depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.6/ivys/ivy-0.10.xml"),
             getResolveOptions(new String[] {"*"}));
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -3845,7 +3845,7 @@ public class ResolveTest extends TestCase {
     public void testResolveExcludesModuleWide() throws Exception {
         // mod2.6 depends on mod2.1 and excludes mod1.1 module wide
         // mod2.1 depends on mod1.1 which depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.6/ivys/ivy-0.11.xml"),
             getResolveOptions(new String[] {"*"}));
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -3864,7 +3864,7 @@ public class ResolveTest extends TestCase {
         // mod2.6 depends on mod2.3 in conf default and mod2.5 in conf exclude
         // mod2.5 depends on mod2.3
         // mod2.6 globally exclude mod2.3 in conf exclude
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.6/ivys/ivy-0.13.xml"),
             getResolveOptions(new String[] {"include"}));
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -3877,7 +3877,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveExcludesConf2() throws Exception {
         // same as testResolveExcludesConf
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.6/ivys/ivy-0.13.xml"),
             getResolveOptions(new String[] {"exclude"}));
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -3889,7 +3889,7 @@ public class ResolveTest extends TestCase {
     }
 
     public void testResolveExcludesConf3() throws Exception {
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.6/ivys/ivy-0.14.xml"),
             getResolveOptions(new String[] {"exclude"}));
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -3902,7 +3902,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveExceptConfiguration() throws Exception {
         // mod10.2 depends on mod5.1 conf *, !A
-        ivy.resolve(new File("test/repositories/2/mod10.2/ivy-2.0.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/2/mod10.2/ivy-2.0.xml"),
             getResolveOptions(new String[] {"*"}));
 
         assertFalse(getArchiveFileInCache("org5", "mod5.1", "4.1", "art51A", "jar", "jar").exists());
@@ -3914,7 +3914,7 @@ public class ResolveTest extends TestCase {
         // mod5.1;4.4 -> mod1.2;2.0 (B,xplatform->default)
         // mod5.1;4.4 -> mod2.2;0.9 (B,windows->myconf1;B,linux->myconf2)
         // mod5.1;4.4 -> mod2.1;0.5 (B,windows->A+B)
-        ivy.resolve(new File("test/repositories/2/mod5.2/ivy-3.0.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/2/mod5.2/ivy-3.0.xml"),
             getResolveOptions(new String[] {"A"}));
 
         assertTrue(getArchiveFileInCache("org5", "mod5.1", "4.4", "art51A", "jar", "jar").exists());
@@ -3928,7 +3928,7 @@ public class ResolveTest extends TestCase {
         // mod5.1;4.4 -> mod1.2;2.0 (B,xplatform->default)
         // mod5.1;4.4 -> mod2.2;0.9 (B,windows->myconf1;B,linux->myconf2)
         // mod5.1;4.4 -> mod2.1;0.5 (B,windows->A+B)
-        ivy.resolve(new File("test/repositories/2/mod5.2/ivy-3.0.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/2/mod5.2/ivy-3.0.xml"),
             getResolveOptions(new String[] {"B"}));
 
         assertFalse(getArchiveFileInCache("org5", "mod5.1", "4.4", "art51A", "jar", "jar").exists());
@@ -3948,7 +3948,7 @@ public class ResolveTest extends TestCase {
         // mod5.1;4.4 -> mod1.2;2.0 (B,xplatform->default)
         // mod5.1;4.4 -> mod2.2;0.9 (B,windows->myconf1;B,linux->myconf2)
         // mod5.1;4.4 -> mod2.1;0.5 (B,windows->A+B)
-        ivy.resolve(new File("test/repositories/2/mod5.2/ivy-3.0.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/2/mod5.2/ivy-3.0.xml"),
             getResolveOptions(new String[] {"B+windows"}));
 
         assertFalse(getArchiveFileInCache("org5", "mod5.1", "4.4", "art51A", "jar", "jar").exists());
@@ -3970,7 +3970,7 @@ public class ResolveTest extends TestCase {
         // mod5.1;4.4 -> mod2.2;0.9 (B,windows->myconf1;B,linux->myconf2)
         // mod5.1;4.4 -> mod2.1;0.5 (B,windows->A+B)
         // mod5.1;4.4 -> mod2.8;0.6 (windows,linux->@+thread+debug;A,B->*)
-        ivy.resolve(new File("test/repositories/2/mod5.2/ivy-3.0.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/2/mod5.2/ivy-3.0.xml"),
             getResolveOptions(new String[] {"B+linux"}));
 
         assertFalse(getArchiveFileInCache("org5", "mod5.1", "4.4", "art51A", "jar", "jar").exists());
@@ -4001,7 +4001,7 @@ public class ResolveTest extends TestCase {
         // mod5.1;4.5 -> mod2.2;0.9 (B,windows->myconf1;B,linux->myconf2)
         // mod5.1;4.5 -> mod2.1;0.5 (B,windows->A+B)
         // mod5.1;4.5 -> mod2.8;0.6 (windows,linux->@+thread+debug;A,B->*)
-        ivy.resolve(new File("test/repositories/2/mod5.2/ivy-3.1.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/2/mod5.2/ivy-3.1.xml"),
             getResolveOptions(new String[] {"B+linux"}));
 
         assertFalse(getArchiveFileInCache("org5", "mod5.1", "4.5", "art51A", "jar", "jar").exists());
@@ -4028,7 +4028,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveFallbackConfiguration() throws Exception {
         // mod10.2 depends on mod5.1 conf runtime(default)
-        ivy.resolve(new File("test/repositories/2/mod10.2/ivy-1.0.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/2/mod10.2/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
 
         assertTrue(getArchiveFileInCache("org5", "mod5.1", "4.0", "art51A", "jar", "jar").exists());
@@ -4036,7 +4036,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveFallbackConfiguration2() throws Exception {
         // mod10.2 depends on mod5.1 conf runtime(*)
-        ivy.resolve(new File("test/repositories/2/mod10.2/ivy-1.1.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/2/mod10.2/ivy-1.1.xml"),
             getResolveOptions(new String[] {"*"}));
 
         assertTrue(getArchiveFileInCache("org5", "mod5.1", "4.0", "art51A", "jar", "jar").exists());
@@ -4045,7 +4045,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveFallbackConfiguration3() throws Exception {
         // mod10.2 depends on mod5.1 conf runtime(*),compile(*)
-        ivy.resolve(new File("test/repositories/2/mod10.2/ivy-1.2.xml"),
+        ivy.resolve(FileUtil.newFile("test/repositories/2/mod10.2/ivy-1.2.xml"),
             getResolveOptions(new String[] {"*"}));
 
         assertTrue(getArchiveFileInCache("org5", "mod5.1", "4.0", "art51A", "jar", "jar").exists());
@@ -4054,7 +4054,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveFallbackConfiguration4() throws Exception {
         // mod10.2 depends on mod5.1 conf runtime()
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod10.2/ivy-1.3.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod10.2/ivy-1.3.xml"),
             getResolveOptions(new String[] {"*"}));
         assertFalse(report.hasError());
 
@@ -4065,8 +4065,8 @@ public class ResolveTest extends TestCase {
     public void testResolveMaven2() throws Exception {
         // test3 depends on test2 which depends on test
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File(
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/m2/org/apache/test3/1.0/test3-1.0.pom"),
             getResolveOptions(new String[] {"test"}));
         assertNotNull(report);
@@ -4091,8 +4091,8 @@ public class ResolveTest extends TestCase {
 
     public void testResolveMaven2WithConflict() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File(
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/m2/org/apache/test3/1.1/test3-1.1.pom"),
             getResolveOptions(new String[] {"default"}));
         assertFalse(report.hasError());
@@ -4115,7 +4115,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveMaven2WithConflict2() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
         ResolveReport report = ivy.resolve(ResolveTest.class.getResource("ivy-874.xml"),
             getResolveOptions(new String[] {"default"}));
         assertFalse(report.hasError());
@@ -4132,10 +4132,10 @@ public class ResolveTest extends TestCase {
         // Same as testResolveMaven2 but with a relocated module pointing to the module
         // used in testResolveMaven2.
         ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
         ivy.pushContext();
         try {
-            ResolveReport report = ivy.resolve(new File(
+            ResolveReport report = ivy.resolve(FileUtil.newFile(
                     "test/repositories/m2/org/relocated/test3/1.0/test3-1.0.pom"),
                 getResolveOptions(new String[] {"*"}));
             assertNotNull(report);
@@ -4159,10 +4159,10 @@ public class ResolveTest extends TestCase {
         // Same as testResolveMaven2 but with a relocated module pointing to the module
         // used in testResolveMaven2.
         ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
         ivy.pushContext();
         try {
-            ResolveReport report = ivy.resolve(new File(
+            ResolveReport report = ivy.resolve(FileUtil.newFile(
                     "test/repositories/m2/org/relocated/test3full/1.1/test3full-1.1.pom"),
                 getResolveOptions(new String[] {"*"}));
             assertNotNull(report);
@@ -4184,10 +4184,10 @@ public class ResolveTest extends TestCase {
 
     public void testResolveVesionRelocationChainedWithGroupRelocation() throws Exception {
         ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
         ivy.pushContext();
         try {
-            ResolveReport report = ivy.resolve(new File(
+            ResolveReport report = ivy.resolve(FileUtil.newFile(
                     "test/repositories/m2/org/relocated/test3/1.1/test3-1.1.pom"),
                 getResolveOptions(new String[] {"*"}));
             assertNotNull(report);
@@ -4209,10 +4209,10 @@ public class ResolveTest extends TestCase {
 
     public void testResolveTransitivelyToRelocatedPom() throws Exception {
         ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
         ivy.pushContext();
         try {
-            ResolveReport report = ivy.resolve(new File(
+            ResolveReport report = ivy.resolve(FileUtil.newFile(
                     "test/repositories/m2/org/relocated/testRelocationUser/1.0/"
                             + "testRelocationUser-1.0.pom"),
                 getResolveOptions(new String[] {"compile"}));
@@ -4235,10 +4235,10 @@ public class ResolveTest extends TestCase {
 
     public void testResolveTransitivelyToPomRelocatedToNewVersion() throws Exception {
         ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
         ivy.pushContext();
         try {
-            ResolveReport report = ivy.resolve(new File(
+            ResolveReport report = ivy.resolve(FileUtil.newFile(
                     "test/repositories/m2/org/relocated/testRelocationUser/1.1/"
                             + "testRelocationUser-1.1.pom"),
                 getResolveOptions(new String[] {"compile"}));
@@ -4263,8 +4263,8 @@ public class ResolveTest extends TestCase {
         // test case for IVY-418
         // test-classifier depends on test-classified with classifier asl
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File(
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/m2/org/apache/test-classifier/1.0/test-classifier-1.0.pom"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -4290,8 +4290,8 @@ public class ResolveTest extends TestCase {
         // test case for IVY-1041
         // test-classifier depends on test-classified with classifier asl
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File(
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/m2/org/apache/test-classifier/2.0/test-classifier-2.0.pom"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -4315,7 +4315,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveMaven2GetSources() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
         ResolveReport report = ivy.resolve(
             ResolveTest.class.getResource("ivy-m2-with-sources.xml"),
             getResolveOptions(new String[] {"*"}));
@@ -4337,7 +4337,7 @@ public class ResolveTest extends TestCase {
     public void testResolveMaven2GetSourcesWithSrcClassifier() throws Exception {
         // IVY-1138
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
         ResolveReport report = ivy.resolve(ResolveTest.class.getResource("ivy-m2-with-src.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -4356,7 +4356,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveMaven2GetSourcesAndJavadocAuto() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
         ResolveReport report = ivy.resolve(
             ResolveTest.class.getResource("ivy-m2-with-sources-and-javadoc-auto.xml"),
             getResolveOptions(new String[] {"*"}));
@@ -4382,8 +4382,8 @@ public class ResolveTest extends TestCase {
 
     public void testResolveMaven2WithVersionProperty() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File(
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/m2/org/apache/test-version/1.0/test-version-1.0.pom"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -4411,10 +4411,10 @@ public class ResolveTest extends TestCase {
         // it's version is listed
         // as 1.0 in parent2 (dependencies inherited from parent comes after).
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/parentPom/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/parentPom/ivysettings.xml"));
         ivy.getSettings().setDefaultResolver("parentChain");
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/parentPom/org/apache/dm/test/1.0/test-1.0.pom"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -4464,7 +4464,7 @@ public class ResolveTest extends TestCase {
     public void testResolveMaven2ParentPomWithNamespace() throws Exception {
         // Cfr IVY-1186
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/parentPom/ivysettings-namespace.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/parentPom/ivysettings-namespace.xml"));
 
         ResolveReport report = ivy.resolve(
             ModuleRevisionId.newInstance("org.apache.systemDm", "test", "1.0"),
@@ -4522,10 +4522,10 @@ public class ResolveTest extends TestCase {
 
         // now run tests with dual resolver
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/parentPom/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/parentPom/ivysettings.xml"));
         ivy.getSettings().setDefaultResolver("parentDual");
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/parentPom/org/apache/dm/test/1.0/test-1.0.pom"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -4585,10 +4585,10 @@ public class ResolveTest extends TestCase {
         // version,
         // and thus we should get test4;1.0
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/parentPom/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/parentPom/ivysettings.xml"));
         ivy.getSettings().setDefaultResolver("parentChain");
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/parentPom/org/apache/dm/test/2.0/test-2.0.pom"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -4620,10 +4620,10 @@ public class ResolveTest extends TestCase {
     public void testResolveMaven2ParentPomDependencyManagementWithImport() throws Exception {
         // IVY-1376
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/parentPom/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/parentPom/ivysettings.xml"));
         ivy.getSettings().setDefaultResolver("parentChain");
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/parentPom/org/apache/dm/test/3.0/test-3.0.pom"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -4649,8 +4649,8 @@ public class ResolveTest extends TestCase {
         // here we test maven SNAPSHOT versions handling,
         // with m2 snapshotRepository/uniqueVersion set to true
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File(
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/m2/org/apache/test4/1.0/test4-1.0.pom"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -4670,7 +4670,7 @@ public class ResolveTest extends TestCase {
         // with m2 snapshotRepository/uniqueVersion set to true
         // but retrieving by latest.integration
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
         ResolveReport report = ivy.resolve(
             ModuleRevisionId.newInstance("org.apache", "test-SNAPSHOT1", "latest.integration"),
             getResolveOptions(new String[] {"*(public)"}), true);
@@ -4690,8 +4690,8 @@ public class ResolveTest extends TestCase {
         // here we test maven SNAPSHOT versions handling,
         // without m2 snapshotRepository/uniqueVersion set to true
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File(
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/m2/org/apache/test4/1.1/test4-1.1.pom"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -4711,7 +4711,7 @@ public class ResolveTest extends TestCase {
         // with m2 snapshotRepository/uniqueVersion set to true
         // but retrieving by latest.integration
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml"));
         ResolveReport report = ivy.resolve(
             ModuleRevisionId.newInstance("org.apache", "test-SNAPSHOT2", "latest.integration"),
             getResolveOptions(new String[] {"*(public)"}), true);
@@ -4729,7 +4729,7 @@ public class ResolveTest extends TestCase {
     public void testNamespaceMapping() throws Exception {
         // the dependency is in another namespace
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/namespace/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/namespace/ivysettings.xml"));
         ResolveReport report = ivy.resolve(ResolveTest.class.getResource("ivy-namespace.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -4758,7 +4758,7 @@ public class ResolveTest extends TestCase {
         // the dependency is in another namespace and has itself a dependency on a module available
         // in the same namespace
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/namespace/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/namespace/ivysettings.xml"));
         ResolveReport report = ivy.resolve(ResolveTest.class.getResource("ivy-namespace2.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -4784,7 +4784,7 @@ public class ResolveTest extends TestCase {
     public void testNamespaceMapping3() throws Exception {
         // same as 2 but with poms
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/namespace/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/namespace/ivysettings.xml"));
         ResolveReport report = ivy.resolve(ResolveTest.class.getResource("ivy-namespace3.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -4811,7 +4811,7 @@ public class ResolveTest extends TestCase {
         // same as 2 but with incorrect dependency asked: the first ivy file asks for a dependency
         // in the resolver namespace and not the system one: this should fail
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/namespace/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/namespace/ivysettings.xml"));
         ResolveReport report = ivy.resolve(ResolveTest.class.getResource("ivy-namespace4.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -4826,7 +4826,7 @@ public class ResolveTest extends TestCase {
     public void testNamespaceMapping5() throws Exception {
         // Verifies that mapping version numbers works
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/namespace/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/namespace/ivysettings.xml"));
         ResolveReport report = ivy.resolve(ResolveTest.class.getResource("ivy-namespace5.xml"),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -4836,8 +4836,8 @@ public class ResolveTest extends TestCase {
 
     public void testIVY151() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/multirevisions/ivysettings.xml"));
-        ResolveReport report = ivy.resolve(new File("test/repositories/multirevisions/ivy.xml"),
+        ivy.configure(FileUtil.newFile("test/repositories/multirevisions/ivysettings.xml"));
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/multirevisions/ivy.xml"),
             getResolveOptions(new String[] {"compile", "test"}));
 
         assertNotNull(report);
@@ -4849,7 +4849,7 @@ public class ResolveTest extends TestCase {
     public void testCheckRevision() throws Exception {
         // mod12.2 depends on mod12.1 1.0 which depends on mod1.2
         // mod12.1 doesn't have revision in its ivy file
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod12.2/ivy-1.0.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod12.2/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
 
         assertTrue(report.hasError());
@@ -4870,7 +4870,7 @@ public class ResolveTest extends TestCase {
 
         ((BasicResolver) ivy.getSettings().getResolver("2-ivy")).setCheckconsistency(false);
 
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod12.2/ivy-1.0.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod12.2/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
 
         assertFalse(report.hasError());
@@ -4894,7 +4894,7 @@ public class ResolveTest extends TestCase {
         // moreover, mod13.1 depends on mod1.2 in with the following conf mapping: compile->default
         // thus conf j2ee should be empty for each modules
 
-        ResolveReport report = ivy.resolve(new File("test/repositories/2/mod13.3/ivy-1.0.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/2/mod13.3/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
 
         assertFalse(report.hasError());
@@ -4905,7 +4905,7 @@ public class ResolveTest extends TestCase {
 
     public void testExtraAttributes() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/extra-attributes/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/extra-attributes/ivysettings.xml"));
         ivy.getSettings().setDefaultCache(cache);
 
         FileSystemResolver fResolver = (FileSystemResolver) ivy.getSettings().getDefaultResolver();
@@ -4932,7 +4932,7 @@ public class ResolveTest extends TestCase {
     public void testExtraAttributes2() throws Exception {
         // test case for IVY-773
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/extra-attributes/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/extra-attributes/ivysettings.xml"));
         ivy.getSettings().setDefaultCache(cache);
         ivy.getSettings().validate();
 
@@ -4955,7 +4955,7 @@ public class ResolveTest extends TestCase {
         MockMessageLogger mockLogger = new MockMessageLogger();
         Ivy ivy = new Ivy();
         ivy.getLoggerEngine().setDefaultLogger(mockLogger);
-        ivy.configure(new File("test/repositories/extra-attributes/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/extra-attributes/ivysettings.xml"));
         ivy.getSettings().setDefaultCache(cache);
         ivy.getSettings().validate();
 
@@ -4971,7 +4971,7 @@ public class ResolveTest extends TestCase {
         // second test case for IVY-745: now we disable consistency checking, everything should work
         // fine
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/extra-attributes/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/extra-attributes/ivysettings.xml"));
         ivy.getSettings().setDefaultCache(cache);
         ((FileSystemResolver) ivy.getSettings().getResolver("default")).setCheckconsistency(false);
         ivy.getSettings().validate();
@@ -4989,7 +4989,7 @@ public class ResolveTest extends TestCase {
 
     public void testNamespaceExtraAttributes() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/extra-attributes/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/extra-attributes/ivysettings.xml"));
         ivy.getSettings().setDefaultCache(cache);
 
         ResolveReport report = ivy.resolve(ResolveTest.class.getResource("ivy-extra-att-ns.xml"),
@@ -5003,9 +5003,9 @@ public class ResolveTest extends TestCase {
 
     public void testBranches1() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/branches/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/branches/ivysettings.xml"));
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/branches/bar/bar1/trunk/1/ivy.xml"),
             getResolveOptions(new String[] {"*"}).setValidate(false));
         assertFalse(report.hasError());
@@ -5015,9 +5015,9 @@ public class ResolveTest extends TestCase {
 
     public void testBranches2() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/branches/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/branches/ivysettings.xml"));
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/branches/bar/bar1/trunk/2/ivy.xml"),
             getResolveOptions(new String[] {"*"}).setValidate(false));
         assertFalse(report.hasError());
@@ -5027,9 +5027,9 @@ public class ResolveTest extends TestCase {
 
     public void testBranches3() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/branches/ivysettings-defaultbranch1.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/branches/ivysettings-defaultbranch1.xml"));
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/branches/bar/bar1/trunk/1/ivy.xml"),
             getResolveOptions(new String[] {"*"}).setValidate(false));
         assertFalse(report.hasError());
@@ -5039,9 +5039,9 @@ public class ResolveTest extends TestCase {
 
     public void testBranches4() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/branches/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/branches/ivysettings.xml"));
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/branches/bar/bar1/trunk/3/ivy.xml"),
             getResolveOptions(new String[] {"*"}).setValidate(false));
         assertFalse(report.hasError());
@@ -5052,9 +5052,9 @@ public class ResolveTest extends TestCase {
 
     public void testBranches5() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/branches/ivysettings-fooonbranch1.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/branches/ivysettings-fooonbranch1.xml"));
 
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/branches/bar/bar1/trunk/3/ivy.xml"),
             getResolveOptions(new String[] {"*"}).setValidate(false));
         assertFalse(report.hasError());
@@ -5071,10 +5071,10 @@ public class ResolveTest extends TestCase {
         // foo#foo1#trunk;5 -> {}
 
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/branches/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/branches/ivysettings.xml"));
 
         ivy.setVariable("ivy.branch", "branch1");
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/branches/bar/bar1/trunk/4/ivy.xml"),
             getResolveOptions(new String[] {"*"}).setValidate(false));
         assertFalse(report.hasError());
@@ -5083,7 +5083,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache(ivy, "foo#foo2#branch1;1", "foo2", "jar", "jar").exists());
 
         ivy.setVariable("ivy.branch", "trunk");
-        report = ivy.resolve(new File("test/repositories/branches/bar/bar1/trunk/4/ivy.xml"),
+        report = ivy.resolve(FileUtil.newFile("test/repositories/branches/bar/bar1/trunk/4/ivy.xml"),
             getResolveOptions(new String[] {"*"}).setValidate(false));
         assertFalse(report.hasError());
         assertEquals(1, report.getConfigurationReport("default").getNodesNumber());
@@ -5093,11 +5093,11 @@ public class ResolveTest extends TestCase {
     public void testExternalArtifacts() throws Exception {
         Ivy ivy = Ivy.newInstance();
         ivy.getSettings().setVariable("test.base.url",
-            new File("test/repositories/external-artifacts").toURI().toURL().toExternalForm());
-        ivy.configure(new File("test/repositories/external-artifacts/ivysettings.xml"));
+            FileUtil.newFile("test/repositories/external-artifacts").toURI().toURL().toExternalForm());
+        ivy.configure(FileUtil.newFile("test/repositories/external-artifacts/ivysettings.xml"));
 
         ResolveReport report = ivy.resolve(
-            new File("test/repositories/external-artifacts/ivy.xml"),
+            FileUtil.newFile("test/repositories/external-artifacts/ivy.xml"),
             getResolveOptions(ivy.getSettings(), new String[] {"*"}).setValidate(false));
         assertFalse(report.hasError());
 
@@ -5108,7 +5108,7 @@ public class ResolveTest extends TestCase {
 
     public void testResolveWithMultipleIvyPatterns() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File("test/repositories/multi-ivypattern/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/multi-ivypattern/ivysettings.xml"));
 
         ModuleRevisionId module = ModuleRevisionId.newInstance("org1", "mod1.1", "1.+");
 
@@ -5127,7 +5127,7 @@ public class ResolveTest extends TestCase {
     }
 
     public void testPrivateConfigurationTransferWhenConflict() throws Exception {
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/orgConflictAndPrivateConf/root/ivys/ivy-1.0.xml"),
             getResolveOptions(new String[] {"assembly"}));
         assertFalse(report.hasError());
@@ -5263,7 +5263,7 @@ public class ResolveTest extends TestCase {
 
     public void testExtraAttributesForcedDependencies() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File(
+        ivy.configure(FileUtil.newFile(
                 "test/repositories/extra-attributes-forceddependencies/ivysettings-filerepo-attribs.xml"));
         ivy.getSettings().setDefaultCache(cache);
 
@@ -5289,7 +5289,7 @@ public class ResolveTest extends TestCase {
 
     public void testNoAttributesForcedDependencies() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File(
+        ivy.configure(FileUtil.newFile(
                 "test/repositories/extra-attributes-forceddependencies/ivysettings-filerepo-noattribs.xml"));
         ivy.getSettings().setDefaultCache(cache);
 
@@ -5314,7 +5314,7 @@ public class ResolveTest extends TestCase {
 
     public void testExtraAttributesMultipleDependenciesHang() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File(
+        ivy.configure(FileUtil.newFile(
                 "test/repositories/extra-attributes-multipledependencies/ivysettings-filerepo-attribs.xml"));
         ivy.getSettings().setDefaultCache(cache);
 
@@ -5326,7 +5326,7 @@ public class ResolveTest extends TestCase {
 
     public void testExtraAttributesMultipleDependenciesNoHang() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File(
+        ivy.configure(FileUtil.newFile(
                 "test/repositories/extra-attributes-multipledependencies/ivysettings-filerepo-noattribs.xml"));
         ivy.getSettings().setDefaultCache(cache);
 
@@ -5338,7 +5338,7 @@ public class ResolveTest extends TestCase {
 
     public void testExtraAttributesMultipleDependenciesHang2() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File(
+        ivy.configure(FileUtil.newFile(
                 "test/repositories/extra-attributes-multipledependencies/ivysettings-filerepo-attribs.xml"));
         ivy.getSettings().setDefaultCache(cache);
 
@@ -5350,7 +5350,7 @@ public class ResolveTest extends TestCase {
 
     public void testExtraAttributesMultipleDependenciesNoHang2() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(new File(
+        ivy.configure(FileUtil.newFile(
                 "test/repositories/extra-attributes-multipledependencies/ivysettings-filerepo-noattribs.xml"));
         ivy.getSettings().setDefaultCache(cache);
 
@@ -5375,7 +5375,7 @@ public class ResolveTest extends TestCase {
     public void testIVY1159_orderIsModAModB() throws Exception {
         testIVY1159("ivy-depsorder_modA_then_modB.xml", false);
 
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             ivy.getSettings(), deliveredIvyFile.toURI().toURL(), false);
@@ -5390,7 +5390,7 @@ public class ResolveTest extends TestCase {
     public void testIVY1159_orderIsModAModBReplaceForced() throws Exception {
         testIVY1159("ivy-depsorder_modA_then_modB.xml", true);
 
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             ivy.getSettings(), deliveredIvyFile.toURI().toURL(), false);
@@ -5405,7 +5405,7 @@ public class ResolveTest extends TestCase {
     public void testIVY1159_orderIsModBModA() throws Exception {
         testIVY1159("ivy-depsorder_modB_then_modA.xml", false);
 
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             ivy.getSettings(), deliveredIvyFile.toURI().toURL(), false);
@@ -5420,7 +5420,7 @@ public class ResolveTest extends TestCase {
     public void testIVY1159_orderIsModBModAReplaceForced() throws Exception {
         testIVY1159("ivy-depsorder_modB_then_modA.xml", true);
 
-        File deliveredIvyFile = new File("build/test/deliver/ivy-1.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/ivy-1.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             ivy.getSettings(), deliveredIvyFile.toURI().toURL(), false);
@@ -5434,7 +5434,7 @@ public class ResolveTest extends TestCase {
 
     private void testIVY1159(String modCIvyFile, boolean replaceForced) throws Exception {
         ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/IVY-1159/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-1159/ivysettings.xml"));
 
         ResolveOptions opts = new ResolveOptions();
         opts.setConfs(new String[] {"*"});
@@ -5442,7 +5442,7 @@ public class ResolveTest extends TestCase {
         opts.setRefresh(true);
         opts.setTransitive(true);
 
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-1159/" + modCIvyFile),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-1159/" + modCIvyFile),
             opts);
         assertFalse(report.hasError());
 
@@ -5467,14 +5467,14 @@ public class ResolveTest extends TestCase {
 
     public void testIVY1300() throws Exception {
         ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/IVY-1300/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-1300/ivysettings.xml"));
 
         ResolveOptions opts = new ResolveOptions();
         opts.setConfs(new String[] {"*"});
         opts.setResolveId("resolveid");
         opts.setTransitive(true);
 
-        ResolveReport report = ivy.resolve(new File("test/repositories/IVY-1300/assembly-ivy.xml"),
+        ResolveReport report = ivy.resolve(FileUtil.newFile("test/repositories/IVY-1300/assembly-ivy.xml"),
             opts);
         assertFalse(report.hasError());
 
@@ -5512,7 +5512,7 @@ public class ResolveTest extends TestCase {
 
         // now check that the resolve report has the same info as the delivered descriptor
 
-        File deliveredIvyFile = new File("build/test/deliver/assembly-1.xml");
+        File deliveredIvyFile = FileUtil.newFile("build/test/deliver/assembly-1.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             ivy.getSettings(), deliveredIvyFile.toURI().toURL(), false);
@@ -5526,7 +5526,7 @@ public class ResolveTest extends TestCase {
 
     public void testUseCacheOnly() throws Exception {
         ResolveOptions option = getResolveOptions(new String[] {"*"}).setValidate(false);
-        URL url = new File("test/repositories/1/usecacheonly/mod1/ivys/ivy-1.0.xml").toURI()
+        URL url = FileUtil.newFile("test/repositories/1/usecacheonly/mod1/ivys/ivy-1.0.xml").toURI()
                 .toURL();
 
         // normal resolve, the file goes in the cache
@@ -5590,7 +5590,7 @@ public class ResolveTest extends TestCase {
         ivy.getSettings().setDefaultUseOrigin(true);
         ivy.getSettings().setDefaultResolveMode("dynamic");
 
-        URL url = new File("test/repositories/1/usecacheonly/mod3/ivys/ivy-1.0.xml").toURI()
+        URL url = FileUtil.newFile("test/repositories/1/usecacheonly/mod3/ivys/ivy-1.0.xml").toURI()
                 .toURL();
 
         // normal resolve, the file goes in the cache
@@ -5607,7 +5607,7 @@ public class ResolveTest extends TestCase {
     public void testUnpack() throws Exception {
         ResolveOptions options = getResolveOptions(new String[] {"*"});
 
-        URL url = new File("test/repositories/1/packaging/module1/ivys/ivy-1.0.xml").toURI()
+        URL url = FileUtil.newFile("test/repositories/1/packaging/module1/ivys/ivy-1.0.xml").toURI()
                 .toURL();
 
         // normal resolve, the file goes in the cache

--- a/test/java/org/apache/ivy/core/resolve/ResolveTest.java
+++ b/test/java/org/apache/ivy/core/resolve/ResolveTest.java
@@ -252,7 +252,7 @@ public class ResolveTest extends TestCase {
                 .getAbsolutePath();
 
         ArtifactOrigin origin = getSavedArtifactOrigin(artifact);
-        File artInCache = new File(cache, getArchivePathInCache(artifact, origin));
+        File artInCache = FileUtil.newFile(cache, getArchivePathInCache(artifact, origin));
         assertFalse("should not download artifact in useOrigin mode.", artInCache.exists());
         assertEquals("location for artifact not correct.", expectedLocation,
             getArchiveFileInCache(artifact).getAbsolutePath());
@@ -831,19 +831,19 @@ public class ResolveTest extends TestCase {
         // dependencies
         assertTrue(getIvyFileInCache(ivy, ModuleRevisionId.newInstance("org1", "mod1.2", "2.0"))
                 .exists());
-        assertTrue(new File(cache, "mod1.2/ivy.xml").exists());
+        assertTrue(FileUtil.newFile(cache, "mod1.2/ivy.xml").exists());
         assertTrue(getArchiveFileInCache(ivy, "org1", "mod1.2", "2.0", "mod1.2", "jar", "jar")
                 .exists());
-        assertTrue(new File(cache, "mod1.2.jar").exists());
+        assertTrue(FileUtil.newFile(cache, "mod1.2.jar").exists());
     }
 
     public void testChangeCacheLayout2() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/ivysettings.xml"));
         ivy.getSettings().setDefaultRepositoryCacheBasedir(
-            new File(ivy.getSettings().getDefaultCache(), "repository").getAbsolutePath());
+            FileUtil.newFile(ivy.getSettings().getDefaultCache(), "repository").getAbsolutePath());
         ivy.getSettings().setDefaultResolutionCacheBasedir(
-            new File(ivy.getSettings().getDefaultCache(), "workspace").getAbsolutePath());
+            FileUtil.newFile(ivy.getSettings().getDefaultCache(), "workspace").getAbsolutePath());
         ivy.getSettings().validate();
         DefaultRepositoryCacheManager cacheMgr = (DefaultRepositoryCacheManager) ivy.getSettings()
                 .getDefaultRepositoryCacheManager();
@@ -871,10 +871,10 @@ public class ResolveTest extends TestCase {
         // dependencies
         assertTrue(getIvyFileInCache(ivy, ModuleRevisionId.newInstance("org1", "mod1.2", "2.0"))
                 .exists());
-        assertTrue(new File(cache, "repository/mod1.2/ivy.xml").exists());
+        assertTrue(FileUtil.newFile(cache, "repository/mod1.2/ivy.xml").exists());
         assertTrue(getArchiveFileInCache(ivy, "org1", "mod1.2", "2.0", "mod1.2", "jar", "jar")
                 .exists());
-        assertTrue(new File(cache, "repository/mod1.2.jar").exists());
+        assertTrue(FileUtil.newFile(cache, "repository/mod1.2.jar").exists());
     }
 
     public void testMultipleCache() throws Exception {
@@ -900,12 +900,12 @@ public class ResolveTest extends TestCase {
         // ivy file should be cached in default cache, and artifact in cache2
         assertTrue(cacheMgr1.getIvyFileInCache(depMrid).exists());
         assertFalse(cacheMgr1.getArchiveFileInCache(depArtifact).exists());
-        assertEquals(new File(cache, "repo1/mod1.1/ivy-1.0.xml").getCanonicalFile(), cacheMgr1
+        assertEquals(FileUtil.newFile(cache, "repo1/mod1.1/ivy-1.0.xml").getCanonicalFile(), cacheMgr1
                 .getIvyFileInCache(depMrid).getCanonicalFile());
 
         assertFalse(cacheMgr2.getIvyFileInCache(depMrid).exists());
         assertTrue(cacheMgr2.getArchiveFileInCache(depArtifact).exists());
-        assertEquals(new File(cache, "repo2/mod1.1-1.0/mod1.1.jar").getCanonicalFile(), cacheMgr2
+        assertEquals(FileUtil.newFile(cache, "repo2/mod1.1-1.0/mod1.1.jar").getCanonicalFile(), cacheMgr2
                 .getArchiveFileInCache(depArtifact).getCanonicalFile());
     }
 
@@ -2799,7 +2799,7 @@ public class ResolveTest extends TestCase {
         assertNotNull(crr);
         assertEquals(1, crr.getDownloadReports(depId).length);
 
-        File r = new File(cache, ResolveOptions.getDefaultResolveId(mrid.getModuleId()) + "-A.xml");
+        File r = FileUtil.newFile(cache, ResolveOptions.getDefaultResolveId(mrid.getModuleId()) + "-A.xml");
         assertTrue(r.exists());
         final boolean[] found = new boolean[] {false};
         SAXParser saxParser = SAXParserFactory.newInstance().newSAXParser();
@@ -4915,9 +4915,9 @@ public class ResolveTest extends TestCase {
             getResolveOptions(ivy.getSettings(), new String[] {"*"}).setValidate(false));
         assertFalse(report.hasError());
 
-        assertTrue(new File(cache, "apache/mymodule/task1/1854/ivy.xml").exists());
-        assertTrue(new File(cache, "apache/mymodule/task1/1854/mymodule-windows.jar").exists());
-        assertTrue(new File(cache, "apache/mymodule/task1/1854/mymodule-linux.jar").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/mymodule/task1/1854/ivy.xml").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/mymodule/task1/1854/mymodule-windows.jar").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/mymodule/task1/1854/mymodule-linux.jar").exists());
 
         Set moduleRevisions = report.getConfigurationReport("default").getModuleRevisionIds();
         assertEquals(1, moduleRevisions.size());
@@ -4940,14 +4940,14 @@ public class ResolveTest extends TestCase {
             getResolveOptions(ivy.getSettings(), new String[] {"*"}).setValidate(false));
         assertFalse(report.hasError());
 
-        assertTrue(new File(cache, "apache/mymodule/task2/1748/ivy.xml").exists());
-        assertTrue(new File(cache, "apache/mymodule/task2/1748/ivy.xml.original").exists());
-        assertTrue(new File(cache, "apache/mymodule/task2/1748/mymodule-windows.jar").exists());
-        assertTrue(new File(cache, "apache/mymodule/task2/1748/mymodule-linux.jar").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/mymodule/task2/1748/ivy.xml").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/mymodule/task2/1748/ivy.xml.original").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/mymodule/task2/1748/mymodule-windows.jar").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/mymodule/task2/1748/mymodule-linux.jar").exists());
 
-        assertTrue(new File(cache, "apache/module2/task2/1976/ivy.xml").exists());
-        assertTrue(new File(cache, "apache/module2/task2/1976/module2-windows.jar").exists());
-        assertTrue(new File(cache, "apache/module2/task2/1976/module2-linux.jar").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/module2/task2/1976/ivy.xml").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/module2/task2/1976/module2-windows.jar").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/module2/task2/1976/module2-linux.jar").exists());
     }
 
     public void testExtraAttributes3() throws Exception {
@@ -4981,10 +4981,10 @@ public class ResolveTest extends TestCase {
 
         assertFalse(report.hasError());
 
-        assertTrue(new File(cache, "apache/mymodule/task2/1749/ivy.xml").exists());
-        assertTrue(new File(cache, "apache/mymodule/task2/1749/ivy.xml.original").exists());
-        assertTrue(new File(cache, "apache/mymodule/task2/1749/mymodule-windows.jar").exists());
-        assertTrue(new File(cache, "apache/mymodule/task2/1749/mymodule-linux.jar").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/mymodule/task2/1749/ivy.xml").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/mymodule/task2/1749/ivy.xml.original").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/mymodule/task2/1749/mymodule-windows.jar").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/mymodule/task2/1749/mymodule-linux.jar").exists());
     }
 
     public void testNamespaceExtraAttributes() throws Exception {
@@ -4996,9 +4996,9 @@ public class ResolveTest extends TestCase {
             getResolveOptions(ivy.getSettings(), new String[] {"*"}).setValidate(true));
         assertFalse(report.hasError());
 
-        assertTrue(new File(cache, "apache/mymodule/task1/1855/ivy.xml").exists());
-        assertTrue(new File(cache, "apache/mymodule/task1/1855/mymodule-windows.jar").exists());
-        assertTrue(new File(cache, "apache/mymodule/task1/1855/mymodule-linux.jar").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/mymodule/task1/1855/ivy.xml").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/mymodule/task1/1855/mymodule-windows.jar").exists());
+        assertTrue(FileUtil.newFile(cache, "apache/mymodule/task1/1855/mymodule-linux.jar").exists());
     }
 
     public void testBranches1() throws Exception {
@@ -5275,7 +5275,7 @@ public class ResolveTest extends TestCase {
         ivy.deliver("1.0.0", deliverDir.getAbsolutePath() + "/ivy-1.0.0.xml", new DeliverOptions()
                 .setResolveId(report.getResolveId()).setValidate(false).setPubdate(new Date()));
 
-        File deliveredIvyFile = new File(deliverDir, "ivy-1.0.0.xml");
+        File deliveredIvyFile = FileUtil.newFile(deliverDir, "ivy-1.0.0.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             ivy.getSettings(), deliveredIvyFile.toURI().toURL(), false);
@@ -5301,7 +5301,7 @@ public class ResolveTest extends TestCase {
         ivy.deliver("1.0.0", deliverDir.getAbsolutePath() + "/ivy-1.0.0.xml", new DeliverOptions()
                 .setResolveId(report.getResolveId()).setValidate(false).setPubdate(new Date()));
 
-        File deliveredIvyFile = new File(deliverDir, "ivy-1.0.0.xml");
+        File deliveredIvyFile = FileUtil.newFile(deliverDir, "ivy-1.0.0.xml");
         assertTrue(deliveredIvyFile.exists());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             ivy.getSettings(), deliveredIvyFile.toURI().toURL(), false);
@@ -5616,16 +5616,16 @@ public class ResolveTest extends TestCase {
 
         ArtifactDownloadReport adr = report.getAllArtifactsReports()[0];
         File cacheDir = ivy.getSettings().getDefaultRepositoryCacheBasedir();
-        assertEquals(new File(cacheDir, "packaging/module2/jars/module2-1.0.jar"),
+        assertEquals(FileUtil.newFile(cacheDir, "packaging/module2/jars/module2-1.0.jar"),
             adr.getLocalFile());
-        assertEquals(new File(cacheDir, "packaging/module2/jar_unpackeds/module2-1.0"),
+        assertEquals(FileUtil.newFile(cacheDir, "packaging/module2/jar_unpackeds/module2-1.0"),
             adr.getUnpackedLocalFile());
 
         File[] jarContents = adr.getUnpackedLocalFile().listFiles();
         Arrays.sort(jarContents);
-        assertEquals(new File(adr.getUnpackedLocalFile(), "META-INF"), jarContents[0]);
-        assertEquals(new File(adr.getUnpackedLocalFile(), "test.txt"), jarContents[1]);
-        assertEquals(new File(adr.getUnpackedLocalFile(), "META-INF/MANIFEST.MF"),
+        assertEquals(FileUtil.newFile(adr.getUnpackedLocalFile(), "META-INF"), jarContents[0]);
+        assertEquals(FileUtil.newFile(adr.getUnpackedLocalFile(), "test.txt"), jarContents[1]);
+        assertEquals(FileUtil.newFile(adr.getUnpackedLocalFile(), "META-INF/MANIFEST.MF"),
             jarContents[0].listFiles()[0]);
     }
 }

--- a/test/java/org/apache/ivy/core/retrieve/RetrieveTest.java
+++ b/test/java/org/apache/ivy/core/retrieve/RetrieveTest.java
@@ -54,13 +54,13 @@ public class RetrieveTest extends TestCase {
 
     protected void setUp() throws Exception {
         ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
         createCache();
         Message.setDefaultLogger(new DefaultMessageLogger(Message.MSG_DEBUG));
     }
 
     private void createCache() {
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 
@@ -68,7 +68,7 @@ public class RetrieveTest extends TestCase {
         cleanCache();
         Delete del = new Delete();
         del.setProject(new Project());
-        del.setDir(new File("build/test/retrieve"));
+        del.setDir(FileUtil.newFile("build/test/retrieve"));
         del.execute();
     }
 
@@ -81,7 +81,7 @@ public class RetrieveTest extends TestCase {
 
     public void testRetrieveSimple() throws Exception {
         // mod1.1 depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").toURL(),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -101,7 +101,7 @@ public class RetrieveTest extends TestCase {
 
     public void testRetrieveSameFileConflict() throws Exception {
         // mod1.1 depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.4/ivys/ivy-1.0.1.xml").toURL(),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -118,7 +118,7 @@ public class RetrieveTest extends TestCase {
     }
 
     public void testRetrieveDifferentArtifactsOfSameModuleToSameFile() throws Exception {
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org2/mod2.2/ivys/ivy-0.5.xml").toURL(),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -138,7 +138,7 @@ public class RetrieveTest extends TestCase {
     }
 
     public void testEvent() throws Exception {
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").toURL(),
             getResolveOptions(new String[] {"*"}));
 
@@ -172,7 +172,7 @@ public class RetrieveTest extends TestCase {
 
     public void testRetrieveOverwrite() throws Exception {
         // mod1.1 depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").toURL(),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -189,13 +189,13 @@ public class RetrieveTest extends TestCase {
         ivy.retrieve(md.getModuleRevisionId(), pattern,
             getRetrieveOptions().setOverwriteMode("always"));
         assertEquals(
-            new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar").lastModified(),
+            FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar").lastModified(),
             file.lastModified());
     }
 
     public void testRetrieveWithSymlinks() throws Exception {
         // mod1.1 depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").toURL(),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -221,7 +221,7 @@ public class RetrieveTest extends TestCase {
         }
 
         // mod1.1 depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").toURI().toURL(),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -263,7 +263,7 @@ public class RetrieveTest extends TestCase {
     public void testRetrieveWithVariable() throws Exception {
         // mod1.1 depends on mod1.2
         ivy.setVariable("retrieve.dir", "retrieve");
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").toURL(),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -285,7 +285,7 @@ public class RetrieveTest extends TestCase {
 
     public void testRetrieveReport() throws Exception {
         // mod1.1 depends on mod1.2
-        ResolveReport report = ivy.resolve(new File(
+        ResolveReport report = ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/org20/mod20.1/ivys/ivy-1.2.xml").toURL(),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
@@ -313,7 +313,7 @@ public class RetrieveTest extends TestCase {
     public void testUnpack() throws Exception {
         ResolveOptions roptions = getResolveOptions(new String[] {"*"});
 
-        URL url = new File("test/repositories/1/packaging/module1/ivys/ivy-1.0.xml").toURI()
+        URL url = FileUtil.newFile("test/repositories/1/packaging/module1/ivys/ivy-1.0.xml").toURI()
                 .toURL();
 
         // normal resolve, the file goes in the cache
@@ -327,7 +327,7 @@ public class RetrieveTest extends TestCase {
         RetrieveOptions options = getRetrieveOptions();
         ivy.retrieve(md.getModuleRevisionId(), pattern, options);
 
-        File dest = new File("build/test/retrieve/packaging/module2/default/jars/module2-1.0");
+        File dest = FileUtil.newFile("build/test/retrieve/packaging/module2/default/jars/module2-1.0");
         assertTrue(dest.exists());
         assertTrue(dest.isDirectory());
         File[] jarContents = dest.listFiles();
@@ -340,7 +340,7 @@ public class RetrieveTest extends TestCase {
     public void testUnpackSync() throws Exception {
         ResolveOptions roptions = getResolveOptions(new String[] {"*"});
 
-        URL url = new File("test/repositories/1/packaging/module1/ivys/ivy-1.0.xml").toURI()
+        URL url = FileUtil.newFile("test/repositories/1/packaging/module1/ivys/ivy-1.0.xml").toURI()
                 .toURL();
 
         // normal resolve, the file goes in the cache
@@ -355,7 +355,7 @@ public class RetrieveTest extends TestCase {
         options.setSync(true);
         ivy.retrieve(md.getModuleRevisionId(), pattern, options);
 
-        File dest = new File("build/test/retrieve/packaging/module2/default/jars/module2-1.0");
+        File dest = FileUtil.newFile("build/test/retrieve/packaging/module2/default/jars/module2-1.0");
         assertTrue(dest.exists());
         assertTrue(dest.isDirectory());
         File[] jarContents = dest.listFiles();

--- a/test/java/org/apache/ivy/core/retrieve/RetrieveTest.java
+++ b/test/java/org/apache/ivy/core/retrieve/RetrieveTest.java
@@ -41,6 +41,7 @@ import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.report.ResolveReport;
 import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.util.DefaultMessageLogger;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 import org.apache.ivy.util.MockMessageLogger;
 import org.apache.tools.ant.Project;

--- a/test/java/org/apache/ivy/core/retrieve/RetrieveTest.java
+++ b/test/java/org/apache/ivy/core/retrieve/RetrieveTest.java
@@ -89,12 +89,12 @@ public class RetrieveTest extends TestCase {
 
         String pattern = "build/test/retrieve/[module]/[conf]/[artifact]-[revision].[ext]";
         ivy.retrieve(md.getModuleRevisionId(), pattern, getRetrieveOptions());
-        assertTrue(new File(IvyPatternHelper.substitute(pattern, "org1", "mod1.2", "2.0", "mod1.2",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(pattern, "org1", "mod1.2", "2.0", "mod1.2",
             "jar", "jar", "default")).exists());
 
         pattern = "build/test/retrieve/[module]/[conf]/[type]s/[artifact]-[revision].[ext]";
         ivy.retrieve(md.getModuleRevisionId(), pattern, getRetrieveOptions());
-        assertTrue(new File(IvyPatternHelper.substitute(pattern, "org1", "mod1.2", "2.0", "mod1.2",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(pattern, "org1", "mod1.2", "2.0", "mod1.2",
             "jar", "jar", "default")).exists());
     }
 
@@ -111,7 +111,7 @@ public class RetrieveTest extends TestCase {
         MockMessageLogger mockLogger = new MockMessageLogger();
         Message.setDefaultLogger(mockLogger);
         ivy.retrieve(md.getModuleRevisionId(), pattern, getRetrieveOptions());
-        assertTrue(new File(IvyPatternHelper.substitute(pattern, "org1", "mod1.2", "2.2", "mod1.2",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(pattern, "org1", "mod1.2", "2.2", "mod1.2",
             "jar", "jar", "default")).exists());
         mockLogger.assertLogDoesntContain("conflict on");
     }
@@ -181,7 +181,7 @@ public class RetrieveTest extends TestCase {
         String pattern = "build/test/retrieve/[module]/[conf]/[artifact]-[revision].[ext]";
 
         // we create a fake old file to see if it is overwritten
-        File file = new File(IvyPatternHelper.substitute(pattern, "org1", "mod1.2", "2.0",
+        File file = FileUtil.newFile(IvyPatternHelper.substitute(pattern, "org1", "mod1.2", "2.0",
             "mod1.2", "jar", "jar", "default")).getCanonicalFile();
         file.getParentFile().mkdirs();
         file.createNewFile();
@@ -244,7 +244,7 @@ public class RetrieveTest extends TestCase {
         // if the OS is known to support symlink, check that the file is a symlink,
         // otherwise just check the file exist.
 
-        File file = new File(filename);
+        File file = FileUtil.newFile(filename);
         assertTrue("The file " + filename + " doesn't exist", file.exists());
 
         String os = System.getProperty("os.name");
@@ -272,13 +272,13 @@ public class RetrieveTest extends TestCase {
         String pattern = "build/test/${retrieve.dir}/[module]/[conf]/[artifact]-[revision].[ext]";
         ivy.retrieve(md.getModuleRevisionId(), pattern, getRetrieveOptions());
         pattern = IvyPatternHelper.substituteVariable(pattern, "retrieve.dir", "retrieve");
-        assertTrue(new File(IvyPatternHelper.substitute(pattern, "org1", "mod1.2", "2.0", "mod1.2",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(pattern, "org1", "mod1.2", "2.0", "mod1.2",
             "jar", "jar", "default")).exists());
 
         pattern = "build/test/${retrieve.dir}/[module]/[conf]/[type]s/[artifact]-[revision].[ext]";
         ivy.retrieve(md.getModuleRevisionId(), pattern, getRetrieveOptions());
         pattern = IvyPatternHelper.substituteVariable(pattern, "retrieve.dir", "retrieve");
-        assertTrue(new File(IvyPatternHelper.substitute(pattern, "org1", "mod1.2", "2.0", "mod1.2",
+        assertTrue(FileUtil.newFile(IvyPatternHelper.substitute(pattern, "org1", "mod1.2", "2.0", "mod1.2",
             "jar", "jar", "default")).exists());
     }
 
@@ -331,9 +331,9 @@ public class RetrieveTest extends TestCase {
         assertTrue(dest.isDirectory());
         File[] jarContents = dest.listFiles();
         Arrays.sort(jarContents);
-        assertEquals(new File(dest, "META-INF"), jarContents[0]);
-        assertEquals(new File(dest, "test.txt"), jarContents[1]);
-        assertEquals(new File(dest, "META-INF/MANIFEST.MF"), jarContents[0].listFiles()[0]);
+        assertEquals(FileUtil.newFile(dest, "META-INF"), jarContents[0]);
+        assertEquals(FileUtil.newFile(dest, "test.txt"), jarContents[1]);
+        assertEquals(FileUtil.newFile(dest, "META-INF/MANIFEST.MF"), jarContents[0].listFiles()[0]);
     }
 
     public void testUnpackSync() throws Exception {
@@ -359,9 +359,9 @@ public class RetrieveTest extends TestCase {
         assertTrue(dest.isDirectory());
         File[] jarContents = dest.listFiles();
         Arrays.sort(jarContents);
-        assertEquals(new File(dest, "META-INF"), jarContents[0]);
-        assertEquals(new File(dest, "test.txt"), jarContents[1]);
-        assertEquals(new File(dest, "META-INF/MANIFEST.MF"), jarContents[0].listFiles()[0]);
+        assertEquals(FileUtil.newFile(dest, "META-INF"), jarContents[0]);
+        assertEquals(FileUtil.newFile(dest, "test.txt"), jarContents[1]);
+        assertEquals(FileUtil.newFile(dest, "META-INF/MANIFEST.MF"), jarContents[0].listFiles()[0]);
     }
 
     private RetrieveOptions getRetrieveOptions() {

--- a/test/java/org/apache/ivy/core/search/SearchTest.java
+++ b/test/java/org/apache/ivy/core/search/SearchTest.java
@@ -37,7 +37,7 @@ import org.apache.ivy.plugins.resolver.IBiblioResolver;
 public class SearchTest extends TestCase {
     public void testListInMavenRepo() throws Exception {
         Ivy ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml").toURI().toURL());
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml").toURI().toURL());
 
         Map otherTokenValues = new HashMap();
         otherTokenValues.put(IvyPatternHelper.ORGANISATION_KEY, "org.apache");
@@ -50,7 +50,7 @@ public class SearchTest extends TestCase {
 
     public void testListInMavenRepo2() throws Exception {
         Ivy ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/m2/ivysettings.xml").toURI().toURL());
+        ivy.configure(FileUtil.newFile("test/repositories/m2/ivysettings.xml").toURI().toURL());
         ((IBiblioResolver) ivy.getSettings().getResolver("m2")).setUseMavenMetadata(false);
 
         Map otherTokenValues = new HashMap();
@@ -64,7 +64,7 @@ public class SearchTest extends TestCase {
 
     public void testListModulesWithExtraAttributes() throws ParseException, IOException {
         Ivy ivy = Ivy.newInstance();
-        ivy.configure(new File("test/repositories/IVY-1128/ivysettings.xml"));
+        ivy.configure(FileUtil.newFile("test/repositories/IVY-1128/ivysettings.xml"));
         IvySettings settings = ivy.getSettings();
 
         Map extendedAttributes = new HashMap();

--- a/test/java/org/apache/ivy/core/search/SearchTest.java
+++ b/test/java/org/apache/ivy/core/search/SearchTest.java
@@ -33,6 +33,7 @@ import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.matcher.PatternMatcher;
 import org.apache.ivy.plugins.resolver.IBiblioResolver;
+import org.apache.ivy.util.FileUtil;
 
 public class SearchTest extends TestCase {
     public void testListInMavenRepo() throws Exception {

--- a/test/java/org/apache/ivy/core/settings/ConfigureTest.java
+++ b/test/java/org/apache/ivy/core/settings/ConfigureTest.java
@@ -27,6 +27,7 @@ import org.apache.ivy.Ivy;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
 import org.apache.ivy.plugins.resolver.IBiblioResolver;
 import org.apache.ivy.plugins.resolver.IvyRepResolver;
+import org.apache.ivy.util.FileUtil;
 
 public class ConfigureTest extends TestCase {
     public void testDefault() throws ParseException, IOException {

--- a/test/java/org/apache/ivy/core/settings/ConfigureTest.java
+++ b/test/java/org/apache/ivy/core/settings/ConfigureTest.java
@@ -56,7 +56,7 @@ public class ConfigureTest extends TestCase {
 
     public void testTypedefWithCustomClasspath() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.setVariable("ivy.custom.test.dir", new File("test/java/org/apache/ivy/core/settings")
+        ivy.setVariable("ivy.custom.test.dir", FileUtil.newFile("test/java/org/apache/ivy/core/settings")
                 .toURI().toURL().toString());
         ivy.configure(ConfigureTest.class.getResource("ivysettings-custom-typedef.xml"));
 
@@ -68,7 +68,7 @@ public class ConfigureTest extends TestCase {
     public void testTypedefWithCustomClasspathWithFile() throws Exception {
         Ivy ivy = new Ivy();
         ivy.setVariable("ivy.custom.test.dir",
-            new File("test/java/org/apache/ivy/core/settings").getAbsolutePath());
+            FileUtil.newFile("test/java/org/apache/ivy/core/settings").getAbsolutePath());
         ivy.configure(ConfigureTest.class.getResource("ivysettings-custom-typedef2.xml"));
 
         DependencyResolver custom = ivy.getSettings().getResolver("custom");

--- a/test/java/org/apache/ivy/core/settings/XmlSettingsParserTest.java
+++ b/test/java/org/apache/ivy/core/settings/XmlSettingsParserTest.java
@@ -592,8 +592,8 @@ public class XmlSettingsParserTest extends TestCase {
         assertNotNull(r);
         assertTrue(r instanceof PackagerResolver);
         PackagerResolver packager = (PackagerResolver) r;
-        assertEquals(new File(basedir, "packager/build"), packager.getBuildRoot());
-        assertEquals(new File(basedir, "packager/cache"), packager.getResourceCache());
+        assertEquals(FileUtil.newFile(basedir, "packager/build"), packager.getBuildRoot());
+        assertEquals(FileUtil.newFile(basedir, "packager/cache"), packager.getResourceCache());
     }
 
     public void testBaseDirVariables() throws Exception {
@@ -633,7 +633,7 @@ public class XmlSettingsParserTest extends TestCase {
     }
 
     private void assertLocationEquals(String expected, Object pattern) throws IOException {
-        assertEquals(new File(expected).getCanonicalFile(),
+        assertEquals(FileUtil.newFile(expected).getCanonicalFile(),
             new File((String) pattern).getCanonicalFile());
     }
 }

--- a/test/java/org/apache/ivy/core/settings/XmlSettingsParserTest.java
+++ b/test/java/org/apache/ivy/core/settings/XmlSettingsParserTest.java
@@ -48,6 +48,7 @@ import org.apache.ivy.plugins.resolver.packager.PackagerResolver;
 import org.apache.ivy.plugins.version.ChainVersionMatcher;
 import org.apache.ivy.plugins.version.MockVersionMatcher;
 import org.apache.ivy.plugins.version.VersionMatcher;
+import org.apache.ivy.util.FileUtil;
 
 /**
  * TODO write javadoc

--- a/test/java/org/apache/ivy/core/settings/XmlSettingsParserTest.java
+++ b/test/java/org/apache/ivy/core/settings/XmlSettingsParserTest.java
@@ -194,9 +194,9 @@ public class XmlSettingsParserTest extends TestCase {
         XmlSettingsParser parser = new XmlSettingsParser(settings);
         parser.parse(XmlSettingsParserTest.class.getResource("ivysettings-cache.xml"));
 
-        assertEquals(new File("repository").getCanonicalFile(), settings
+        assertEquals(FileUtil.newFile("repository").getCanonicalFile(), settings
                 .getDefaultRepositoryCacheBasedir().getCanonicalFile());
-        assertEquals(new File("resolution").getCanonicalFile(), settings
+        assertEquals(FileUtil.newFile("resolution").getCanonicalFile(), settings
                 .getDefaultResolutionCacheBasedir().getCanonicalFile());
         assertEquals("artifact-lock", settings.getDefaultLockStrategy().getName());
 
@@ -218,7 +218,7 @@ public class XmlSettingsParserTest extends TestCase {
             c.getTTL(ModuleRevisionId.newInstance("org2", "A", "A")));
         assertEquals(60 * 3600 * 1000, // 2d 12h = 60h
             c.getTTL(ModuleRevisionId.newInstance("org3", "A", "A")));
-        assertEquals(new File("mycache").getCanonicalFile(), c.getBasedir().getCanonicalFile());
+        assertEquals(FileUtil.newFile("mycache").getCanonicalFile(), c.getBasedir().getCanonicalFile());
         assertEquals(false, c.isUseOrigin());
         assertEquals("no-lock", c.getLockStrategy().getName());
 
@@ -229,7 +229,7 @@ public class XmlSettingsParserTest extends TestCase {
                 .getRepositoryCacheManager("mycache2");
         assertNotNull(c2);
         assertEquals("mycache2", c2.getName());
-        assertEquals(new File("repository").getCanonicalFile(), c2.getBasedir().getCanonicalFile());
+        assertEquals(FileUtil.newFile("repository").getCanonicalFile(), c2.getBasedir().getCanonicalFile());
         assertEquals("artifact-lock", c2.getLockStrategy().getName());
 
         assertEquals("[module]/ivys/ivy-[revision].xml", c2.getIvyPattern());
@@ -584,7 +584,7 @@ public class XmlSettingsParserTest extends TestCase {
 
     public void testFileAttribute() throws Exception {
         IvySettings settings = new IvySettings();
-        File basedir = new File("test").getAbsoluteFile();
+        File basedir = FileUtil.newFile("test").getAbsoluteFile();
         settings.setBaseDir(basedir);
         XmlSettingsParser parser = new XmlSettingsParser(settings);
         parser.parse(XmlSettingsParserTest.class.getResource("ivysettings-packager.xml"));
@@ -599,16 +599,16 @@ public class XmlSettingsParserTest extends TestCase {
 
     public void testBaseDirVariables() throws Exception {
         IvySettings settings = new IvySettings();
-        settings.setBaseDir(new File("test/base/dir"));
-        assertEquals(new File("test/base/dir").getAbsolutePath(), settings.getVariable("basedir"));
-        assertEquals(new File("test/base/dir").getAbsolutePath(),
+        settings.setBaseDir(FileUtil.newFile("test/base/dir"));
+        assertEquals(FileUtil.newFile("test/base/dir").getAbsolutePath(), settings.getVariable("basedir"));
+        assertEquals(FileUtil.newFile("test/base/dir").getAbsolutePath(),
             settings.getVariable("ivy.basedir"));
 
         settings = new IvySettings();
-        settings.setVariable("basedir", new File("other/base/dir").getAbsolutePath());
-        settings.setBaseDir(new File("test/base/dir"));
-        assertEquals(new File("other/base/dir").getAbsolutePath(), settings.getVariable("basedir"));
-        assertEquals(new File("test/base/dir").getAbsolutePath(),
+        settings.setVariable("basedir", FileUtil.newFile("other/base/dir").getAbsolutePath());
+        settings.setBaseDir(FileUtil.newFile("test/base/dir"));
+        assertEquals(FileUtil.newFile("other/base/dir").getAbsolutePath(), settings.getVariable("basedir"));
+        assertEquals(FileUtil.newFile("test/base/dir").getAbsolutePath(),
             settings.getVariable("ivy.basedir"));
     }
 
@@ -635,6 +635,6 @@ public class XmlSettingsParserTest extends TestCase {
 
     private void assertLocationEquals(String expected, Object pattern) throws IOException {
         assertEquals(FileUtil.newFile(expected).getCanonicalFile(),
-            new File((String) pattern).getCanonicalFile());
+            FileUtil.newFile((String) pattern).getCanonicalFile());
     }
 }

--- a/test/java/org/apache/ivy/osgi/core/AggregatedOSGiResolverTest.java
+++ b/test/java/org/apache/ivy/osgi/core/AggregatedOSGiResolverTest.java
@@ -40,6 +40,7 @@ import org.apache.ivy.osgi.repo.AbstractOSGiResolver.RequirementStrategy;
 import org.apache.ivy.osgi.repo.AggregatedOSGiResolver;
 import org.apache.ivy.osgi.updatesite.UpdateSiteResolver;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
+import org.apache.ivy.util.FileUtil;
 
 public class AggregatedOSGiResolverTest extends TestCase {
 

--- a/test/java/org/apache/ivy/osgi/core/AggregatedOSGiResolverTest.java
+++ b/test/java/org/apache/ivy/osgi/core/AggregatedOSGiResolverTest.java
@@ -57,27 +57,27 @@ public class AggregatedOSGiResolverTest extends TestCase {
         settings = new IvySettings();
 
         OBRResolver bundleResolver = new OBRResolver();
-        bundleResolver.setRepoXmlFile(new File("test/test-repo/bundlerepo/repo.xml")
+        bundleResolver.setRepoXmlFile(FileUtil.newFile("test/test-repo/bundlerepo/repo.xml")
                 .getAbsolutePath());
         bundleResolver.setName("bundle");
         bundleResolver.setSettings(settings);
         settings.addResolver(bundleResolver);
 
         UpdateSiteResolver updatesite = new UpdateSiteResolver();
-        updatesite.setUrl(new File("test/test-p2/ivyde-repo").toURI().toURL().toExternalForm());
+        updatesite.setUrl(FileUtil.newFile("test/test-p2/ivyde-repo").toURI().toURL().toExternalForm());
         updatesite.setName("updatesite");
         updatesite.setSettings(settings);
         settings.addResolver(updatesite);
 
         OBRResolver repo1 = new OBRResolver();
-        repo1.setRepoXmlFile(new File("test/test-repo/multi-osgi/repo1/obr.xml").getAbsolutePath());
+        repo1.setRepoXmlFile(FileUtil.newFile("test/test-repo/multi-osgi/repo1/obr.xml").getAbsolutePath());
         repo1.setName("repo1");
         repo1.setSettings(settings);
         repo1.setRequirementStrategy(RequirementStrategy.noambiguity);
         settings.addResolver(repo1);
 
         OBRResolver repo2 = new OBRResolver();
-        repo2.setRepoXmlFile(new File("test/test-repo/multi-osgi/repo2/obr.xml").getAbsolutePath());
+        repo2.setRepoXmlFile(FileUtil.newFile("test/test-repo/multi-osgi/repo2/obr.xml").getAbsolutePath());
         repo2.setName("repo2");
         repo2.setSettings(settings);
         repo2.setRequirementStrategy(RequirementStrategy.noambiguity);
@@ -94,7 +94,7 @@ public class AggregatedOSGiResolverTest extends TestCase {
 
         settings.setDefaultResolver("multiosgi");
 
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
         settings.setDefaultCache(cache);
 

--- a/test/java/org/apache/ivy/osgi/core/OSGiManifestParserTest.java
+++ b/test/java/org/apache/ivy/osgi/core/OSGiManifestParserTest.java
@@ -36,7 +36,7 @@ public class OSGiManifestParserTest extends AbstractModuleDescriptorParserTester
 
         settings = new IvySettings();
         // prevent test from polluting local cache
-        settings.setDefaultCache(new File("build/cache"));
+        settings.setDefaultCache(FileUtil.newFile("build/cache"));
     }
 
     public void testSimple() throws Exception {

--- a/test/java/org/apache/ivy/osgi/core/OSGiManifestParserTest.java
+++ b/test/java/org/apache/ivy/osgi/core/OSGiManifestParserTest.java
@@ -25,6 +25,7 @@ import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.parser.AbstractModuleDescriptorParserTester;
 import org.apache.ivy.util.DefaultMessageLogger;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 
 public class OSGiManifestParserTest extends AbstractModuleDescriptorParserTester {

--- a/test/java/org/apache/ivy/osgi/obr/OBRParserTest.java
+++ b/test/java/org/apache/ivy/osgi/obr/OBRParserTest.java
@@ -28,6 +28,7 @@ import org.apache.ivy.osgi.obr.xml.OBRXMLParser;
 import org.apache.ivy.osgi.repo.BundleRepoDescriptor;
 import org.apache.ivy.osgi.repo.ModuleDescriptorWrapper;
 import org.apache.ivy.util.CollectionUtils;
+import org.apache.ivy.util.FileUtil;
 
 public class OBRParserTest extends TestCase {
 

--- a/test/java/org/apache/ivy/osgi/obr/OBRParserTest.java
+++ b/test/java/org/apache/ivy/osgi/obr/OBRParserTest.java
@@ -35,7 +35,7 @@ public class OBRParserTest extends TestCase {
     private File testObr = FileUtil.newFile("test/test-obr");
 
     public void testParse() throws Exception {
-        BundleRepoDescriptor repo = OBRXMLParser.parse(testObr.toURI(), new FileInputStream(
+        BundleRepoDescriptor repo = OBRXMLParser.parse(testObr.toURI(), FileUtil.newInputStream(
                 FileUtil.newFile(testObr, "obr.xml")));
         assertNotNull(repo);
         assertEquals("OBR/Releases", repo.getName());
@@ -43,7 +43,7 @@ public class OBRParserTest extends TestCase {
     }
 
     public void testParseSource() throws Exception {
-        BundleRepoDescriptor repo = OBRXMLParser.parse(testObr.toURI(), new FileInputStream(
+        BundleRepoDescriptor repo = OBRXMLParser.parse(testObr.toURI(), FileUtil.newInputStream(
                 FileUtil.newFile(testObr, "sources.xml")));
         assertNotNull(repo);
         assertEquals(2, CollectionUtils.toList(repo.getModules()).size());

--- a/test/java/org/apache/ivy/osgi/obr/OBRParserTest.java
+++ b/test/java/org/apache/ivy/osgi/obr/OBRParserTest.java
@@ -35,7 +35,7 @@ public class OBRParserTest extends TestCase {
 
     public void testParse() throws Exception {
         BundleRepoDescriptor repo = OBRXMLParser.parse(testObr.toURI(), new FileInputStream(
-                new File(testObr, "obr.xml")));
+                FileUtil.newFile(testObr, "obr.xml")));
         assertNotNull(repo);
         assertEquals("OBR/Releases", repo.getName());
         assertEquals("1253581430652", repo.getLastModified());
@@ -43,7 +43,7 @@ public class OBRParserTest extends TestCase {
 
     public void testParseSource() throws Exception {
         BundleRepoDescriptor repo = OBRXMLParser.parse(testObr.toURI(), new FileInputStream(
-                new File(testObr, "sources.xml")));
+                FileUtil.newFile(testObr, "sources.xml")));
         assertNotNull(repo);
         assertEquals(2, CollectionUtils.toList(repo.getModules()).size());
         Iterator<ModuleDescriptorWrapper> itModule = repo.getModules();

--- a/test/java/org/apache/ivy/osgi/obr/OBRParserTest.java
+++ b/test/java/org/apache/ivy/osgi/obr/OBRParserTest.java
@@ -32,7 +32,7 @@ import org.apache.ivy.util.FileUtil;
 
 public class OBRParserTest extends TestCase {
 
-    private File testObr = new File("test/test-obr");
+    private File testObr = FileUtil.newFile("test/test-obr");
 
     public void testParse() throws Exception {
         BundleRepoDescriptor repo = OBRXMLParser.parse(testObr.toURI(), new FileInputStream(

--- a/test/java/org/apache/ivy/osgi/obr/OBRResolverTest.java
+++ b/test/java/org/apache/ivy/osgi/obr/OBRResolverTest.java
@@ -294,7 +294,7 @@ public class OBRResolverTest extends TestCase {
 
     private void genericTestResolve(String jarName, String conf, ModuleRevisionId[] expectedMrids,
             ModuleRevisionId[] expected2Mrids) throws Exception {
-        JarInputStream in = new JarInputStream(new FileInputStream("test/test-repo/bundlerepo/"
+        JarInputStream in = new JarInputStream(FileUtil.newInputStream("test/test-repo/bundlerepo/"
                 + jarName));
         BundleInfo bundleInfo = ManifestParser.parseManifest(in.getManifest());
         bundleInfo.addArtifact(new BundleArtifact(false, FileUtil.newFile("test/test-repo/bundlerepo/"
@@ -326,7 +326,7 @@ public class OBRResolverTest extends TestCase {
     }
 
     private void genericTestFailingResolve(String jarName, String conf) throws Exception {
-        JarInputStream in = new JarInputStream(new FileInputStream("test/test-repo/bundlerepo/"
+        JarInputStream in = new JarInputStream(FileUtil.newInputStream("test/test-repo/bundlerepo/"
                 + jarName));
         BundleInfo bundleInfo = ManifestParser.parseManifest(in.getManifest());
         bundleInfo.addArtifact(new BundleArtifact(false, FileUtil.newFile("test/test-repo/bundlerepo/"

--- a/test/java/org/apache/ivy/osgi/obr/OBRResolverTest.java
+++ b/test/java/org/apache/ivy/osgi/obr/OBRResolverTest.java
@@ -54,6 +54,7 @@ import org.apache.ivy.osgi.repo.AbstractOSGiResolver.RequirementStrategy;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
 import org.apache.ivy.plugins.resolver.DualResolver;
 import org.apache.ivy.plugins.resolver.FileSystemResolver;
+import org.apache.ivy.util.FileUtil;
 
 public class OBRResolverTest extends TestCase {
 

--- a/test/java/org/apache/ivy/osgi/obr/OBRResolverTest.java
+++ b/test/java/org/apache/ivy/osgi/obr/OBRResolverTest.java
@@ -104,14 +104,14 @@ public class OBRResolverTest extends TestCase {
         settings = new IvySettings();
 
         bundleResolver = new OBRResolver();
-        bundleResolver.setRepoXmlFile(new File("test/test-repo/bundlerepo/repo.xml")
+        bundleResolver.setRepoXmlFile(FileUtil.newFile("test/test-repo/bundlerepo/repo.xml")
                 .getAbsolutePath());
         bundleResolver.setName("bundle");
         bundleResolver.setSettings(settings);
         settings.addResolver(bundleResolver);
 
         bundleUrlResolver = new OBRResolver();
-        bundleUrlResolver.setRepoXmlURL(new File("test/test-repo/bundlerepo/repo.xml").toURI()
+        bundleUrlResolver.setRepoXmlURL(FileUtil.newFile("test/test-repo/bundlerepo/repo.xml").toURI()
                 .toURL().toExternalForm());
         bundleUrlResolver.setName("bundleurl");
         bundleUrlResolver.setSettings(settings);
@@ -119,12 +119,12 @@ public class OBRResolverTest extends TestCase {
 
         dualResolver = new DualResolver();
         OBRResolver resolver = new OBRResolver();
-        resolver.setRepoXmlFile(new File("test/test-repo/ivyrepo/repo.xml").getAbsolutePath());
+        resolver.setRepoXmlFile(FileUtil.newFile("test/test-repo/ivyrepo/repo.xml").getAbsolutePath());
         resolver.setName("dual-bundle");
         resolver.setSettings(settings);
         dualResolver.add(resolver);
         dualResolver.setName("dual");
-        File ivyrepo = new File("test/test-repo/ivyrepo");
+        File ivyrepo = FileUtil.newFile("test/test-repo/ivyrepo");
         FileSystemResolver fileSystemResolver = new FileSystemResolver();
         fileSystemResolver.addIvyPattern(ivyrepo.getAbsolutePath()
                 + "/[organisation]/[module]/[revision]/ivy.xml");
@@ -137,7 +137,7 @@ public class OBRResolverTest extends TestCase {
 
         settings.setDefaultResolver("bundle");
 
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
         settings.setDefaultCache(cache);
 
@@ -297,7 +297,7 @@ public class OBRResolverTest extends TestCase {
         JarInputStream in = new JarInputStream(new FileInputStream("test/test-repo/bundlerepo/"
                 + jarName));
         BundleInfo bundleInfo = ManifestParser.parseManifest(in.getManifest());
-        bundleInfo.addArtifact(new BundleArtifact(false, new File("test/test-repo/bundlerepo/"
+        bundleInfo.addArtifact(new BundleArtifact(false, FileUtil.newFile("test/test-repo/bundlerepo/"
                 + jarName).toURI(), null));
         DefaultModuleDescriptor md = BundleInfoAdapter.toModuleDescriptor(
             OSGiManifestParser.getInstance(), null, bundleInfo, profileProvider);
@@ -329,7 +329,7 @@ public class OBRResolverTest extends TestCase {
         JarInputStream in = new JarInputStream(new FileInputStream("test/test-repo/bundlerepo/"
                 + jarName));
         BundleInfo bundleInfo = ManifestParser.parseManifest(in.getManifest());
-        bundleInfo.addArtifact(new BundleArtifact(false, new File("test/test-repo/bundlerepo/"
+        bundleInfo.addArtifact(new BundleArtifact(false, FileUtil.newFile("test/test-repo/bundlerepo/"
                 + jarName).toURI(), null));
         DefaultModuleDescriptor md = BundleInfoAdapter.toModuleDescriptor(
             OSGiManifestParser.getInstance(), null, bundleInfo, profileProvider);

--- a/test/java/org/apache/ivy/osgi/obr/OBRXMLWriterTest.java
+++ b/test/java/org/apache/ivy/osgi/obr/OBRXMLWriterTest.java
@@ -56,8 +56,8 @@ public class OBRXMLWriterTest extends TestCase {
         bundle.addArtifact(new BundleArtifact(false, new URI("file:///test2.jar"), null));
         bundles.add(bundle);
 
-        new File("build/test-files").mkdirs();
-        File obrFile = new File("build/test-files/obr-sources.xml");
+        FileUtil.newFile("build/test-files").mkdirs();
+        File obrFile = FileUtil.newFile("build/test-files/obr-sources.xml");
         OutputStream out = FileUtil.newOutputStream(obrFile);
         try {
             ContentHandler hanlder = OBRXMLWriter.newHandler(out, "UTF-8", true);

--- a/test/java/org/apache/ivy/osgi/obr/OBRXMLWriterTest.java
+++ b/test/java/org/apache/ivy/osgi/obr/OBRXMLWriterTest.java
@@ -67,7 +67,7 @@ public class OBRXMLWriterTest extends TestCase {
             out.close();
         }
 
-        FileInputStream in = new FileInputStream(obrFile);
+        FileInputStream in = FileUtil.newInputStream(obrFile);
         BundleRepoDescriptor repo;
         try {
             repo = OBRXMLParser.parse(new URI("file:///test"), in);

--- a/test/java/org/apache/ivy/osgi/obr/OBRXMLWriterTest.java
+++ b/test/java/org/apache/ivy/osgi/obr/OBRXMLWriterTest.java
@@ -17,9 +17,7 @@
  */
 package org.apache.ivy.osgi.obr;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
+import java.io.*;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +33,7 @@ import org.apache.ivy.osgi.repo.BundleRepoDescriptor;
 import org.apache.ivy.osgi.repo.ModuleDescriptorWrapper;
 import org.apache.ivy.osgi.util.Version;
 import org.apache.ivy.util.CollectionUtils;
+import org.apache.ivy.util.FileUtil;
 import org.xml.sax.ContentHandler;
 
 public class OBRXMLWriterTest extends TestCase {
@@ -59,7 +58,7 @@ public class OBRXMLWriterTest extends TestCase {
 
         new File("build/test-files").mkdirs();
         File obrFile = new File("build/test-files/obr-sources.xml");
-        FileOutputStream out = FileUtil.newOutputStream(obrFile);
+        OutputStream out = FileUtil.newOutputStream(obrFile);
         try {
             ContentHandler hanlder = OBRXMLWriter.newHandler(out, "UTF-8", true);
             OBRXMLWriter.writeBundles(bundles, hanlder);
@@ -67,7 +66,7 @@ public class OBRXMLWriterTest extends TestCase {
             out.close();
         }
 
-        FileInputStream in = FileUtil.newInputStream(obrFile);
+        InputStream in = FileUtil.newInputStream(obrFile);
         BundleRepoDescriptor repo;
         try {
             repo = OBRXMLParser.parse(new URI("file:///test"), in);

--- a/test/java/org/apache/ivy/osgi/obr/OBRXMLWriterTest.java
+++ b/test/java/org/apache/ivy/osgi/obr/OBRXMLWriterTest.java
@@ -59,7 +59,7 @@ public class OBRXMLWriterTest extends TestCase {
 
         new File("build/test-files").mkdirs();
         File obrFile = new File("build/test-files/obr-sources.xml");
-        FileOutputStream out = new FileOutputStream(obrFile);
+        FileOutputStream out = FileUtil.newOutputStream(obrFile);
         try {
             ContentHandler hanlder = OBRXMLWriter.newHandler(out, "UTF-8", true);
             OBRXMLWriter.writeBundles(bundles, hanlder);

--- a/test/java/org/apache/ivy/osgi/p2/P2DescriptorTest.java
+++ b/test/java/org/apache/ivy/osgi/p2/P2DescriptorTest.java
@@ -36,6 +36,7 @@ import org.apache.ivy.core.resolve.ResolvedModuleRevision;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.osgi.core.BundleInfo;
 import org.apache.ivy.osgi.updatesite.UpdateSiteResolver;
+import org.apache.ivy.util.FileUtil;
 
 public class P2DescriptorTest extends TestCase {
 

--- a/test/java/org/apache/ivy/osgi/p2/P2DescriptorTest.java
+++ b/test/java/org/apache/ivy/osgi/p2/P2DescriptorTest.java
@@ -58,24 +58,24 @@ public class P2DescriptorTest extends TestCase {
 
         p2SourceResolver = new UpdateSiteResolver();
         p2SourceResolver.setName("p2-sources");
-        p2SourceResolver.setUrl(new File("test/test-p2/sources").toURI().toURL().toExternalForm());
+        p2SourceResolver.setUrl(FileUtil.newFile("test/test-p2/sources").toURI().toURL().toExternalForm());
         p2SourceResolver.setSettings(settings);
         settings.addResolver(p2SourceResolver);
 
         p2ZippedResolver = new UpdateSiteResolver();
         p2ZippedResolver.setName("p2-zipped");
-        p2ZippedResolver.setUrl(new File("test/test-p2/zipped").toURI().toURL().toExternalForm());
+        p2ZippedResolver.setUrl(FileUtil.newFile("test/test-p2/zipped").toURI().toURL().toExternalForm());
         p2ZippedResolver.setSettings(settings);
         settings.addResolver(p2ZippedResolver);
 
         p2WithPackedResolver = new UpdateSiteResolver();
         p2WithPackedResolver.setName("p2-with-packed");
-        p2WithPackedResolver.setUrl(new File("test/test-p2/packed").toURI().toURL()
+        p2WithPackedResolver.setUrl(FileUtil.newFile("test/test-p2/packed").toURI().toURL()
                 .toExternalForm());
         p2WithPackedResolver.setSettings(settings);
         settings.addResolver(p2WithPackedResolver);
 
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
         settings.setDefaultCache(cache);
 

--- a/test/java/org/apache/ivy/osgi/repo/BundleRepoTest.java
+++ b/test/java/org/apache/ivy/osgi/repo/BundleRepoTest.java
@@ -37,6 +37,7 @@ import org.apache.ivy.osgi.obr.xml.OBRXMLParser;
 import org.apache.ivy.osgi.obr.xml.OBRXMLWriter;
 import org.apache.ivy.plugins.repository.file.FileRepository;
 import org.apache.ivy.plugins.resolver.FileSystemResolver;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.BuildException;
 import org.xml.sax.SAXException;
 

--- a/test/java/org/apache/ivy/osgi/repo/BundleRepoTest.java
+++ b/test/java/org/apache/ivy/osgi/repo/BundleRepoTest.java
@@ -53,7 +53,7 @@ public class BundleRepoTest extends TestCase {
         repo.populate(it.iterator());
 
         BundleRepoDescriptor repo2 = OBRXMLParser.parse(bundlerepo.toURI(), new FileInputStream(
-                new File(bundlerepo, "repo.xml")));
+                FileUtil.newFile(bundlerepo, "repo.xml")));
 
         assertEquals(repo, repo2);
     }
@@ -66,7 +66,7 @@ public class BundleRepoTest extends TestCase {
         repo.populate(it.iterator());
 
         BundleRepoDescriptor repo2 = OBRXMLParser.parse(bundlerepo.toURI(), new FileInputStream(
-                new File(bundlerepo, "repo.xml")));
+                FileUtil.newFile(bundlerepo, "repo.xml")));
 
         assertEquals(repo, repo2);
     }
@@ -85,7 +85,7 @@ public class BundleRepoTest extends TestCase {
         repo.populate(it.iterator());
 
         BundleRepoDescriptor repo2 = OBRXMLParser.parse(ivyrepo.toURI(), new FileInputStream(
-                new File(ivyrepo, "repo.xml")));
+                FileUtil.newFile(ivyrepo, "repo.xml")));
 
         assertEquals(repo, repo2);
     }

--- a/test/java/org/apache/ivy/osgi/repo/BundleRepoTest.java
+++ b/test/java/org/apache/ivy/osgi/repo/BundleRepoTest.java
@@ -43,9 +43,9 @@ import org.xml.sax.SAXException;
 
 public class BundleRepoTest extends TestCase {
 
-    private File bundlerepo = new File("test/test-repo/bundlerepo");
+    private File bundlerepo = FileUtil.newFile("test/test-repo/bundlerepo");
 
-    private File ivyrepo = new File("test/test-repo/ivyrepo");
+    private File ivyrepo = FileUtil.newFile("test/test-repo/ivyrepo");
 
     public void testFS() throws Exception {
         FSManifestIterable it = new FSManifestIterable(bundlerepo);

--- a/test/java/org/apache/ivy/osgi/repo/BundleRepoTest.java
+++ b/test/java/org/apache/ivy/osgi/repo/BundleRepoTest.java
@@ -53,7 +53,7 @@ public class BundleRepoTest extends TestCase {
                 ExecutionEnvironmentProfileProvider.getInstance());
         repo.populate(it.iterator());
 
-        BundleRepoDescriptor repo2 = OBRXMLParser.parse(bundlerepo.toURI(), new FileInputStream(
+        BundleRepoDescriptor repo2 = OBRXMLParser.parse(bundlerepo.toURI(), FileUtil.newInputStream(
                 FileUtil.newFile(bundlerepo, "repo.xml")));
 
         assertEquals(repo, repo2);
@@ -66,7 +66,7 @@ public class BundleRepoTest extends TestCase {
                 ExecutionEnvironmentProfileProvider.getInstance());
         repo.populate(it.iterator());
 
-        BundleRepoDescriptor repo2 = OBRXMLParser.parse(bundlerepo.toURI(), new FileInputStream(
+        BundleRepoDescriptor repo2 = OBRXMLParser.parse(bundlerepo.toURI(), FileUtil.newInputStream(
                 FileUtil.newFile(bundlerepo, "repo.xml")));
 
         assertEquals(repo, repo2);
@@ -85,7 +85,7 @@ public class BundleRepoTest extends TestCase {
                 ExecutionEnvironmentProfileProvider.getInstance());
         repo.populate(it.iterator());
 
-        BundleRepoDescriptor repo2 = OBRXMLParser.parse(ivyrepo.toURI(), new FileInputStream(
+        BundleRepoDescriptor repo2 = OBRXMLParser.parse(ivyrepo.toURI(), FileUtil.newInputStream(
                 FileUtil.newFile(ivyrepo, "repo.xml")));
 
         assertEquals(repo, repo2);

--- a/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteAndIbiblioResolverTest.java
+++ b/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteAndIbiblioResolverTest.java
@@ -60,7 +60,7 @@ public class UpdateSiteAndIbiblioResolverTest extends TestCase {
 
         resolver = new UpdateSiteResolver();
         resolver.setName("ivyde-repo");
-        resolver.setUrl(new File("test/test-p2/ivyde-repo").toURI().toURL().toExternalForm());
+        resolver.setUrl(FileUtil.newFile("test/test-p2/ivyde-repo").toURI().toURL().toExternalForm());
         resolver.setSettings(settings);
 
         resolver2 = new IBiblioResolver();
@@ -77,7 +77,7 @@ public class UpdateSiteAndIbiblioResolverTest extends TestCase {
 
         settings.setDefaultResolver("chain");
 
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
         settings.setDefaultCache(cache);
 

--- a/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteAndIbiblioResolverTest.java
+++ b/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteAndIbiblioResolverTest.java
@@ -34,6 +34,7 @@ import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.osgi.core.BundleInfo;
 import org.apache.ivy.plugins.resolver.ChainResolver;
 import org.apache.ivy.plugins.resolver.IBiblioResolver;
+import org.apache.ivy.util.FileUtil;
 
 public class UpdateSiteAndIbiblioResolverTest extends TestCase {
 

--- a/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteLoaderTest.java
+++ b/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteLoaderTest.java
@@ -33,6 +33,7 @@ import org.apache.ivy.osgi.repo.ModuleDescriptorWrapper;
 import org.apache.ivy.osgi.repo.RepoDescriptor;
 import org.apache.ivy.util.CacheCleaner;
 import org.apache.ivy.util.CollectionUtils;
+import org.apache.ivy.util.FileUtil;
 import org.xml.sax.SAXException;
 
 public class UpdateSiteLoaderTest extends TestCase {

--- a/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteLoaderTest.java
+++ b/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteLoaderTest.java
@@ -43,7 +43,7 @@ public class UpdateSiteLoaderTest extends TestCase {
 
     protected void setUp() throws Exception {
         IvySettings ivySettings = new IvySettings();
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
         ivySettings.setDefaultCache(cache);
         CacheResourceOptions options = new CacheResourceOptions();
@@ -79,11 +79,11 @@ public class UpdateSiteLoaderTest extends TestCase {
     }
 
     public void testComposite() throws Exception {
-        RepoDescriptor site = loader.load(new File("test/test-p2/composite/").toURI());
+        RepoDescriptor site = loader.load(FileUtil.newFile("test/test-p2/composite/").toURI());
         assertEquals(8, CollectionUtils.toList(site.getModules()).size());
 
         // check that the url of the artifact is correctly resolved
-        String path = new File("test/test-p2/ivyde-repo/").toURI().toURL().toExternalForm();
+        String path = FileUtil.newFile("test/test-p2/ivyde-repo/").toURI().toURL().toExternalForm();
         ModuleDescriptor md = site.getModules().next().getModuleDescriptor();
         assertTrue(md.getAllArtifacts()[0].getUrl().toExternalForm().startsWith(path));
     }

--- a/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteResolverTest.java
+++ b/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteResolverTest.java
@@ -57,13 +57,13 @@ public class UpdateSiteResolverTest extends TestCase {
 
         resolver = new UpdateSiteResolver();
         resolver.setName("ivyde-repo");
-        resolver.setUrl(new File("test/test-p2/ivyde-repo").toURI().toURL().toExternalForm());
+        resolver.setUrl(FileUtil.newFile("test/test-p2/ivyde-repo").toURI().toURL().toExternalForm());
         resolver.setSettings(settings);
         settings.addResolver(resolver);
 
         settings.setDefaultResolver("ivyde-repo");
 
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
         settings.setDefaultCache(cache);
 

--- a/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteResolverTest.java
+++ b/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteResolverTest.java
@@ -39,6 +39,7 @@ import org.apache.ivy.core.search.OrganisationEntry;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.osgi.core.BundleInfo;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
+import org.apache.ivy.util.FileUtil;
 
 public class UpdateSiteResolverTest extends TestCase {
 

--- a/test/java/org/apache/ivy/plugins/conflict/LatestConflictManagerTest.java
+++ b/test/java/org/apache/ivy/plugins/conflict/LatestConflictManagerTest.java
@@ -40,7 +40,7 @@ public class LatestConflictManagerTest extends TestCase {
     protected void setUp() throws Exception {
         ivy = new Ivy();
         ivy.configure(LatestConflictManagerTest.class.getResource("ivysettings-latest.xml"));
-        _cache = new File("build/cache");
+        _cache = FileUtil.newFile("build/cache");
         _cache.mkdirs();
     }
 
@@ -97,8 +97,8 @@ public class LatestConflictManagerTest extends TestCase {
         // set timestamps, because svn is not preserving this information,
         // and the latest time strategy is relying on it
         long time = System.currentTimeMillis() - 10000;
-        new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar").setLastModified(time);
-        new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.2.jar")
+        FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar").setLastModified(time);
+        FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.2.jar")
                 .setLastModified(time + 2000);
 
         ResolveReport report = ivy.resolve(
@@ -124,8 +124,8 @@ public class LatestConflictManagerTest extends TestCase {
         // set timestamps, because svn is not preserving this information,
         // and the latest time strategy is relying on it
         long time = System.currentTimeMillis() - 10000;
-        new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar").setLastModified(time);
-        new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.2.jar")
+        FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar").setLastModified(time);
+        FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.2.jar")
                 .setLastModified(time + 2000);
 
         ResolveReport report = ivy.resolve(
@@ -159,10 +159,10 @@ public class LatestConflictManagerTest extends TestCase {
         // set timestamps, because svn is not preserving this information,
         // and the latest time strategy is relying on it
         long time = System.currentTimeMillis() - 10000;
-        new File("test/repositories/IVY-407/MyCompany/C/ivy-1.0.0.xml").setLastModified(time);
-        new File("test/repositories/IVY-407/MyCompany/C/ivy-1.0.1.xml")
+        FileUtil.newFile("test/repositories/IVY-407/MyCompany/C/ivy-1.0.0.xml").setLastModified(time);
+        FileUtil.newFile("test/repositories/IVY-407/MyCompany/C/ivy-1.0.1.xml")
                 .setLastModified(time + 2000);
-        new File("test/repositories/IVY-407/MyCompany/C/ivy-1.0.2.xml")
+        FileUtil.newFile("test/repositories/IVY-407/MyCompany/C/ivy-1.0.2.xml")
                 .setLastModified(time + 4000);
 
         ResolveReport report = ivy.resolve(

--- a/test/java/org/apache/ivy/plugins/conflict/RegexpConflictManagerTest.java
+++ b/test/java/org/apache/ivy/plugins/conflict/RegexpConflictManagerTest.java
@@ -33,7 +33,7 @@ public class RegexpConflictManagerTest extends TestCase {
     protected void setUp() throws Exception {
         ivy = new Ivy();
         ivy.configure(RegexpConflictManagerTest.class.getResource("ivysettings-regexp-test.xml"));
-        _cache = new File("build/cache");
+        _cache = FileUtil.newFile("build/cache");
         _cache.mkdirs();
     }
 

--- a/test/java/org/apache/ivy/plugins/conflict/StrictConflictManagerTest.java
+++ b/test/java/org/apache/ivy/plugins/conflict/StrictConflictManagerTest.java
@@ -33,7 +33,7 @@ public class StrictConflictManagerTest extends TestCase {
     protected void setUp() throws Exception {
         ivy = new Ivy();
         ivy.configure(StrictConflictManagerTest.class.getResource("ivysettings-strict-test.xml"));
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         cache.mkdirs();
     }
 

--- a/test/java/org/apache/ivy/plugins/lock/ArtifactLockStrategyTest.java
+++ b/test/java/org/apache/ivy/plugins/lock/ArtifactLockStrategyTest.java
@@ -42,11 +42,11 @@ import org.apache.ivy.util.Message;
 
 public class ArtifactLockStrategyTest extends TestCase {
     protected void setUp() throws Exception {
-        FileUtil.forceDelete(new File("build/test/cache"));
+        FileUtil.forceDelete(FileUtil.newFile("build/test/cache"));
     }
 
     protected void tearDown() throws Exception {
-        FileUtil.forceDelete(new File("build/test/cache"));
+        FileUtil.forceDelete(FileUtil.newFile("build/test/cache"));
     }
 
     public void testConcurrentResolve() throws Exception {
@@ -82,7 +82,7 @@ public class ArtifactLockStrategyTest extends TestCase {
 
     private RepositoryCacheManager newCacheManager(IvySettings settings) {
         DefaultRepositoryCacheManager cacheManager = new DefaultRepositoryCacheManager("cache",
-                settings, new File("build/test/cache"));
+                settings, FileUtil.newFile("build/test/cache"));
         cacheManager.setLockStrategy(new CreateFileLockStrategy(false));
         return cacheManager;
     }

--- a/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorParserTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorParserTest.java
@@ -59,7 +59,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         }
     }
 
-    private File dest = new File("build/test/test-write.xml");
+    private File dest = FileUtil.newFile("build/test/test-write.xml");
 
     private MockResolver mockedResolver = new MockedDependencyResolver();
 

--- a/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorParserTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorParserTest.java
@@ -42,6 +42,7 @@ import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorParser;
 import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorParserTest;
 import org.apache.ivy.plugins.repository.url.URLResource;
 import org.apache.ivy.plugins.resolver.MockResolver;
+import org.apache.ivy.util.FileUtil;
 
 public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParserTester {
     // junit test -- DO NOT REMOVE used by ant to know it's a junit test

--- a/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorWriterTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorWriterTest.java
@@ -40,7 +40,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         }
     }
 
-    private File _dest = new File("build/test/test-write.xml");
+    private File _dest = FileUtil.newFile("build/test/test-write.xml");
 
     public void testSimple() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(

--- a/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorWriterTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorWriterTest.java
@@ -48,7 +48,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         PomModuleDescriptorWriter.write(md, _dest, getWriterOptions());
         assertTrue(_dest.exists());
 
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(_dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(_dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-simple.xml").replaceAll("\r\n", "\n").replace(
             '\r', '\n');
@@ -61,7 +61,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         PomModuleDescriptorWriter.write(md, _dest, getWriterOptions());
         assertTrue(_dest.exists());
 
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(_dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(_dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-simple-dependencies.xml").replaceAll("\r\n",
             "\n").replace('\r', '\n');
@@ -74,7 +74,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         PomModuleDescriptorWriter.write(md, _dest, getWriterOptions());
         assertTrue(_dest.exists());
 
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(_dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(_dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-dependencies-with-scope.xml").replaceAll("\r\n",
             "\n").replace('\r', '\n');
@@ -87,7 +87,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         PomModuleDescriptorWriter.write(md, _dest, getWriterOptions());
         assertTrue(_dest.exists());
 
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(_dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(_dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-dependencies-with-type.xml").replaceAll("\r\n",
             "\n").replace('\r', '\n');
@@ -101,7 +101,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         PomModuleDescriptorWriter.write(md, _dest, getWriterOptions());
         assertTrue(_dest.exists());
 
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(_dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(_dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-dependencies-with-classifier.xml").replaceAll(
             "\r\n", "\n").replace('\r', '\n');
@@ -114,7 +114,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         PomModuleDescriptorWriter.write(md, _dest, getWriterOptions());
         assertTrue(_dest.exists());
 
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(_dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(_dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-dependencies-optional.xml").replaceAll("\r\n",
             "\n").replace('\r', '\n');
@@ -127,7 +127,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         PomModuleDescriptorWriter.write(md, _dest, getWriterOptions());
         assertTrue(_dest.exists());
 
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(_dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(_dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-packaging.xml").replaceAll("\r\n", "\n")
                 .replace('\r', '\n');
@@ -141,7 +141,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
             getWriterOptions().setConfs(new String[] {"compile"}));
         assertTrue(_dest.exists());
 
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(_dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(_dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-compile-dependencies.xml").replaceAll("\r\n",
             "\n").replace('\r', '\n');
@@ -155,7 +155,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
             getWriterOptions().setConfs(new String[] {"runtime"}));
         assertTrue(_dest.exists());
 
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(_dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(_dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-dependencies-with-scope.xml").replaceAll("\r\n",
             "\n").replace('\r', '\n');
@@ -168,7 +168,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         PomModuleDescriptorWriter.write(md, _dest, getWriterOptions().setConfs(new String[] {"*"}));
         assertTrue(_dest.exists());
 
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(_dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(_dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-dependencies-with-scope.xml").replaceAll("\r\n",
             "\n").replace('\r', '\n');
@@ -182,7 +182,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
             getWriterOptions().setConfs(new String[] {"*", "!runtime"}));
         assertTrue(_dest.exists());
 
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(_dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(_dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-compile-dependencies.xml").replaceAll("\r\n",
             "\n").replace('\r', '\n');

--- a/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorParserTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorParserTest.java
@@ -1349,7 +1349,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         File resolveRoot = new File("build/tmp/xmlModuleDescriptorTest");
         assertTrue(resolveRoot.exists() || resolveRoot.mkdirs());
 
-        FileUtil.copy(getClass().getResource("test-extends-parent.xml"), new File(resolveRoot,
+        FileUtil.copy(getClass().getResource("test-extends-parent.xml"), FileUtil.newFile(resolveRoot,
                 "myorg/myparent/ivy.xml"), null);
 
         FileSystemResolver resolver = new FileSystemResolver();

--- a/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorParserTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorParserTest.java
@@ -62,7 +62,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
 
         this.settings = new IvySettings();
         // prevent test from polluting local cache
-        settings.setDefaultCache(new File("build/cache"));
+        settings.setDefaultCache(FileUtil.newFile("build/cache"));
     }
 
     public void testSimple() throws Exception {
@@ -903,7 +903,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
 
     public void testImportConfigurations5() throws Exception {
         // import configurations
-        settings.setVariable("base.dir", new File(".").getAbsolutePath());
+        settings.setVariable("base.dir", FileUtil.newFile(".").getAbsolutePath());
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-configurations-import5.xml"), true);
         assertNotNull(md);
@@ -1346,7 +1346,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
 
     public void testExtendsCached() throws Exception {
         // configure a resolver to serve the parent descriptor, so that parse succeeds.
-        File resolveRoot = new File("build/tmp/xmlModuleDescriptorTest");
+        File resolveRoot = FileUtil.newFile("build/tmp/xmlModuleDescriptorTest");
         assertTrue(resolveRoot.exists() || resolveRoot.mkdirs());
 
         FileUtil.copy(getClass().getResource("test-extends-parent.xml"), FileUtil.newFile(resolveRoot,

--- a/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorWriterTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorWriterTest.java
@@ -59,7 +59,7 @@ public class XmlModuleDescriptorWriterTest extends TestCase {
         XmlModuleDescriptorWriter.write(md, LICENSE, dest);
 
         assertTrue(dest.exists());
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-simple.xml").replaceAll("\r\n", "\n").replace(
             '\r', '\n');
@@ -76,7 +76,7 @@ public class XmlModuleDescriptorWriterTest extends TestCase {
         XmlModuleDescriptorWriter.write(md, LICENSE, dest);
 
         assertTrue(dest.exists());
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-info.xml").replaceAll("\r\n", "\n").replace(
             '\r', '\n');
@@ -90,7 +90,7 @@ public class XmlModuleDescriptorWriterTest extends TestCase {
         XmlModuleDescriptorWriter.write(md, LICENSE, dest);
 
         assertTrue(dest.exists());
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-dependencies.xml").replaceAll("\r\n", "\n")
                 .replace('\r', '\n');
@@ -103,7 +103,7 @@ public class XmlModuleDescriptorWriterTest extends TestCase {
         XmlModuleDescriptorWriter.write(md, LICENSE, dest);
 
         assertTrue(dest.exists());
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-full.xml").replaceAll("\r\n", "\n").replace(
             '\r', '\n');
@@ -117,7 +117,7 @@ public class XmlModuleDescriptorWriterTest extends TestCase {
         XmlModuleDescriptorWriter.write(md, LICENSE, dest);
 
         assertTrue(dest.exists());
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-extrainfo.xml").replaceAll("\r\n", "\n")
                 .replace('\r', '\n');
@@ -131,7 +131,7 @@ public class XmlModuleDescriptorWriterTest extends TestCase {
         XmlModuleDescriptorWriter.write(md, LICENSE, dest);
 
         assertTrue(dest.exists());
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(dest)))
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(dest)))
                 .replaceAll("\r\n", "\n").replace('\r', '\n');
         String expected = readEntirely("test-write-extrainfo-nested.xml").replaceAll("\r\n", "\n")
                 .replace('\r', '\n');
@@ -145,7 +145,7 @@ public class XmlModuleDescriptorWriterTest extends TestCase {
         XmlModuleDescriptorWriter.write(md, LICENSE, dest);
 
         assertTrue(dest.exists());
-        String wrote = FileUtil.readEntirely(new BufferedReader(new FileReader(dest))).replaceAll(
+        String wrote = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(dest))).replaceAll(
             "\r\n?", "\n");
         String expected = readEntirely("test-write-extends.xml").replaceAll("\r\n?", "\n");
         assertEquals(expected, wrote);

--- a/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorWriterTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorWriterTest.java
@@ -47,7 +47,7 @@ public class XmlModuleDescriptorWriterTest extends TestCase {
         }
     }
 
-    private File dest = new File("build/test/test-write.xml");
+    private File dest = FileUtil.newFile("build/test/test-write.xml");
 
     public void testSimple() throws Exception {
         DefaultModuleDescriptor md = (DefaultModuleDescriptor) XmlModuleDescriptorParser

--- a/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleUpdaterTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleUpdaterTest.java
@@ -89,7 +89,7 @@ public class XmlModuleUpdaterTest extends TestCase {
         assertTrue(dest.exists());
         String expected = FileUtil.readEntirely(new BufferedReader(new InputStreamReader(
                 XmlModuleUpdaterTest.class.getResourceAsStream("updated.xml"))));
-        String updated = FileUtil.readEntirely(new BufferedReader(new FileReader(dest)));
+        String updated = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(dest)));
         assertEquals(expected, updated);
     }
 
@@ -187,7 +187,7 @@ public class XmlModuleUpdaterTest extends TestCase {
         assertTrue(dest.exists());
         String expected = FileUtil.readEntirely(new BufferedReader(new InputStreamReader(
                 XmlModuleUpdaterTest.class.getResourceAsStream("updated.xml"))));
-        String updated = FileUtil.readEntirely(new BufferedReader(new FileReader(dest)));
+        String updated = FileUtil.readEntirely(new BufferedReader(FileUtil.newReader(dest)));
         assertEquals(expected, updated);
     }
 

--- a/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleUpdaterTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleUpdaterTest.java
@@ -60,7 +60,7 @@ public class XmlModuleUpdaterTest extends TestCase {
          * separator used in updater being platform dependent
          */
         XmlModuleDescriptorUpdater.LINE_SEPARATOR = "\n";
-        File dest = new File("build/updated-test.xml");
+        File dest = FileUtil.newFile("build/updated-test.xml");
         dest.deleteOnExit();
         Map resolvedRevisions = new HashMap();
         resolvedRevisions.put(
@@ -95,7 +95,7 @@ public class XmlModuleUpdaterTest extends TestCase {
 
     public void testUpdateWithComments() throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        URL settingsUrl = new File("test/java/org/apache/ivy/plugins/parser/xml/"
+        URL settingsUrl = FileUtil.newFile("test/java/org/apache/ivy/plugins/parser/xml/"
                 + "test-with-comments.xml").toURI().toURL();
         XmlModuleDescriptorUpdater.update(settingsUrl, new BufferedOutputStream(buffer, 1024),
             getUpdateOptions("release", "mynewrev"));
@@ -117,7 +117,7 @@ public class XmlModuleUpdaterTest extends TestCase {
          * separator used in updater being platform dependent
          */
         XmlModuleDescriptorUpdater.LINE_SEPARATOR = "\n";
-        File dest = new File("build/updated-test2.xml");
+        File dest = FileUtil.newFile("build/updated-test2.xml");
         dest.deleteOnExit();
         Map resolvedRevisions = new HashMap();
         resolvedRevisions.put(
@@ -193,7 +193,7 @@ public class XmlModuleUpdaterTest extends TestCase {
 
     public void testUpdateWithImportedMappingOverride() throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        URL settingsUrl = new File("test/java/org/apache/ivy/plugins/parser/xml/"
+        URL settingsUrl = FileUtil.newFile("test/java/org/apache/ivy/plugins/parser/xml/"
                 + "test-configurations-import4.xml").toURI().toURL();
         XmlModuleDescriptorUpdater.update(settingsUrl, buffer,
             getUpdateOptions("release", "mynewrev"));
@@ -207,7 +207,7 @@ public class XmlModuleUpdaterTest extends TestCase {
 
     public void testUpdateWithExcludeConfigurations1() throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        URL settingsUrl = new File("test/java/org/apache/ivy/plugins/parser/xml/"
+        URL settingsUrl = FileUtil.newFile("test/java/org/apache/ivy/plugins/parser/xml/"
                 + "test-update-excludedconfs1.xml").toURI().toURL();
         XmlModuleDescriptorUpdater.update(settingsUrl, buffer,
             getUpdateOptions("release", "mynewrev").setConfsToExclude(new String[] {"myconf2"}));
@@ -233,7 +233,7 @@ public class XmlModuleUpdaterTest extends TestCase {
 
     public void testUpdateWithExcludeConfigurations2() throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        URL settingFile = new File("test/java/org/apache/ivy/plugins/parser/xml/"
+        URL settingFile = FileUtil.newFile("test/java/org/apache/ivy/plugins/parser/xml/"
                 + "test-update-excludedconfs2.xml").toURI().toURL();
         try {
             XmlModuleDescriptorUpdater
@@ -249,7 +249,7 @@ public class XmlModuleUpdaterTest extends TestCase {
 
     public void testUpdateWithExcludeConfigurations3() throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        URL settingsUrl = new File("test/java/org/apache/ivy/plugins/parser/xml/"
+        URL settingsUrl = FileUtil.newFile("test/java/org/apache/ivy/plugins/parser/xml/"
                 + "test-update-excludedconfs3.xml").toURI().toURL();
 
         XmlModuleDescriptorUpdater.update(
@@ -281,7 +281,7 @@ public class XmlModuleUpdaterTest extends TestCase {
 
     public void testUpdateWithExcludeConfigurations4() throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        URL settingsUrl = new File("test/java/org/apache/ivy/plugins/parser/xml/"
+        URL settingsUrl = FileUtil.newFile("test/java/org/apache/ivy/plugins/parser/xml/"
                 + "test-update-excludedconfs4.xml").toURI().toURL();
         XmlModuleDescriptorUpdater.update(settingsUrl, buffer,
             getUpdateOptions("release", "mynewrev").setConfsToExclude(new String[] {"myconf2"}));
@@ -307,7 +307,7 @@ public class XmlModuleUpdaterTest extends TestCase {
 
     public void testUpdateWithExcludeConfigurations5() throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        URL settingsUrl = new File("test/java/org/apache/ivy/plugins/parser/xml/"
+        URL settingsUrl = FileUtil.newFile("test/java/org/apache/ivy/plugins/parser/xml/"
                 + "test-update-excludedconfs5.xml").toURI().toURL();
         XmlModuleDescriptorUpdater.update(settingsUrl, buffer,
             getUpdateOptions("release", "mynewrev").setConfsToExclude(new String[] {"myconf2"}));

--- a/test/java/org/apache/ivy/plugins/report/XmlReportParserTest.java
+++ b/test/java/org/apache/ivy/plugins/report/XmlReportParserTest.java
@@ -35,12 +35,12 @@ public class XmlReportParserTest extends TestCase {
 
     protected void setUp() throws Exception {
         _ivy = new Ivy();
-        _ivy.configure(new File("test/repositories/ivysettings.xml"));
+        _ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
         createCache();
     }
 
     private void createCache() {
-        _cache = new File("build/cache");
+        _cache = FileUtil.newFile("build/cache");
         _cache.mkdirs();
     }
 
@@ -57,7 +57,7 @@ public class XmlReportParserTest extends TestCase {
 
     public void testGetResolvedModule() throws Exception {
         ResolveReport report = _ivy.resolve(
-            new File("test/java/org/apache/ivy/plugins/report/ivy-with-info.xml"),
+            FileUtil.newFile("test/java/org/apache/ivy/plugins/report/ivy-with-info.xml"),
             getResolveOptions(new String[] {"default"}).setValidate(false).setResolveId(
                 "testGetResolvedModule"));
         assertNotNull(report);

--- a/test/java/org/apache/ivy/plugins/report/XmlReportParserTest.java
+++ b/test/java/org/apache/ivy/plugins/report/XmlReportParserTest.java
@@ -25,6 +25,7 @@ import org.apache.ivy.Ivy;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.report.ResolveReport;
 import org.apache.ivy.core.resolve.ResolveOptions;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
 

--- a/test/java/org/apache/ivy/plugins/report/XmlReportWriterTest.java
+++ b/test/java/org/apache/ivy/plugins/report/XmlReportWriterTest.java
@@ -37,12 +37,12 @@ public class XmlReportWriterTest extends TestCase {
 
     protected void setUp() throws Exception {
         _ivy = new Ivy();
-        _ivy.configure(new File("test/repositories/ivysettings.xml"));
+        _ivy.configure(FileUtil.newFile("test/repositories/ivysettings.xml"));
         createCache();
     }
 
     private void createCache() {
-        _cache = new File("build/cache");
+        _cache = FileUtil.newFile("build/cache");
         _cache.mkdirs();
     }
 
@@ -55,7 +55,7 @@ public class XmlReportWriterTest extends TestCase {
     }
 
     public void testWriteOrigin() throws Exception {
-        ResolveReport report = _ivy.resolve(new File(
+        ResolveReport report = _ivy.resolve(FileUtil.newFile(
                 "test/repositories/1/special-encoding-root-ivy.xml"),
             getResolveOptions(new String[] {"default"}));
         assertNotNull(report);
@@ -67,7 +67,7 @@ public class XmlReportWriterTest extends TestCase {
         String xml = buffer.toString(XmlReportWriter.REPORT_ENCODING);
 
         String expectedLocation = "location=\""
-                + new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar").getAbsolutePath()
+                + FileUtil.newFile("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar").getAbsolutePath()
                 + "\"";
         String expectedIsLocal = "is-local=\"true\"";
         String expectedOrg = "organisation=\"sp\u00E9cial\"";
@@ -84,8 +84,8 @@ public class XmlReportWriterTest extends TestCase {
     }
 
     public void testEscapeXml() throws Exception {
-        _ivy.configure(new File("test/repositories/IVY-635/ivysettings.xml"));
-        ResolveReport report = _ivy.resolve(new File(
+        _ivy.configure(FileUtil.newFile("test/repositories/IVY-635/ivysettings.xml"));
+        ResolveReport report = _ivy.resolve(FileUtil.newFile(
                 "test/java/org/apache/ivy/plugins/report/ivy-635.xml"),
             getResolveOptions(new String[] {"default"}));
         assertNotNull(report);
@@ -102,7 +102,7 @@ public class XmlReportWriterTest extends TestCase {
     }
 
     public void testWriteModuleInfo() throws Exception {
-        ResolveReport report = _ivy.resolve(new File(
+        ResolveReport report = _ivy.resolve(FileUtil.newFile(
                 "test/java/org/apache/ivy/plugins/report/ivy-with-info.xml"),
             getResolveOptions(new String[] {"default"}).setValidate(false));
         assertNotNull(report);

--- a/test/java/org/apache/ivy/plugins/report/XmlReportWriterTest.java
+++ b/test/java/org/apache/ivy/plugins/report/XmlReportWriterTest.java
@@ -27,6 +27,7 @@ import org.apache.ivy.Ivy;
 import org.apache.ivy.core.report.ResolveReport;
 import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.util.CacheCleaner;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.XMLHelper;
 import org.xml.sax.helpers.DefaultHandler;
 

--- a/test/java/org/apache/ivy/plugins/repository/vfs/VfsRepositoryTest.java
+++ b/test/java/org/apache/ivy/plugins/repository/vfs/VfsRepositoryTest.java
@@ -55,7 +55,7 @@ public class VfsRepositoryTest extends TestCase {
         super.setUp();
         helper = new VfsTestHelper();
         repo = new VfsRepository();
-        scratchDir = new File(FileUtil.concat(VfsTestHelper.TEST_REPO_DIR,
+        scratchDir = FileUtil.newFile(FileUtil.concat(VfsTestHelper.TEST_REPO_DIR,
             VfsTestHelper.SCRATCH_DIR));
         scratchDir.mkdir();
     }
@@ -87,8 +87,8 @@ public class VfsRepositoryTest extends TestCase {
             }
 
             try {
-                repo.put(new File(srcFile), vfsURI.toString(), false);
-                if (!new File(srcFile).exists()) {
+                repo.put(FileUtil.newFile(srcFile), vfsURI.toString(), false);
+                if (!FileUtil.newFile(srcFile).exists()) {
                     fail("Put didn't happen. Src VfsURI: " + vfsURI.toString()
                             + ".\nExpected file: " + destFile);
                 }
@@ -108,7 +108,7 @@ public class VfsRepositoryTest extends TestCase {
         String testResource = VfsTestHelper.TEST_IVY_XML;
         String srcFile = FileUtil.concat(VfsTestHelper.TEST_REPO_DIR, testResource);
         String destResource = VfsTestHelper.SCRATCH_DIR + "/" + testResource;
-        File destFile = new File(FileUtil.concat(VfsTestHelper.TEST_REPO_DIR, destResource));
+        File destFile = FileUtil.newFile(FileUtil.concat(VfsTestHelper.TEST_REPO_DIR, destResource));
 
         Iterator vfsURIs = helper.createVFSUriSet(destResource).iterator();
         while (vfsURIs.hasNext()) {
@@ -124,8 +124,8 @@ public class VfsRepositoryTest extends TestCase {
             destFile.createNewFile();
 
             try {
-                repo.put(new File(srcFile), vfsURI.toString(), true);
-                if (!new File(srcFile).exists()) {
+                repo.put(FileUtil.newFile(srcFile), vfsURI.toString(), true);
+                if (!FileUtil.newFile(srcFile).exists()) {
                     fail("Put didn't happen. Src VfsURI: " + vfsURI.toString()
                             + ".\nExpected file: " + destFile);
                 }
@@ -148,7 +148,7 @@ public class VfsRepositoryTest extends TestCase {
         String testResource = VfsTestHelper.TEST_IVY_XML;
         String srcFile = FileUtil.concat(VfsTestHelper.TEST_REPO_DIR, testResource);
         String destResource = VfsTestHelper.SCRATCH_DIR + "/" + testResource;
-        File destFile = new File(FileUtil.concat(VfsTestHelper.TEST_REPO_DIR, destResource));
+        File destFile = FileUtil.newFile(FileUtil.concat(VfsTestHelper.TEST_REPO_DIR, destResource));
         destFile.getParentFile().mkdirs();
         destFile.createNewFile();
 
@@ -157,7 +157,7 @@ public class VfsRepositoryTest extends TestCase {
             VfsURI vfsURI = (VfsURI) vfsURIs.next();
 
             try {
-                repo.put(new File(srcFile), vfsURI.toString(), false);
+                repo.put(FileUtil.newFile(srcFile), vfsURI.toString(), false);
                 fail("Did not throw expected IOException from attempted overwrite of existing file");
             } catch (IOException e) {
             }
@@ -181,8 +181,8 @@ public class VfsRepositoryTest extends TestCase {
             }
 
             try {
-                repo.get(vfsURI.toString(), new File(testFile));
-                if (!new File(testFile).exists()) {
+                repo.get(vfsURI.toString(), FileUtil.newFile(testFile));
+                if (!FileUtil.newFile(testFile).exists()) {
                     fail("Expected file: " + testFile + "not found. Failed vfsURI: "
                             + vfsURI.toString());
                 }
@@ -200,7 +200,7 @@ public class VfsRepositoryTest extends TestCase {
      */
     public void testGetOverwriteExisting() throws Exception {
         String testResource = VfsTestHelper.TEST_IVY_XML;
-        File testFile = new File(FileUtil.concat(scratchDir.getAbsolutePath(), testResource));
+        File testFile = FileUtil.newFile(FileUtil.concat(scratchDir.getAbsolutePath(), testResource));
 
         Iterator vfsURIs = helper.createVFSUriSet(testResource).iterator();
         while (vfsURIs.hasNext()) {

--- a/test/java/org/apache/ivy/plugins/repository/vfs/VfsTestHelper.java
+++ b/test/java/org/apache/ivy/plugins/repository/vfs/VfsTestHelper.java
@@ -65,7 +65,7 @@ public class VfsTestHelper {
 
         // setup and initialize ivy
         ivy = new Ivy();
-        ivy.configure(new File(IVY_CONFIG_FILE));
+        ivy.configure(FileUtil.newFile(IVY_CONFIG_FILE));
     }
 
     /**

--- a/test/java/org/apache/ivy/plugins/resolver/ChainResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/ChainResolverTest.java
@@ -43,6 +43,7 @@ import org.apache.ivy.core.settings.XmlSettingsParser;
 import org.apache.ivy.core.sort.SortEngine;
 import org.apache.ivy.plugins.latest.LatestRevisionStrategy;
 import org.apache.ivy.plugins.latest.LatestTimeStrategy;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.MockMessageLogger;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;

--- a/test/java/org/apache/ivy/plugins/resolver/ChainResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/ChainResolverTest.java
@@ -62,7 +62,7 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
     protected void setUp() throws Exception {
         settings = new IvySettings();
         engine = new ResolveEngine(settings, new EventManager(), new SortEngine(settings));
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         data = new ResolveData(engine, new ResolveOptions());
         cache.mkdirs();
         settings.setDefaultCache(cache);

--- a/test/java/org/apache/ivy/plugins/resolver/DualResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/DualResolverTest.java
@@ -48,7 +48,7 @@ public class DualResolverTest extends AbstractDependencyResolverTest {
     protected void setUp() throws Exception {
         _settings = new IvySettings();
         _engine = new ResolveEngine(_settings, new EventManager(), new SortEngine(_settings));
-        _cache = new File("build/cache");
+        _cache = FileUtil.newFile("build/cache");
         _data = new ResolveData(_engine, new ResolveOptions());
         _cache.mkdirs();
         _settings.setDefaultCache(_cache);

--- a/test/java/org/apache/ivy/plugins/resolver/DualResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/DualResolverTest.java
@@ -32,6 +32,7 @@ import org.apache.ivy.core.resolve.ResolvedModuleRevision;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.settings.XmlSettingsParser;
 import org.apache.ivy.core.sort.SortEngine;
+import org.apache.ivy.util.FileUtil;
 
 /**
  * Test for DualResolver

--- a/test/java/org/apache/ivy/plugins/resolver/FileSystemResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/FileSystemResolverTest.java
@@ -324,7 +324,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         File archiveFileInCache = cacheManager.getArchiveFileInCache(artifacts[0]);
         resolver.download(artifacts, getDownloadOptions());
         assertTrue(archiveFileInCache.exists());
-        BufferedReader r = new BufferedReader(new FileReader(archiveFileInCache));
+        BufferedReader r = new BufferedReader(FileUtil.newReader(archiveFileInCache));
         assertEquals("before", r.readLine());
         r.close();
 
@@ -355,7 +355,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         artifacts = rmr.getDescriptor().getArtifacts("default");
         resolver.download(artifacts, getDownloadOptions());
         assertTrue(archiveFileInCache.exists());
-        r = new BufferedReader(new FileReader(archiveFileInCache));
+        r = new BufferedReader(FileUtil.newReader(archiveFileInCache));
         assertEquals("after", r.readLine());
         r.close();
     }
@@ -394,7 +394,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         resolver.download(artifacts, getDownloadOptions());
         File archiveFileInCache = cacheManager.getArchiveFileInCache(artifacts[0]);
         assertTrue(archiveFileInCache.exists());
-        BufferedReader r = new BufferedReader(new FileReader(archiveFileInCache));
+        BufferedReader r = new BufferedReader(FileUtil.newReader(archiveFileInCache));
         assertEquals("before", r.readLine());
         r.close();
 
@@ -418,7 +418,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
             rmr.getPublicationDate());
 
         assertTrue(archiveFileInCache.exists());
-        r = new BufferedReader(new FileReader(archiveFileInCache));
+        r = new BufferedReader(FileUtil.newReader(archiveFileInCache));
         assertEquals("before", r.readLine());
         r.close();
 
@@ -434,7 +434,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         artifacts = rmr.getDescriptor().getArtifacts("default");
         resolver.download(artifacts, getDownloadOptions());
         assertTrue(archiveFileInCache.exists());
-        r = new BufferedReader(new FileReader(archiveFileInCache));
+        r = new BufferedReader(FileUtil.newReader(archiveFileInCache));
         assertEquals("after", r.readLine());
         r.close();
     }

--- a/test/java/org/apache/ivy/plugins/resolver/FileSystemResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/FileSystemResolverTest.java
@@ -60,7 +60,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
     private static final String REL_IVY_PATTERN = "test" + FS + "repositories" + FS + "1" + FS
             + "[organisation]" + FS + "[module]" + FS + "ivys" + FS + "ivy-[revision].xml";
 
-    private static final String IVY_PATTERN = new File(".").getAbsolutePath() + FS
+    private static final String IVY_PATTERN = FileUtil.newFile(".").getAbsolutePath() + FS
             + REL_IVY_PATTERN;
 
     private IvySettings settings;
@@ -80,7 +80,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
     protected void setUp() throws Exception {
         settings = new IvySettings();
         engine = new ResolveEngine(settings, new EventManager(), new SortEngine(settings));
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         data = new ResolveData(engine, new ResolveOptions());
         cache.mkdirs();
         settings.setDefaultCache(cache);
@@ -91,13 +91,13 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         // change important last modified dates cause svn doesn't keep them
         long minute = 60 * 1000;
         long time = new GregorianCalendar().getTimeInMillis() - (4 * minute);
-        new File("test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").setLastModified(time);
+        FileUtil.newFile("test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").setLastModified(time);
         time += minute;
-        new File("test/repositories/1/org1/mod1.1/ivys/ivy-1.0.1.xml").setLastModified(time);
+        FileUtil.newFile("test/repositories/1/org1/mod1.1/ivys/ivy-1.0.1.xml").setLastModified(time);
         time += minute;
-        new File("test/repositories/1/org1/mod1.1/ivys/ivy-1.1.xml").setLastModified(time);
+        FileUtil.newFile("test/repositories/1/org1/mod1.1/ivys/ivy-1.1.xml").setLastModified(time);
         time += minute;
-        new File("test/repositories/1/org1/mod1.1/ivys/ivy-2.0.xml").setLastModified(time);
+        FileUtil.newFile("test/repositories/1/org1/mod1.1/ivys/ivy-2.0.xml").setLastModified(time);
     }
 
     protected void tearDown() throws Exception {
@@ -165,7 +165,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
 
         // check that the found ivy file is the one from the first pattern!
         assertEquals(
-            new File("test/repositories/multi-ivypattern/ivy1/ivy-1.0.xml").getCanonicalPath(),
+            FileUtil.newFile("test/repositories/multi-ivypattern/ivy1/ivy-1.0.xml").getCanonicalPath(),
             FileUtil.newFile(ivyRef.getResource().getName()).getCanonicalPath());
     }
 
@@ -251,8 +251,8 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
 
         resolver.addIvyPattern(settings.getBaseDir() + FS + "test" + FS + "repositories" + FS
                 + "checkmodified" + FS + "ivy-[revision].xml");
-        File modify = new File("test/repositories/checkmodified/ivy-1.0.xml");
-        FileUtil.copy(new File("test/repositories/checkmodified/ivy-1.0-before.xml"), modify, null,
+        File modify = FileUtil.newFile("test/repositories/checkmodified/ivy-1.0.xml");
+        FileUtil.copy(FileUtil.newFile("test/repositories/checkmodified/ivy-1.0-before.xml"), modify, null,
             true);
         Date pubdate = new GregorianCalendar(2004, 10, 1, 11, 0, 0).getTime();
         modify.setLastModified(pubdate.getTime());
@@ -266,7 +266,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         assertEquals(pubdate, rmr.getPublicationDate());
 
         // updates ivy file in repository
-        FileUtil.copy(new File("test/repositories/checkmodified/ivy-1.0-after.xml"), modify, null,
+        FileUtil.copy(FileUtil.newFile("test/repositories/checkmodified/ivy-1.0-after.xml"), modify, null,
             true);
         pubdate = new GregorianCalendar(2005, 4, 1, 11, 0, 0).getTime();
         modify.setLastModified(pubdate.getTime());
@@ -300,13 +300,13 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
                 + "norevision" + FS + "ivy-[module].xml");
         resolver.addArtifactPattern(settings.getBaseDir() + FS + "test" + FS + "repositories" + FS
                 + "norevision" + FS + "[artifact].[ext]");
-        File modify = new File("test/repositories/norevision/ivy-mod1.1.xml");
-        File artifact = new File("test/repositories/norevision/mod1.1.jar");
+        File modify = FileUtil.newFile("test/repositories/norevision/ivy-mod1.1.xml");
+        File artifact = FileUtil.newFile("test/repositories/norevision/mod1.1.jar");
 
         // 'publish' 'before' version
-        FileUtil.copy(new File("test/repositories/norevision/ivy-mod1.1-before.xml"), modify, null,
+        FileUtil.copy(FileUtil.newFile("test/repositories/norevision/ivy-mod1.1-before.xml"), modify, null,
             true);
-        FileUtil.copy(new File("test/repositories/norevision/mod1.1-before.jar"), artifact, null,
+        FileUtil.copy(FileUtil.newFile("test/repositories/norevision/mod1.1-before.jar"), artifact, null,
             true);
         Date pubdate = new GregorianCalendar(2004, 10, 1, 11, 0, 0).getTime();
         modify.setLastModified(pubdate.getTime());
@@ -329,9 +329,9 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         r.close();
 
         // updates ivy file and artifact in repository
-        FileUtil.copy(new File("test/repositories/norevision/ivy-mod1.1-after.xml"), modify, null,
+        FileUtil.copy(FileUtil.newFile("test/repositories/norevision/ivy-mod1.1-after.xml"), modify, null,
             true);
-        FileUtil.copy(new File("test/repositories/norevision/mod1.1-after.jar"), artifact, null,
+        FileUtil.copy(FileUtil.newFile("test/repositories/norevision/mod1.1-after.jar"), artifact, null,
             true);
         pubdate = new GregorianCalendar(2005, 4, 1, 11, 0, 0).getTime();
         modify.setLastModified(pubdate.getTime());
@@ -371,13 +371,13 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
                 + "checkmodified" + FS + "ivy-[revision].xml");
         resolver.addArtifactPattern(settings.getBaseDir() + FS + "test" + FS + "repositories" + FS
                 + "checkmodified" + FS + "[artifact]-[revision].[ext]");
-        File modify = new File("test/repositories/checkmodified/ivy-1.0.xml");
-        File artifact = new File("test/repositories/checkmodified/mod1.1-1.0.jar");
+        File modify = FileUtil.newFile("test/repositories/checkmodified/ivy-1.0.xml");
+        File artifact = FileUtil.newFile("test/repositories/checkmodified/mod1.1-1.0.jar");
 
         // 'publish' 'before' version
-        FileUtil.copy(new File("test/repositories/checkmodified/ivy-1.0-before.xml"), modify, null,
+        FileUtil.copy(FileUtil.newFile("test/repositories/checkmodified/ivy-1.0-before.xml"), modify, null,
             true);
-        FileUtil.copy(new File("test/repositories/checkmodified/mod1.1-1.0-before.jar"), artifact,
+        FileUtil.copy(FileUtil.newFile("test/repositories/checkmodified/mod1.1-1.0-before.jar"), artifact,
             null, true);
         Date pubdate = new GregorianCalendar(2004, 10, 1, 11, 0, 0).getTime();
         modify.setLastModified(pubdate.getTime());
@@ -399,9 +399,9 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         r.close();
 
         // updates ivy file and artifact in repository
-        FileUtil.copy(new File("test/repositories/checkmodified/ivy-1.0-after.xml"), modify, null,
+        FileUtil.copy(FileUtil.newFile("test/repositories/checkmodified/ivy-1.0-after.xml"), modify, null,
             true);
-        FileUtil.copy(new File("test/repositories/checkmodified/mod1.1-1.0-after.jar"), artifact,
+        FileUtil.copy(FileUtil.newFile("test/repositories/checkmodified/mod1.1-1.0-after.jar"), artifact,
             null, true);
         pubdate = new GregorianCalendar(2005, 4, 1, 11, 0, 0).getTime();
         modify.setLastModified(pubdate.getTime());
@@ -489,7 +489,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         resolver.setSettings(settings);
         assertEquals("test", resolver.getName());
 
-        resolver.addIvyPattern(new File("src/java").getAbsolutePath() + "/../../" + REL_IVY_PATTERN);
+        resolver.addIvyPattern(FileUtil.newFile("src/java").getAbsolutePath() + "/../../" + REL_IVY_PATTERN);
         resolver.addArtifactPattern(settings.getBaseDir() + "/src/../test/repositories/1/"
                 + "[organisation]/[module]/[type]s/[artifact]-[revision].[type]");
 
@@ -566,18 +566,18 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
             Artifact ivyArtifact = new DefaultArtifact(mrid, new Date(), "ivy", "ivy", "xml");
             Artifact artifact = new DefaultArtifact(mrid, new Date(), "myartifact", "mytype",
                     "myext");
-            File src = new File("test/repositories/ivysettings.xml");
+            File src = FileUtil.newFile("test/repositories/ivysettings.xml");
             resolver.beginPublishTransaction(mrid, false);
             resolver.publish(ivyArtifact, src, false);
             resolver.publish(artifact, src, false);
             resolver.commitPublishTransaction();
 
-            assertTrue(new File("test/repositories/1/myorg/mymodule/myrevision/ivy.xml").exists());
-            assertTrue(new File(
+            assertTrue(FileUtil.newFile("test/repositories/1/myorg/mymodule/myrevision/ivy.xml").exists());
+            assertTrue(FileUtil.newFile(
                     "test/repositories/1/myorg/mymodule/mytypes/myartifact-myrevision.myext")
                     .exists());
         } finally {
-            FileUtil.forceDelete(new File("test/repositories/1/myorg"));
+            FileUtil.forceDelete(FileUtil.newFile("test/repositories/1/myorg"));
         }
     }
 
@@ -593,8 +593,8 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
             resolver.addArtifactPattern(settings.getBaseDir()
                     + "/test/repositories/1/[organisation]/[module]/[revision]/[artifact]-[revision].[ext]");
 
-            File ivyFile = new File("test/repositories/1/myorg/mymodule/myrevision/ivy.xml");
-            File artifactFile = new File(
+            File ivyFile = FileUtil.newFile("test/repositories/1/myorg/mymodule/myrevision/ivy.xml");
+            File artifactFile = FileUtil.newFile(
                     "test/repositories/1/myorg/mymodule/myrevision/myartifact-myrevision.myext");
             touch(ivyFile);
             touch(artifactFile);
@@ -603,7 +603,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
             Artifact ivyArtifact = new DefaultArtifact(mrid, new Date(), "ivy", "ivy", "xml");
             Artifact artifact = new DefaultArtifact(mrid, new Date(), "myartifact", "mytype",
                     "myext");
-            File src = new File("test/repositories/ivysettings.xml");
+            File src = FileUtil.newFile("test/repositories/ivysettings.xml");
             resolver.beginPublishTransaction(mrid, true);
             resolver.publish(ivyArtifact, src, true);
             resolver.publish(artifact, src, true);
@@ -613,7 +613,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
             assertEquals(length, ivyFile.length());
             assertEquals(length, artifactFile.length());
         } finally {
-            FileUtil.forceDelete(new File("test/repositories/1/myorg"));
+            FileUtil.forceDelete(FileUtil.newFile("test/repositories/1/myorg"));
         }
     }
 
@@ -637,27 +637,27 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
             Artifact ivyArtifact = new DefaultArtifact(mrid, new Date(), "ivy", "ivy", "xml");
             Artifact artifact = new DefaultArtifact(mrid, new Date(), "myartifact", "mytype",
                     "myext");
-            File src = new File("test/repositories/ivysettings.xml");
+            File src = FileUtil.newFile("test/repositories/ivysettings.xml");
 
             resolver.beginPublishTransaction(mrid, false);
 
             // files should not be available until the transaction is committed
             resolver.publish(ivyArtifact, src, false);
-            assertFalse(new File("test/repositories/1/myorg/mymodule/myrevision/ivy.xml").exists());
+            assertFalse(FileUtil.newFile("test/repositories/1/myorg/mymodule/myrevision/ivy.xml").exists());
 
             resolver.publish(artifact, src, false);
-            assertFalse(new File(
+            assertFalse(FileUtil.newFile(
                     "test/repositories/1/myorg/mymodule/myrevision/myartifact-myrevision.myext")
                     .exists());
 
             resolver.commitPublishTransaction();
 
-            assertTrue(new File("test/repositories/1/myorg/mymodule/myrevision/ivy.xml").exists());
-            assertTrue(new File(
+            assertTrue(FileUtil.newFile("test/repositories/1/myorg/mymodule/myrevision/ivy.xml").exists());
+            assertTrue(FileUtil.newFile(
                     "test/repositories/1/myorg/mymodule/myrevision/myartifact-myrevision.myext")
                     .exists());
         } finally {
-            FileUtil.forceDelete(new File("test/repositories/1/myorg"));
+            FileUtil.forceDelete(FileUtil.newFile("test/repositories/1/myorg"));
         }
     }
 
@@ -677,29 +677,29 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
             Artifact ivyArtifact = new DefaultArtifact(mrid, new Date(), "ivy", "ivy", "xml");
             Artifact artifact = new DefaultArtifact(mrid, new Date(), "myartifact", "mytype",
                     "myext");
-            File src = new File("test/repositories/ivysettings.xml");
+            File src = FileUtil.newFile("test/repositories/ivysettings.xml");
 
             resolver.beginPublishTransaction(mrid, false);
 
             // files should not be available until the transaction is committed
             resolver.publish(ivyArtifact, src, false);
-            assertFalse(new File("test/repositories/1/myorg/mymodule/mybranch/myrevision/ivy.xml")
+            assertFalse(FileUtil.newFile("test/repositories/1/myorg/mymodule/mybranch/myrevision/ivy.xml")
                     .exists());
 
             resolver.publish(artifact, src, false);
-            assertFalse(new File(
+            assertFalse(FileUtil.newFile(
                     "test/repositories/1/myorg/mymodule/mybranch/myrevision/myartifact-myrevision.myext")
                     .exists());
 
             resolver.commitPublishTransaction();
 
-            assertTrue(new File("test/repositories/1/myorg/mymodule/mybranch/myrevision/ivy.xml")
+            assertTrue(FileUtil.newFile("test/repositories/1/myorg/mymodule/mybranch/myrevision/ivy.xml")
                     .exists());
-            assertTrue(new File(
+            assertTrue(FileUtil.newFile(
                     "test/repositories/1/myorg/mymodule/mybranch/myrevision/myartifact-myrevision.myext")
                     .exists());
         } finally {
-            FileUtil.forceDelete(new File("test/repositories/1/myorg"));
+            FileUtil.forceDelete(FileUtil.newFile("test/repositories/1/myorg"));
         }
     }
 
@@ -718,29 +718,29 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
             Artifact ivyArtifact = new DefaultArtifact(mrid, new Date(), "ivy", "ivy", "xml");
             Artifact artifact = new DefaultArtifact(mrid, new Date(), "myartifact", "mytype",
                     "myext");
-            File src = new File("test/repositories/ivysettings.xml");
+            File src = FileUtil.newFile("test/repositories/ivysettings.xml");
 
             resolver.beginPublishTransaction(mrid, false);
 
             // files should not be available until the transaction is committed
             resolver.publish(ivyArtifact, src, false);
-            assertFalse(new File("test/repositories/1/myorg/mymodule/myrevision/ivy/ivy.xml")
+            assertFalse(FileUtil.newFile("test/repositories/1/myorg/mymodule/myrevision/ivy/ivy.xml")
                     .exists());
 
             resolver.publish(artifact, src, false);
-            assertFalse(new File(
+            assertFalse(FileUtil.newFile(
                     "test/repositories/1/myorg/mymodule/myrevision/mytype/myartifact-myrevision.myext")
                     .exists());
 
             resolver.commitPublishTransaction();
 
-            assertTrue(new File("test/repositories/1/myorg/mymodule/myrevision/ivy/ivy.xml")
+            assertTrue(FileUtil.newFile("test/repositories/1/myorg/mymodule/myrevision/ivy/ivy.xml")
                     .exists());
-            assertTrue(new File(
+            assertTrue(FileUtil.newFile(
                     "test/repositories/1/myorg/mymodule/myrevision/mytype/myartifact-myrevision.myext")
                     .exists());
         } finally {
-            FileUtil.forceDelete(new File("test/repositories/1/myorg"));
+            FileUtil.forceDelete(FileUtil.newFile("test/repositories/1/myorg"));
         }
     }
 
@@ -761,29 +761,29 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
             Artifact ivyArtifact = new DefaultArtifact(mrid, new Date(), "ivy", "ivy", "xml");
             Artifact artifact = new DefaultArtifact(mrid, new Date(), "myartifact", "mytype",
                     "myext");
-            File src = new File("test/repositories/ivysettings.xml");
+            File src = FileUtil.newFile("test/repositories/ivysettings.xml");
 
             resolver.beginPublishTransaction(mrid, false);
 
             // files should not be available until the transaction is committed
             resolver.publish(ivyArtifact, src, false);
-            assertFalse(new File(
+            assertFalse(FileUtil.newFile(
                     "test/repositories/m2/org/apache/mymodule/myrevision/ivy-myrevision.xml")
                     .exists());
             resolver.publish(artifact, src, false);
-            assertFalse(new File(
+            assertFalse(FileUtil.newFile(
                     "test/repositories/m2/org/apache/mymodule/myrevision/myartifact-myrevision.myext")
                     .exists());
 
             resolver.commitPublishTransaction();
-            assertTrue(new File(
+            assertTrue(FileUtil.newFile(
                     "test/repositories/m2/org/apache/mymodule/myrevision/ivy-myrevision.xml")
                     .exists());
-            assertTrue(new File(
+            assertTrue(FileUtil.newFile(
                     "test/repositories/m2/org/apache/mymodule/myrevision/myartifact-myrevision.myext")
                     .exists());
         } finally {
-            FileUtil.forceDelete(new File("test/repositories/m2/org/apache/mymodule"));
+            FileUtil.forceDelete(FileUtil.newFile("test/repositories/m2/org/apache/mymodule"));
         }
     }
 
@@ -802,18 +802,18 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
             Artifact ivyArtifact = new DefaultArtifact(mrid, new Date(), "ivy", "ivy", "xml");
             Artifact artifact = new DefaultArtifact(mrid, new Date(), "myartifact", "mytype",
                     "myext");
-            File src = new File("test/repositories/ivysettings.xml");
+            File src = FileUtil.newFile("test/repositories/ivysettings.xml");
             resolver.beginPublishTransaction(mrid, false);
             resolver.publish(ivyArtifact, src, false);
             resolver.publish(artifact, src, false);
             resolver.abortPublishTransaction();
 
-            assertFalse(new File("test/repositories/1/myorg/mymodule/myrevision/ivy.xml").exists());
-            assertFalse(new File(
+            assertFalse(FileUtil.newFile("test/repositories/1/myorg/mymodule/myrevision/ivy.xml").exists());
+            assertFalse(FileUtil.newFile(
                     "test/repositories/1/myorg/mymodule/myrevision/myartifact-myrevision.myext")
                     .exists());
         } finally {
-            FileUtil.forceDelete(new File("test/repositories/1/myorg"));
+            FileUtil.forceDelete(FileUtil.newFile("test/repositories/1/myorg"));
         }
     }
 
@@ -832,7 +832,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
             ModuleRevisionId mrid = ModuleRevisionId.newInstance("myorg", "mymodule", "myrevision");
             Artifact artifact = new DefaultArtifact(mrid, new Date(), "myartifact", "mytype",
                     "myext");
-            File src = new File("test/repositories/ivysettings.xml");
+            File src = FileUtil.newFile("test/repositories/ivysettings.xml");
             try {
                 resolver.beginPublishTransaction(mrid, false);
 
@@ -842,7 +842,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
                 assertTrue(ex.getMessage().indexOf("transactional") != -1);
             }
         } finally {
-            FileUtil.forceDelete(new File("test/repositories/1/myorg"));
+            FileUtil.forceDelete(FileUtil.newFile("test/repositories/1/myorg"));
         }
     }
 
@@ -863,7 +863,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
             Artifact ivyArtifact = new DefaultArtifact(mrid, new Date(), "ivy", "ivy", "xml");
             Artifact artifact = new DefaultArtifact(mrid, new Date(), "myartifact", "mytype",
                     "myext");
-            File src = new File("test/repositories/ivysettings.xml");
+            File src = FileUtil.newFile("test/repositories/ivysettings.xml");
             try {
                 resolver.beginPublishTransaction(mrid, false);
                 resolver.publish(ivyArtifact, src, false);
@@ -873,7 +873,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
                 assertTrue(ex.getMessage().indexOf("transactional") != -1);
             }
         } finally {
-            FileUtil.forceDelete(new File("test/repositories/1/myorg"));
+            FileUtil.forceDelete(FileUtil.newFile("test/repositories/1/myorg"));
         }
     }
 
@@ -890,7 +890,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
             ModuleRevisionId mrid = ModuleRevisionId.newInstance("myorg", "mymodule", "myrevision");
             Artifact artifact = new DefaultArtifact(mrid, new Date(), "myartifact", "mytype",
                     "myext");
-            File src = new File("test/repositories/ivysettings.xml");
+            File src = FileUtil.newFile("test/repositories/ivysettings.xml");
             try {
                 // overwrite transaction not supported
                 resolver.beginPublishTransaction(mrid, true);
@@ -901,7 +901,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
                 assertTrue(ex.getMessage().indexOf("transactional") != -1);
             }
         } finally {
-            FileUtil.forceDelete(new File("test/repositories/1/myorg"));
+            FileUtil.forceDelete(FileUtil.newFile("test/repositories/1/myorg"));
         }
     }
 
@@ -921,26 +921,26 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
             Artifact ivyArtifact = new DefaultArtifact(mrid, new Date(), "ivy", "ivy", "xml");
             Artifact artifact = new DefaultArtifact(mrid, new Date(), "myartifact", "mytype",
                     "myext");
-            File src = new File("test/repositories/ivysettings.xml");
+            File src = FileUtil.newFile("test/repositories/ivysettings.xml");
             resolver.beginPublishTransaction(mrid, false);
 
             // with transactions disabled the file should be available as soon as they are published
             resolver.publish(ivyArtifact, src, false);
-            assertTrue(new File("test/repositories/1/myorg/mymodule/myrevision/ivy.xml").exists());
+            assertTrue(FileUtil.newFile("test/repositories/1/myorg/mymodule/myrevision/ivy.xml").exists());
 
             resolver.publish(artifact, src, false);
-            assertTrue(new File(
+            assertTrue(FileUtil.newFile(
                     "test/repositories/1/myorg/mymodule/myrevision/myartifact-myrevision.myext")
                     .exists());
 
             resolver.commitPublishTransaction();
 
-            assertTrue(new File("test/repositories/1/myorg/mymodule/myrevision/ivy.xml").exists());
-            assertTrue(new File(
+            assertTrue(FileUtil.newFile("test/repositories/1/myorg/mymodule/myrevision/ivy.xml").exists());
+            assertTrue(FileUtil.newFile(
                     "test/repositories/1/myorg/mymodule/myrevision/myartifact-myrevision.myext")
                     .exists());
         } finally {
-            FileUtil.forceDelete(new File("test/repositories/1/myorg"));
+            FileUtil.forceDelete(FileUtil.newFile("test/repositories/1/myorg"));
         }
     }
 

--- a/test/java/org/apache/ivy/plugins/resolver/FileSystemResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/FileSystemResolverTest.java
@@ -166,7 +166,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         // check that the found ivy file is the one from the first pattern!
         assertEquals(
             new File("test/repositories/multi-ivypattern/ivy1/ivy-1.0.xml").getCanonicalPath(),
-            new File(ivyRef.getResource().getName()).getCanonicalPath());
+            FileUtil.newFile(ivyRef.getResource().getName()).getCanonicalPath());
     }
 
     private DownloadOptions getDownloadOptions() {

--- a/test/java/org/apache/ivy/plugins/resolver/IBiblioResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/IBiblioResolverTest.java
@@ -46,6 +46,7 @@ import org.apache.ivy.core.search.RevisionEntry;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortEngine;
 import org.apache.ivy.plugins.matcher.ExactPatternMatcher;
+import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.MockMessageLogger;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;

--- a/test/java/org/apache/ivy/plugins/resolver/IBiblioResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/IBiblioResolverTest.java
@@ -67,7 +67,7 @@ public class IBiblioResolverTest extends AbstractDependencyResolverTest {
     protected void setUp() throws Exception {
         _settings = new IvySettings();
         _engine = new ResolveEngine(_settings, new EventManager(), new SortEngine(_settings));
-        _cache = new File("build/cache");
+        _cache = FileUtil.newFile("build/cache");
         _data = new ResolveData(_engine, new ResolveOptions());
         _cache.mkdirs();
         _settings.setDefaultCache(_cache);

--- a/test/java/org/apache/ivy/plugins/resolver/IvyRepResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/IvyRepResolverTest.java
@@ -34,6 +34,7 @@ import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.core.resolve.ResolvedModuleRevision;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortEngine;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
 

--- a/test/java/org/apache/ivy/plugins/resolver/IvyRepResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/IvyRepResolverTest.java
@@ -52,7 +52,7 @@ public class IvyRepResolverTest extends AbstractDependencyResolverTest {
     protected void setUp() throws Exception {
         _settings = new IvySettings();
         _engine = new ResolveEngine(_settings, new EventManager(), new SortEngine(_settings));
-        _cache = new File("build/cache");
+        _cache = FileUtil.newFile("build/cache");
         _data = new ResolveData(_engine, new ResolveOptions());
         _cache.mkdirs();
         _settings.setDefaultCache(_cache);
@@ -107,7 +107,7 @@ public class IvyRepResolverTest extends AbstractDependencyResolverTest {
 
     public void testIvyRepWithLocalURL() throws Exception {
         IvyRepResolver resolver = new IvyRepResolver();
-        String rootpath = new File("test/repositories/1").getAbsolutePath();
+        String rootpath = FileUtil.newFile("test/repositories/1").getAbsolutePath();
 
         resolver.setName("testLocal");
         resolver.setIvyroot("file:" + rootpath);

--- a/test/java/org/apache/ivy/plugins/resolver/JarResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/JarResolverTest.java
@@ -32,6 +32,7 @@ import org.apache.ivy.core.resolve.ResolvedModuleRevision;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortEngine;
 import org.apache.ivy.util.CacheCleaner;
+import org.apache.ivy.util.FileUtil;
 
 public class JarResolverTest extends TestCase {
 

--- a/test/java/org/apache/ivy/plugins/resolver/JarResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/JarResolverTest.java
@@ -48,7 +48,7 @@ public class JarResolverTest extends TestCase {
     protected void setUp() throws Exception {
         settings = new IvySettings();
         engine = new ResolveEngine(settings, new EventManager(), new SortEngine(settings));
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         data = new ResolveData(engine, new ResolveOptions());
         cache.mkdirs();
         settings.setDefaultCache(cache);
@@ -62,7 +62,7 @@ public class JarResolverTest extends TestCase {
     public void testSimpleFile() throws Exception {
         JarResolver resolver = new JarResolver();
         resolver.setName("jarresolver1");
-        resolver.setFile(new File("test/jar-repos/jarrepo1.jar").getAbsolutePath());
+        resolver.setFile(FileUtil.newFile("test/jar-repos/jarrepo1.jar").getAbsolutePath());
         resolver.addIvyPattern("[organisation]/[module]/ivys/ivy-[revision].xml");
         resolver.addArtifactPattern("[organisation]/[module]/[type]s/[artifact]-[revision].[type]");
         resolver.setSettings(settings);
@@ -76,7 +76,7 @@ public class JarResolverTest extends TestCase {
     public void testSubdirInFile() throws Exception {
         JarResolver resolver = new JarResolver();
         resolver.setName("jarresolver1_subdir");
-        resolver.setFile(new File("test/jar-repos/jarrepo1_subdir.jar").getAbsolutePath());
+        resolver.setFile(FileUtil.newFile("test/jar-repos/jarrepo1_subdir.jar").getAbsolutePath());
         resolver.addIvyPattern("1/[organisation]/[module]/ivys/ivy-[revision].xml");
         resolver.addArtifactPattern("1/[organisation]/[module]/[type]s/[artifact]-[revision].[type]");
         resolver.setSettings(settings);
@@ -90,7 +90,7 @@ public class JarResolverTest extends TestCase {
     public void testUrl() throws Exception {
         JarResolver resolver = new JarResolver();
         resolver.setName("jarresolver1");
-        resolver.setUrl(new File("test/jar-repos/jarrepo1.jar").toURI().toURL().toExternalForm());
+        resolver.setUrl(FileUtil.newFile("test/jar-repos/jarrepo1.jar").toURI().toURL().toExternalForm());
         resolver.addIvyPattern("[organisation]/[module]/ivys/ivy-[revision].xml");
         resolver.addArtifactPattern("[organisation]/[module]/[type]s/[artifact]-[revision].[type]");
         resolver.setSettings(settings);

--- a/test/java/org/apache/ivy/plugins/resolver/Maven2LocalTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/Maven2LocalTest.java
@@ -45,7 +45,7 @@ public class Maven2LocalTest extends TestCase {
     protected void setUp() throws Exception {
         settings = new IvySettings();
         engine = new ResolveEngine(settings, new EventManager(), new SortEngine(settings));
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         data = new ResolveData(engine, new ResolveOptions());
         cache.mkdirs();
         settings.setDefaultCache(cache);
@@ -85,7 +85,7 @@ public class Maven2LocalTest extends TestCase {
         resolver.setSettings(settings);
         resolver.setName("maven2");
         resolver.setM2compatible(true);
-        resolver.setRoot(new File("test/repositories/m2").toURI().toURL().toExternalForm());
+        resolver.setRoot(FileUtil.newFile("test/repositories/m2").toURI().toURL().toExternalForm());
         return resolver;
     }
 }

--- a/test/java/org/apache/ivy/plugins/resolver/Maven2LocalTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/Maven2LocalTest.java
@@ -32,6 +32,7 @@ import org.apache.ivy.core.resolve.ResolvedModuleRevision;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortEngine;
 import org.apache.ivy.util.CacheCleaner;
+import org.apache.ivy.util.FileUtil;
 
 public class Maven2LocalTest extends TestCase {
     private IvySettings settings;

--- a/test/java/org/apache/ivy/plugins/resolver/MirroredURLResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/MirroredURLResolverTest.java
@@ -47,7 +47,7 @@ public class MirroredURLResolverTest extends TestCase {
     protected void setUp() throws Exception {
         settings = new IvySettings();
         engine = new ResolveEngine(settings, new EventManager(), new SortEngine(settings));
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         data = new ResolveData(engine, new ResolveOptions());
         cache.mkdirs();
         settings.setDefaultCache(cache);

--- a/test/java/org/apache/ivy/plugins/resolver/MirroredURLResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/MirroredURLResolverTest.java
@@ -31,6 +31,7 @@ import org.apache.ivy.core.resolve.ResolvedModuleRevision;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.settings.XmlSettingsParser;
 import org.apache.ivy.core.sort.SortEngine;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
 

--- a/test/java/org/apache/ivy/plugins/resolver/PackagerResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/PackagerResolverTest.java
@@ -71,8 +71,8 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
 
         // Create work space with build and resource cache directories
         workdir = new File("build/test/PackagerResolverTest");
-        builddir = new File(workdir, "build");
-        cachedir = new File(workdir, "resources");
+        builddir = FileUtil.newFile(workdir, "build");
+        cachedir = FileUtil.newFile(workdir, "resources");
         cleanupTempDirs();
         if (!builddir.mkdirs() || !cachedir.mkdirs()) {
             throw new Exception("can't create directories under " + workdir);
@@ -139,7 +139,7 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
             assertEquals(DownloadStatus.SUCCESSFUL, ar.getDownloadStatus());
 
             // Verify resource cache now contains the distribution archive
-            assertTrue(new File(cachedir, "mod-1.0.tar.gz").exists());
+            assertTrue(FileUtil.newFile(cachedir, "mod-1.0.tar.gz").exists());
 
             // Download again, should use Ivy cache this time
             report = resolver.download(new Artifact[] {artifact}, downloadOptions());
@@ -206,11 +206,11 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
             resolver.download(new Artifact[] {artifact}, downloadOptions());
 
             // assert that the file A.jar is extracted from the archive
-            File jar = new File(builddir, "org/A/1.0/artifacts/jars/A.jar");
+            File jar = FileUtil.newFile(builddir, "org/A/1.0/artifacts/jars/A.jar");
             assertTrue(jar.exists());
 
             // assert that the file README is not extracted from the archive
-            File readme = new File(builddir, "org/A/1.0/extract/A-1.0/README");
+            File readme = FileUtil.newFile(builddir, "org/A/1.0/extract/A-1.0/README");
             assertFalse(readme.exists());
         } finally {
             Locale.setDefault(oldLocale);
@@ -253,11 +253,11 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
             resolver.download(new Artifact[] {artifact}, downloadOptions());
 
             // assert that the file B.jar is extracted from the archive
-            File jar = new File(builddir, "org/B/1.0/artifacts/jars/B.jar");
+            File jar = FileUtil.newFile(builddir, "org/B/1.0/artifacts/jars/B.jar");
             assertTrue(jar.exists());
 
             // assert that the file README is not extracted from the archive
-            File readme = new File(builddir, "org/B/1.0/extract/B-1.0/README");
+            File readme = FileUtil.newFile(builddir, "org/B/1.0/extract/B-1.0/README");
             assertFalse(readme.exists());
         } finally {
             Locale.setDefault(oldLocale);

--- a/test/java/org/apache/ivy/plugins/resolver/PackagerResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/PackagerResolverTest.java
@@ -64,13 +64,13 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
         settings = new IvySettings();
         ResolveEngine engine = new ResolveEngine(settings, new EventManager(), new SortEngine(
                 settings));
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         data = new ResolveData(engine, new ResolveOptions());
         cache.mkdirs();
         settings.setDefaultCache(cache);
 
         // Create work space with build and resource cache directories
-        workdir = new File("build/test/PackagerResolverTest");
+        workdir = FileUtil.newFile("build/test/PackagerResolverTest");
         builddir = FileUtil.newFile(workdir, "build");
         cachedir = FileUtil.newFile(workdir, "resources");
         cleanupTempDirs();
@@ -98,7 +98,7 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
             // Create and configure resolver
             PackagerResolver resolver = new PackagerResolver();
             resolver.setSettings(settings);
-            String repoRoot = new File("test/repositories/packager/repo").toURI().toURL()
+            String repoRoot = FileUtil.newFile("test/repositories/packager/repo").toURI().toURL()
                     .toExternalForm();
             resolver.addIvyPattern(repoRoot + "[organisation]/[module]/[revision]/ivy.xml");
             resolver.setPackagerPattern(repoRoot
@@ -108,7 +108,7 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
             resolver.setPreserveBuildDirectories(true);
             resolver.setVerbose(true);
 
-            resolver.setProperty("packager.website.url", new File(
+            resolver.setProperty("packager.website.url", FileUtil.newFile(
                     "test/repositories/packager/website").toURI().toURL().toExternalForm());
 
             resolver.setName("packager");
@@ -180,7 +180,7 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
             // Create and configure resolver
             PackagerResolver resolver = new PackagerResolver();
             resolver.setSettings(settings);
-            String repoRoot = new File("test/repositories/IVY-1179/repo").toURI().toURL()
+            String repoRoot = FileUtil.newFile("test/repositories/IVY-1179/repo").toURI().toURL()
                     .toExternalForm();
             resolver.addIvyPattern(repoRoot + "[organisation]/[module]/[revision]/ivy.xml");
             resolver.setPackagerPattern(repoRoot
@@ -190,7 +190,7 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
             resolver.setPreserveBuildDirectories(true);
             resolver.setVerbose(true);
 
-            resolver.setProperty("packager.website.url", new File(
+            resolver.setProperty("packager.website.url", FileUtil.newFile(
                     "test/repositories/IVY-1179/website").toURI().toURL().toExternalForm());
 
             resolver.setName("packager");
@@ -227,7 +227,7 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
             // Create and configure resolver
             PackagerResolver resolver = new PackagerResolver();
             resolver.setSettings(settings);
-            String repoRoot = new File("test/repositories/IVY-1179/repo").toURI().toURL()
+            String repoRoot = FileUtil.newFile("test/repositories/IVY-1179/repo").toURI().toURL()
                     .toExternalForm();
             resolver.addIvyPattern(repoRoot + "[organisation]/[module]/[revision]/ivy.xml");
             resolver.setPackagerPattern(repoRoot
@@ -237,7 +237,7 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
             resolver.setPreserveBuildDirectories(true);
             resolver.setVerbose(true);
 
-            resolver.setProperty("packager.website.url", new File(
+            resolver.setProperty("packager.website.url", FileUtil.newFile(
                     "test/repositories/IVY-1179/website").toURI().toURL().toExternalForm());
 
             resolver.setName("packager");

--- a/test/java/org/apache/ivy/plugins/resolver/URLResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/URLResolverTest.java
@@ -59,7 +59,7 @@ public class URLResolverTest extends AbstractDependencyResolverTest {
     protected void setUp() throws Exception {
         settings = new IvySettings();
         engine = new ResolveEngine(settings, new EventManager(), new SortEngine(settings));
-        cache = new File("build/cache");
+        cache = FileUtil.newFile("build/cache");
         data = new ResolveData(engine, new ResolveOptions());
         cache.mkdirs();
         settings.setDefaultCache(cache);
@@ -75,7 +75,7 @@ public class URLResolverTest extends AbstractDependencyResolverTest {
     public void testFile() throws Exception {
         URLResolver resolver = new URLResolver();
         resolver.setSettings(settings);
-        String rootpath = new File("test/repositories/1").toURI().toURL().toExternalForm();
+        String rootpath = FileUtil.newFile("test/repositories/1").toURI().toURL().toExternalForm();
         resolver.addIvyPattern(rootpath + "/[organisation]/[module]/ivys/ivy-[revision].xml");
         resolver.addArtifactPattern(rootpath
                 + "/[organisation]/[module]/[type]s/[artifact]-[revision].[type]");
@@ -120,7 +120,7 @@ public class URLResolverTest extends AbstractDependencyResolverTest {
     public void testLatestFile() throws Exception {
         URLResolver resolver = new URLResolver();
         resolver.setSettings(settings);
-        String rootpath = new File("test/repositories/1").toURI().toURL().toExternalForm();
+        String rootpath = FileUtil.newFile("test/repositories/1").toURI().toURL().toExternalForm();
         resolver.addIvyPattern(rootpath + "[organisation]/[module]/ivys/ivy-[revision].xml");
         resolver.addArtifactPattern(rootpath
                 + "[organisation]/[module]/[type]s/[artifact]-[revision].[type]");
@@ -140,7 +140,7 @@ public class URLResolverTest extends AbstractDependencyResolverTest {
     public void testLatestFileWithOpaqueURL() throws Exception {
         URLResolver resolver = new URLResolver();
         resolver.setSettings(settings);
-        String rootpath = new File("test/repositories/1").getAbsoluteFile().toURI().toURL()
+        String rootpath = FileUtil.newFile("test/repositories/1").getAbsoluteFile().toURI().toURL()
                 .toExternalForm();
         resolver.addIvyPattern(rootpath + "/[organisation]/[module]/ivys/ivy-[revision].xml");
         resolver.addArtifactPattern(rootpath
@@ -326,7 +326,7 @@ public class URLResolverTest extends AbstractDependencyResolverTest {
     public void testDownloadWithUseOriginIsTrue() throws Exception {
         URLResolver resolver = new URLResolver();
         resolver.setSettings(settings);
-        String rootpath = new File("test/repositories/1").toURI().toURL().toExternalForm();
+        String rootpath = FileUtil.newFile("test/repositories/1").toURI().toURL().toExternalForm();
         resolver.addIvyPattern(rootpath + "/[organisation]/[module]/ivys/ivy-[revision].xml");
         resolver.addArtifactPattern(rootpath
                 + "/[organisation]/[module]/[type]s/[artifact]-[revision].[type]");

--- a/test/java/org/apache/ivy/plugins/resolver/URLResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/URLResolverTest.java
@@ -40,6 +40,7 @@ import org.apache.ivy.core.resolve.ResolvedModuleRevision;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortEngine;
 import org.apache.ivy.plugins.matcher.ExactPatternMatcher;
+import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
 

--- a/test/java/org/apache/ivy/plugins/resolver/util/ResolverHelperTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/util/ResolverHelperTest.java
@@ -27,7 +27,7 @@ import org.apache.ivy.plugins.repository.file.FileRepository;
 public class ResolverHelperTest extends TestCase {
 
     public void testListTokenValuesForIvy1238() {
-        FileRepository rep = new FileRepository(new File(".").getAbsoluteFile());
+        FileRepository rep = new FileRepository(FileUtil.newFile(".").getAbsoluteFile());
         String[] revisions = ResolverHelper.listTokenValues(rep,
             "test/repositories/IVY-1238/ivy-org/modA/v[revision]/ivy.xml", "revision");
 

--- a/test/java/org/apache/ivy/plugins/resolver/util/ResolverHelperTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/util/ResolverHelperTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import junit.framework.TestCase;
 
 import org.apache.ivy.plugins.repository.file.FileRepository;
+import org.apache.ivy.util.FileUtil;
 
 public class ResolverHelperTest extends TestCase {
 

--- a/test/java/org/apache/ivy/plugins/trigger/LogTriggerTest.java
+++ b/test/java/org/apache/ivy/plugins/trigger/LogTriggerTest.java
@@ -43,7 +43,7 @@ public class LogTriggerTest extends TestCase {
             ModuleRevisionId.parse("o#A;1"), new Date()), new String[] {"c"});
         trigger = new LogTrigger();
         trigger.setEvent(ev.getName());
-        testDir = new File("build/test/trigger");
+        testDir = FileUtil.newFile("build/test/trigger");
         testDir.mkdirs();
     }
 

--- a/test/java/org/apache/ivy/plugins/trigger/LogTriggerTest.java
+++ b/test/java/org/apache/ivy/plugins/trigger/LogTriggerTest.java
@@ -63,7 +63,7 @@ public class LogTriggerTest extends TestCase {
 
     public void testFile() throws Exception {
         trigger.setMessage("msg: ${organisation} ${module} ${revision}");
-        File f = new File(testDir, "test.log");
+        File f = FileUtil.newFile(testDir, "test.log");
         trigger.setFile(f);
 
         trigger.progress(ev);
@@ -79,7 +79,7 @@ public class LogTriggerTest extends TestCase {
 
     public void testFileNoAppend() throws Exception {
         trigger.setMessage("msg: ${organisation} ${module} ${revision}");
-        File f = new File(testDir, "test.log");
+        File f = FileUtil.newFile(testDir, "test.log");
         trigger.setFile(f);
         trigger.setAppend(false);
 

--- a/test/java/org/apache/ivy/util/url/BasicURLHandlerTest.java
+++ b/test/java/org/apache/ivy/util/url/BasicURLHandlerTest.java
@@ -34,7 +34,7 @@ public class BasicURLHandlerTest extends TestCase {
     private BasicURLHandler handler;
 
     protected void setUp() throws Exception {
-        testDir = new File("build/BasicURLHandlerTest");
+        testDir = FileUtil.newFile("build/BasicURLHandlerTest");
         testDir.mkdirs();
 
         handler = new BasicURLHandler();
@@ -48,8 +48,8 @@ public class BasicURLHandlerTest extends TestCase {
         assertTrue(handler.isReachable(new URL("http://www.google.fr/")));
         assertFalse(handler.isReachable(new URL("http://www.google.fr/unknownpage.html")));
 
-        assertTrue(handler.isReachable(new File("build.xml").toURI().toURL()));
-        assertFalse(handler.isReachable(new File("unknownfile.xml").toURI().toURL()));
+        assertTrue(handler.isReachable(FileUtil.newFile("build.xml").toURI().toURL()));
+        assertFalse(handler.isReachable(FileUtil.newFile("unknownfile.xml").toURI().toURL()));
 
         // to test ftp we should know of an anonymous ftp site... !
         // assertTrue(handler.isReachable(new URL("ftp://ftp.mozilla.org/pub/dir.sizes")));
@@ -57,16 +57,16 @@ public class BasicURLHandlerTest extends TestCase {
     }
 
     public void testContentEncoding() throws Exception {
-        assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/daniels.html"), new File(
+        assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/daniels.html"), FileUtil.newFile(
                 testDir, "gzip.txt"));
         assertDownloadOK(new URL(
-                "http://carsten.codimi.de/gzip.yaws/daniels.html?deflate=on&zlib=on"), new File(
+                "http://carsten.codimi.de/gzip.yaws/daniels.html?deflate=on&zlib=on"), FileUtil.newFile(
                 testDir, "deflate-zlib.txt"));
         assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/daniels.html?deflate=on"),
             FileUtil.newFile(testDir, "deflate.txt"));
         assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/a5.ps"), FileUtil.newFile(testDir,
                 "a5-gzip.ps"));
-        assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/a5.ps?deflate=on"), new File(
+        assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/a5.ps?deflate=on"), FileUtil.newFile(
                 testDir, "a5-deflate.ps"));
         assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/nh80.pdf"), FileUtil.newFile(testDir,
                 "nh80-gzip.pdf"));

--- a/test/java/org/apache/ivy/util/url/BasicURLHandlerTest.java
+++ b/test/java/org/apache/ivy/util/url/BasicURLHandlerTest.java
@@ -63,15 +63,15 @@ public class BasicURLHandlerTest extends TestCase {
                 "http://carsten.codimi.de/gzip.yaws/daniels.html?deflate=on&zlib=on"), new File(
                 testDir, "deflate-zlib.txt"));
         assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/daniels.html?deflate=on"),
-            new File(testDir, "deflate.txt"));
-        assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/a5.ps"), new File(testDir,
+            FileUtil.newFile(testDir, "deflate.txt"));
+        assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/a5.ps"), FileUtil.newFile(testDir,
                 "a5-gzip.ps"));
         assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/a5.ps?deflate=on"), new File(
                 testDir, "a5-deflate.ps"));
-        assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/nh80.pdf"), new File(testDir,
+        assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/nh80.pdf"), FileUtil.newFile(testDir,
                 "nh80-gzip.pdf"));
         assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/nh80.pdf?deflate=on"),
-            new File(testDir, "nh80-deflate.pdf"));
+            FileUtil.newFile(testDir, "nh80-deflate.pdf"));
     }
 
     private void assertDownloadOK(URL url, File file) throws Exception {

--- a/test/java/org/apache/ivy/util/url/HttpclientURLHandlerTest.java
+++ b/test/java/org/apache/ivy/util/url/HttpclientURLHandlerTest.java
@@ -35,7 +35,7 @@ public class HttpclientURLHandlerTest extends TestCase {
     private HttpClientHandler handler;
 
     protected void setUp() throws Exception {
-        testDir = new File("build/HttpclientURLHandlerTest");
+        testDir = FileUtil.newFile("build/HttpclientURLHandlerTest");
         testDir.mkdirs();
 
         handler = new HttpClientHandler();
@@ -61,16 +61,16 @@ public class HttpclientURLHandlerTest extends TestCase {
     }
 
     public void testContentEncoding() throws Exception {
-        assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/daniels.html"), new File(
+        assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/daniels.html"), FileUtil.newFile(
                 testDir, "gzip.txt"));
         assertDownloadOK(new URL(
-                "http://carsten.codimi.de/gzip.yaws/daniels.html?deflate=on&zlib=on"), new File(
+                "http://carsten.codimi.de/gzip.yaws/daniels.html?deflate=on&zlib=on"), FileUtil.newFile(
                 testDir, "deflate-zlib.txt"));
         assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/daniels.html?deflate=on"),
             FileUtil.newFile(testDir, "deflate.txt"));
         assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/a5.ps"), FileUtil.newFile(testDir,
                 "a5-gzip.ps"));
-        assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/a5.ps?deflate=on"), new File(
+        assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/a5.ps?deflate=on"), FileUtil.newFile(
                 testDir, "a5-deflate.ps"));
         assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/nh80.pdf"), FileUtil.newFile(testDir,
                 "nh80-gzip.pdf"));

--- a/test/java/org/apache/ivy/util/url/HttpclientURLHandlerTest.java
+++ b/test/java/org/apache/ivy/util/url/HttpclientURLHandlerTest.java
@@ -67,15 +67,15 @@ public class HttpclientURLHandlerTest extends TestCase {
                 "http://carsten.codimi.de/gzip.yaws/daniels.html?deflate=on&zlib=on"), new File(
                 testDir, "deflate-zlib.txt"));
         assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/daniels.html?deflate=on"),
-            new File(testDir, "deflate.txt"));
-        assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/a5.ps"), new File(testDir,
+            FileUtil.newFile(testDir, "deflate.txt"));
+        assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/a5.ps"), FileUtil.newFile(testDir,
                 "a5-gzip.ps"));
         assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/a5.ps?deflate=on"), new File(
                 testDir, "a5-deflate.ps"));
-        assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/nh80.pdf"), new File(testDir,
+        assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/nh80.pdf"), FileUtil.newFile(testDir,
                 "nh80-gzip.pdf"));
         assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/nh80.pdf?deflate=on"),
-            new File(testDir, "nh80-deflate.pdf"));
+            FileUtil.newFile(testDir, "nh80-deflate.pdf"));
     }
 
     private void assertDownloadOK(URL url, File file) throws Exception {


### PR DESCRIPTION
Seeing how you have this nice branch of Ivy already set up, I decided to go to you guys with this first.
Basically, I'd _really_ love to be able to test my entire workflow, including the use of Ivy to publish things, and I'd like to do this safely. 
Now, since I'm using Java 7, there's a really nice tool called [memoryfilesystem](https://github.com/marschall/memoryfilesystem) which provides a Java 7 NIO `FileSystem` stored entirely in memory.
I can (and did) extend File to make all operations use a nio `Path` behind the scenes, but the blockers are all these `new File()` calls, as well as `new FileInputStream` etc. So I've decided to make all these into function calls, all centralised under Ivy's `FileUtil`, that can easily be overridden. (and of course, still compatible with Java 5).

Hence I've translated:
- `new File(...)` into `FileUtil.newFile(...)`
- `new FileInputStream(...)` into `FileUtil.newInputStream(...)` -- _returns an `InputStream`_, not a `FileInputStream` but haven't had problems with this fact anywhere in the code
- `new FileOutputStream(...)` into `FileUtil.newOutputStream(...)` -- _returns an `OutputStream`_ - same argument as above
- `new FileReader(...)` into `FileUtil.newReader(...)` -- _returns a `Reader` not a `FileReader`_ but again, same argument as above

You'd overwrite the default behaviour by saying:

``` java
// PathBackedFile is expected to provide the same constructors as java.io.File with the exception of the constructor taking a FileDescriptor
FileUtil.setFIleImpl( PathBackedFile.class ); // where PathBackedFile <: File
// Set FileOps, which dictate how to create Input|Output Streams and Readers given a File
FileUtil.setFileOps( new FileUtil.FileOps {
  public InputStream newInputStream(File f) { 
    if (f instanceof PathBackedFile)
      // PathBackedFile.path is a java.nio.file.Path
      return java.nio.file.Files.getInputStream( ((PathBackedFile) f).path );
    else
      return super.newInputStream(f);
  }

  // etc for newOutputStream and newReader
});
```

_Edit:_ There's also `RandomAccessFile` that I should fix, possibly in the same way: allowing the user to provide their own implementation. Currently it's only used in `org.apache.ivy.plugins.lock.FileBasedLockStrategy`.
