### PR TITLE
Cache IvyNode#getdependencies

### DIFF
--- a/src/java/org/apache/ivy/core/resolve/IvyNode.java
+++ b/src/java/org/apache/ivy/core/resolve/IvyNode.java
@@ -101,7 +101,7 @@ public class IvyNode implements Comparable {
 
     private Collection loadedRootModuleConfs = new HashSet();
 
-    private Map loadedDependencies = new HashMap();
+    private Map/* <String, Collection<IvyNode>> */loadedDependencies = new HashMap/*<String, Collection<IvyNode>>*/();
 
     // //////// USAGE DATA
 

--- a/src/java/org/apache/ivy/core/resolve/IvyNode.java
+++ b/src/java/org/apache/ivy/core/resolve/IvyNode.java
@@ -101,6 +101,8 @@ public class IvyNode implements Comparable {
 
     private Collection loadedRootModuleConfs = new HashSet();
 
+    private Map loadedDependencies = new HashMap();
+
     // //////// USAGE DATA
 
     private IvyNodeUsage usage = new IvyNodeUsage(this);
@@ -327,6 +329,18 @@ public class IvyNode implements Comparable {
             throw new IllegalStateException(
                     "impossible to get dependencies when data has not been loaded");
         }
+        String cacheInput = rootModuleConf + ":" + conf + ":" + requestedConf;
+        if (loadedDependencies.containsKey(cacheInput)) {
+            return (Collection) loadedDependencies.get(cacheInput);
+        } else {
+            Collection cacheOutput = doGetDependencies(rootModuleConf, conf, requestedConf);
+            loadedDependencies.put(cacheInput, cacheOutput);
+            return cacheOutput;
+        }
+    }
+
+    private Collection/* <IvyNode> */doGetDependencies(String rootModuleConf, String conf,
+            String requestedConf) {
         DependencyDescriptor[] dds = md.getDependencies();
         Map/* <ModuleRevisionId, IvyNode> */dependencies = new LinkedHashMap(); // it's important to
                                                                                 // respect order

--- a/src/java/org/apache/ivy/core/resolve/ResolveEngine.java
+++ b/src/java/org/apache/ivy/core/resolve/ResolveEngine.java
@@ -793,6 +793,7 @@ public class ResolveEngine {
 
         // now we can actually resolve this configuration dependencies
         if (!isDependenciesFetched(node.getNode(), conf) && node.isTransitive()) {
+            Message.debug("about to get dependencies for " + node.toString());
             Collection/* <VisitNode> */dependencies = node.getDependencies(conf);
             for (Iterator iter = dependencies.iterator(); iter.hasNext();) {
                 VisitNode dep = (VisitNode) iter.next();


### PR DESCRIPTION
`IvyNode#getDependencies` is one of the hot spots frequently called during resolution. See sbt/ivy#4 for more analysis on `ResolveEngine.resolve`.

Adding caching at this level is not as invasive, and has a nice speedup. Using large-graph sample project, 17s resolution improved to 10s.
