### PR TITLE
Increase default size for ModuleDescriptorMemoryCache

### DIFF
--- a/src/java/org/apache/ivy/core/cache/DefaultRepositoryCacheManager.java
+++ b/src/java/org/apache/ivy/core/cache/DefaultRepositoryCacheManager.java
@@ -79,7 +79,7 @@ public class DefaultRepositoryCacheManager implements RepositoryCacheManager, Iv
 
     private static final String DEFAULT_IVY_PATTERN = "[organisation]/[module](/[branch])/ivy-[revision].xml";
 
-    private static final int DEFAULT_MEMORY_CACHE_SIZE = 150;
+    private static final int DEFAULT_MEMORY_CACHE_SIZE = 1024;
 
     private static MessageDigest SHA_DIGEST;
     static {


### PR DESCRIPTION
Increase the default size of module descriptor memory cache from 150 to 1024.
There are some speedup gain when the dependency graph is large.

Related to sbt/ivy#4, increasing the cache size should reduce the IO overhead during Ivy resolution. Compared to cached `IvyNode#getDependencies` available on 2.4.x-sbt branch, the increasing ModuleDescriptorMemoryCache to 1024 shortened "large-graph" project's resolution from 12±1s to 11±1s. In the wild, I have a project with speedup from 14±5s to 13±1s.
