### PR TITLE
Add caching around DefaultDependencyDescriptor's doesExclude.

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,14 +1,13 @@
-                          Apache Ivy (TM) 2.3.0-rc2
+                          Apache Ivy (TM) 2.3.0
                                Release Notes
    -----------------------------------------------------------------------
 
 CONTENTS
 1. What is Apache Ivy?
-2. Status of this release
-3. How to Get Involved
-4. How to Report Issues
-5. Committers and Contributors for this release
-6. List of Changes in this Release   
+2. How to Get Involved
+3. How to Report Issues
+4. Committers and Contributors for this release
+5. List of Changes in this Release   
    
    
 1. What is Apache Ivy?
@@ -28,28 +27,18 @@ It is characterized by the following:
         with Apache Ant providing a number of powerful Ant tasks ranging 
         from dependency resolution to dependency reporting and publication.
 
-2. Status of this release 
-
-This is the second release candidate of Ivy targetting 2.3.0. 
-
-As a release candidate version, we strongly encourage the use of this version for 
-testing and validation. From now on, features are frozen until final 2.3.0 version, 
-only bug fixes may be applied before 2.3.0. If no outstanding bugs are reported 
-with this release candidate, it will promoted to 2.3.0 about three weeks after this
-release candidate. 
-
-3. How to Get Involved
+2. How to Get Involved
 
 The Apache Ivy project really needs and appreciates any contributions, 
 including documentation help, source code and feedback.  If you are interested
 in contributing, please visit http://ant.apache.org/ivy/get-involved.html.
 
-4. How to Report Issues
+3. How to Report Issues
 
 The Apache Ivy project uses JIRA for issue tracking.  Please report any 
 issues you find at http://issues.apache.org/jira/browse/IVY
 
-5. Committers and Contributors for this Release
+4. Committers and Contributors for this Release
 
 Here is the list of people who have contributed source code and documentation
 to this release. Many thanks to all of them, and also to the whole Ivy community
@@ -58,6 +47,7 @@ long, but Ivy couldn't be what it is without you!
 
  Committers
     Matt Benson
+    Jean-Louis Boudart
     Maarten Coene
     Xavier Hanin
     Nicolas Lalevee
@@ -65,28 +55,64 @@ long, but Ivy couldn't be what it is without you!
     Gilles Scokart
 
  Contributors
-    Jean-Louis Boudart
+    Arnold Blaasmo
     Ed Burcher
+    Joseph Boyd
+    Wei Chen
     Robin Fernandes
     Wolfgang Frank
     Mitch Gitman
+    Payam Hekmat
+    Stepan Koltsov
     Thomas Kurpick
     Ales Nosek
+    Douglas Palmer
     Carl Quinn
+    Torkild U. Resheim
+    Jens Rohloff
+    Ben Schmidt
+    Nihal Sinha
+    Sven Zethelius
 
 For the list of people who have contributed since Ivy inception, see CHANGES.txt file.
 
-6. List of Changes in this Release
+5. List of Changes in this Release
 
 For a full release history of Ivy see the file CHANGES.txt
 
 For details about the following changes, check our JIRA install at 
 http://issues.apache.org/jira/browse/ivy
 
-List of changes since Ivy 2.3.0-rc1:
+List of changes since Ivy 2.2.0:
+- DOCUMENTATION: Bad example in Project dependencies Tutorial (IVY-1263)
+- DOCUMENTATION: remove deprecated defaultCache setting from examples (IVY-1273) (thanks to Joseph Boyd)
+- DOCUMENTATION: link to FAQ is incorrect in distribution files (IVY-793) (thanks to Joseph Boyd)
+- DOCUMENTATION: The tag version-matchers is missing attribute in documentation (IVY-1292) (thanks to Per Arnold Blaasmo)
+- DOCUMENTATION: wrong default resolver documented on the 'How does it work' page (IVY-1265)
+- DOCUMENTATION: Correct outdated links to configuration pages (IVY-1266)
 - DOCUMENTATION: Documentation and Implementation mismatch of makepom (IVY-1383) (thanks to Thomas Kurpick)
 - DOCUMENTATION: added link to extra beginners guide (IVY-1381)
 
+- NEW: [orgPath] can now be used as token in ivy/artifact patterns
+- NEW: New Ant datatype ivy:resources, an Ant resource collection like ivy:cachepath or ivy:cachefileset (IVY-334)
+- NEW: ivy:resolve and post resole task can now have inlined dependencies declaration.
+- NEW: Import Bushel into Ivy core (IVY-1241)
+- NEW: An new resolver 'mirroredurl' which can handle a list of mirrored URL repositories (IVY-468)
+- NEW: Support for a jar resolver (IVY-1312)
+
+- IMPROVEMENT: ivy:install task does not allow specification of conf (IVY-1313) (thanks to Nihal Sinha)
+- IMPROVEMENT: ivy:makepom ignores the artifact type in generated dependencies (IVY-1229) (thanks to Douglas Palmer)
+- IMPROVEMENT: ivy:makepom now honors exclusion of artifacts in generated pom files (IVY-1294) (thanks to Jens Rohloff)
+- IMPROVEMENT: Added support for dynamic revisions in <extends> tag (IVY-1281)
+- IMPROVEMENT: ivy:makepom child element dependency should support the type and classifier attributes (IVY-1262)
+- IMPROVEMENT: ivy:retrieve can now create a path or fileset containing the retrieved artifacts (IVY-1235)
+- IMPROVEMENT: Improve diagnostics in ssh resolver (IVY-1267) (thanks to Stepan Koltsov)
+- IMPROVEMENT: ivy:retrieve now accepts a nested mapper type.
+
+- FIX: Ivy generates wrong revision in URL for Maven snapshots (IVY-1396)
+- FIX: Maven2: resolve failure when parent has <dependencyManagement> with dependency in 'import' scope (IVY-1376)
+- FIX: IvyPublish fails when using extend tags with no explicit location attribute (IVY-1391)
+- FIX: *.lck files created by "artifact-lock" lock strategy are not cleaned up if ivy quits abruptly (IVY-1388) (thanks to Wei Chen)
 - FIX: Ivy default cache path with non-ASCII character lets it crash (IVY-1378)
 - FIX: latest.integration isn't resolved against a Maven snapshot repository (when uniqueVersion = true) (IVY-1036)
 - FIX: Resolve does not deliver all dependent artifacts (IVY-1366) (thanks to Wolfgang Frank)
@@ -107,3 +133,37 @@ List of changes since Ivy 2.3.0-rc1:
 - FIX: Buildnumber and IvyFindRevision Ant tasks should honour defaultBranch setting (IVY-1344) (Thanks to Ales Nosek)
 - FIX: ApacheURLLister.retrieveListing() fails if the encoding of the URL list is different from the default encoding (IVY-1060) (Thanks to Robin Fernandes)
 - FIX: global exclude rules is not applying to root ivy files
+- FIX: Exclude doesn't work when there is some circular dependencies (IVY-1309)
+- FIX: Impossible to get artifacts when data has not been loaded for multiple dynamic revisions (IVY-1333)
+- FIX: Ivy didn't properly handle some file: URLs (IVY-1340)
+- FIX: fallback mechanism didn't work properly for private configurations
+- FIX: /localivy target does not work when building Ivy jar (IVY-1338) (thanks to Ben Schmidt)
+- FIX: The showprogress=false attribute of ivy:resolve doesn't do what it should (IVY-1052) (thanks to Joseph Boyd)
+- FIX: extends ignores defaultconfmapping/defaultconf/confmappingoverride attributes from parent's configurations and dependencies tags (IVY-1213)
+- FIX: NullPointerException when providing empty password to <credentials> (IVY-1335)
+- FIX: [originalname] not expanded for source and javadoc types during publish in ivy:install (IVY-1324)
+- FIX: cannot resolve from repositories that return HTTP 204 in response to an HTTP HEAD request (IVY-1328)
+- FIX: extra attributes lost from info when ivy file is merged with parent (IVY-1206)
+- FIX: ivy:report ant task intermittently "cannot compile stylesheet" (IVY-1325)
+- FIX: Maven 'eclipse-plugin', 'jbi-component' and 'jbi-shared-library' packaging is now mapped to 'jar' extension (IVY-899)
+- FIX: Infinite loop in latest-compatible conflict manager (IVY-1233) (thanks to Payam Hekmat and Sven Zethelius)
+- FIX: extends section of ivy.xml info does not replace variable in location tag (IVY-1287)
+- FIX: Valid Path does not work for Filesystem Resolver (IVY-1268)
+- FIX: quiet="true" does not surpress download 'dots' on packager resolver (IVY-1269)
+- FIX: Dynamic version resolution result can be incorrect when ivy metadata contains extra attributes (IVY-1236)
+- FIX: NullPointerException in FileUtil#forceDelete.
+- FIX: XmlModuleDescriptorUpdater is a mess that produces broken xmls in many cases (IVY-1010)
+- FIX: ivy.xml that contains UTF-8 encoded umlauts cannot be bigger than 10000 bytes (IVY-1253)
+- FIX: Can not use a v[revision] in an artifact pattern of a filesystem resolver (IVY-1238)
+- FIX: Cached ivy.xml is invalid if the description contains the ampersand entity (&amp;) (IVY-1237)
+- FIX: Couldn't authenticate against sites having the same address as the proxy server (IVY-1234)
+- FIX: OutOfMemoryError when uploading large files using commons-httpclient (IVY-1197) (thanks to Torkild U. Resheim)
+- FIX: Only the last dependency descriptor is taken into account on the same module (IVY-1240)
+- FIX: UseCacheOnly doesn't respect the cache configuration in the ivysettings (IVY-1227)
+- FIX: UseCacheOnly is influenced by the TTL on cached metadata (IVY-1243)
+- FIX: ConcurrentModificationException on ivy settings loading (IVY-1250)
+- FIX: Module inheritance sometimes fails to locate parent descriptor in deliver process (IVY-1248)
+- FIX: <cachefileset> on an empty configuration produces a very slow-to-evaluate fileset (IVY-1272)
+- FIX: Ivy does not apply overridden properties to m2 parent dependency versions specified using properties (IVY-1299)
+- FIX: Ivy does not apply overridden properties to m2 parent dependency versions specified using dependencyManagement properties (IVY-1301)
+

--- a/doc/release-notes.html
+++ b/doc/release-notes.html
@@ -28,32 +28,27 @@
 <h2>Announcement</h2>
 
 <pre>
-April 20, 2012 - The Ivy project is pleased to announce its 2.3.0-RC1 release.
+Jan 20, 2013 - The Apache Ivy project is pleased to announce its 2.3.0 release.
 
-Ivy is a tool for managing (recording, tracking, resolving and
+Apache Ivy is a tool for managing (recording, tracking, resolving and
 reporting) project dependencies, characterized by flexibility,
 configurability, and tight integration with Apache Ant.
 
-Key features of this 2.3.0-RC1 release are
+Key features of this 2.3.0 release are
 * improved Ant support with some new Ant tasks and enhancements to existing tasks
+* improved Maven2 compatibility
 * some new resolvers
 * numerous bug fixes as documented in Jira and in the release notes
 
 In addition, experimental OSGI support has been added to the Ivy core.
 
-As a release candidate version, we strongly encourage the use of this version for 
-testing and validation. From now on, features are frozen until final 2.3.0 version, 
-only bug fixes will be applied before 2.3.0. If no outstanding bugs are reported 
-with this release candidate, it will promoted to 2.3.0 about three weeks after this
-release candidate. 
+You can download this 2.3.0 release at:
+http://ant.apache.org/ivy/download.cgi
 
 Issues should be reported to:
 https://issues.apache.org/jira/browse/IVY
 
-Download the 2.3.0-RC1 release at:
-http://ant.apache.org/ivy/download.cgi
-
-More information can be found on the Ivy website:
+More information can be found on the website:
 http://ant.apache.org/ivy/
 
 Regards,
@@ -87,29 +82,18 @@ It is characterized by the following:
         with Apache Ant providing a number of powerful Ant tasks ranging 
         from dependency resolution to dependency reporting and publication.
 
-<h3>2. Status of this release</h3> 
-
-This is the first release candidate of Ivy targetting 2.3.0. 
-
-As a release candidate version, we strongly encourage the use of this version for 
-testing and validation. From now on, features are frozen until final 2.3.0 version, 
-only bug fixes may be applied before 2.3.0. If no outstanding bugs are reported 
-with this release candidate, it will promoted to 2.3.0 about three weeks after this
-release candidate. 
-
-
-<h3>3. How to Get Involved</h3>
+<h3>2. How to Get Involved</h3> 
 
 The Apache Ivy project really needs and appreciates any contributions, 
 including documentation help, source code and feedback.  If you are interested
 in contributing, please visit http://ant.apache.org/ivy/get-involved.html.
 
-<h3>4. How to Report Issues</h3>
+<h3>3. How to Report Issues</h3>
 
 The Apache Ivy project uses JIRA for issue tracking.  Please report any 
 issues you find at http://issues.apache.org/jira/browse/IVY
 
-<h3>5. Committers and Contributors for this Release</h3>
+<h3>4. Committers and Contributors for this Release</h3>
 
 Here is the list of people who have contributed source code and documentation
 to this release. Many thanks to all of them, and also to the whole Ivy community
@@ -118,6 +102,7 @@ long, but Ivy couldn't be what it is without you!
 
  Committers
     Matt Benson
+    Jean-Louis Boudart
     Maarten Coene
     Xavier Hanin
     Nicolas Lalevee
@@ -126,11 +111,18 @@ long, but Ivy couldn't be what it is without you!
 
  Contributors
     Arnold Blaasmo
-    Jean-Louis Boudart
+    Ed Burcher
     Joseph Boyd
+    Wei Chen
+    Robin Fernandes
+    Wolfgang Frank
+    Mitch Gitman
     Payam Hekmat
     Stepan Koltsov
+    Thomas Kurpick
+    Ales Nosek
     Douglas Palmer
+    Carl Quinn
     Torkild U. Resheim
     Jens Rohloff
     Ben Schmidt
@@ -139,7 +131,7 @@ long, but Ivy couldn't be what it is without you!
 
 For the list of people who have contributed since Ivy inception, see CHANGES.txt file.
 
-<h3>6. List of Changes in this Release</h3>
+<h3>5. List of Changes in this Release</h3>
 
 For a full release history of Ivy see the file CHANGES.txt
 
@@ -147,12 +139,16 @@ For details about the following changes, check our JIRA install at
 http://issues.apache.org/jira/browse/ivy
 
 List of changes since Ivy 2.2.0:
+- DOCUMENTATION: Bad example in Project dependencies Tutorial (IVY-1263)
 - DOCUMENTATION: remove deprecated defaultCache setting from examples (IVY-1273) (thanks to Joseph Boyd)
 - DOCUMENTATION: link to FAQ is incorrect in distribution files (IVY-793) (thanks to Joseph Boyd)
 - DOCUMENTATION: The tag version-matchers is missing attribute in documentation (IVY-1292) (thanks to Per Arnold Blaasmo)
 - DOCUMENTATION: wrong default resolver documented on the 'How does it work' page (IVY-1265)
 - DOCUMENTATION: Correct outdated links to configuration pages (IVY-1266)
+- DOCUMENTATION: Documentation and Implementation mismatch of makepom (IVY-1383) (thanks to Thomas Kurpick)
+- DOCUMENTATION: added link to extra beginners guide (IVY-1381)
 
+- NEW: [orgPath] can now be used as token in ivy/artifact patterns
 - NEW: New Ant datatype ivy:resources, an Ant resource collection like ivy:cachepath or ivy:cachefileset (IVY-334)
 - NEW: ivy:resolve and post resole task can now have inlined dependencies declaration.
 - NEW: Import Bushel into Ivy core (IVY-1241)
@@ -162,13 +158,36 @@ List of changes since Ivy 2.2.0:
 - IMPROVEMENT: ivy:install task does not allow specification of conf (IVY-1313) (thanks to Nihal Sinha)
 - IMPROVEMENT: ivy:makepom ignores the artifact type in generated dependencies (IVY-1229) (thanks to Douglas Palmer)
 - IMPROVEMENT: ivy:makepom now honors exclusion of artifacts in generated pom files (IVY-1294) (thanks to Jens Rohloff)
-- IMPROVEMENT: Added support for dynamic revisions in <extends> tag (IVY-1281) (thanks to Jean-Louis Boudart)
+- IMPROVEMENT: Added support for dynamic revisions in <extends> tag (IVY-1281)
 - IMPROVEMENT: ivy:makepom child element dependency should support the type and classifier attributes (IVY-1262)
 - IMPROVEMENT: ivy:retrieve can now create a path or fileset containing the retrieved artifacts (IVY-1235)
 - IMPROVEMENT: Improve diagnostics in ssh resolver (IVY-1267) (thanks to Stepan Koltsov)
-- IMPROVEMENT: ivy:retrieve can now convert 'dotted'-organisation names into a directory tree.
 - IMPROVEMENT: ivy:retrieve now accepts a nested mapper type.
 
+- FIX: Ivy generates wrong revision in URL for Maven snapshots (IVY-1396)
+- FIX: Maven2: resolve failure when parent has <dependencyManagement> with dependency in 'import' scope (IVY-1376)
+- FIX: IvyPublish fails when using extend tags with no explicit location attribute (IVY-1391)
+- FIX: *.lck files created by "artifact-lock" lock strategy are not cleaned up if ivy quits abruptly (IVY-1388) (thanks to Wei Chen)
+- FIX: Ivy default cache path with non-ASCII character lets it crash (IVY-1378)
+- FIX: latest.integration isn't resolved against a Maven snapshot repository (when uniqueVersion = true) (IVY-1036)
+- FIX: Resolve does not deliver all dependent artifacts (IVY-1366) (thanks to Wolfgang Frank)
+- FIX: Ivy descriptors are merged incorrectly when there is an <exclude> element (IVY-1356)
+- FIX: SimpleDateFormat is not thread safe (IVY-1373)
+- FIX: Maven 'hk2-jar' packaging is now supported (IVY-1357)
+- FIX: Maven 'orbit' and 'pear' packaging is now supported (IVY-899)
+- FIX: Memory leak and infinite loop in ModuleId.java (IVY-1362)
+- FIX: Unnecessary warning when parent ivy.xml is not found (IVY-1346)
+- FIX: StackOverflowError when using <extends> and ../ivy.xml is not the parent ivy.xml (IVY-1437)
+- FIX: NullPointerExeption in AbstractOSGiResolver (IVY-1343) (thanks to Thomas Kurpick)
+- FIX: Delivered ivy descriptor inconsistent with resolve report / retrieve and other post-resolve actions (IVY-1300) (thanks to Ed Burcher)
+- FIX: The Updatesite resolver is downloading Eclipse features instead of Eclipse bundle/plugin
+- FIX: ivy:buildlist task confused by extends feature using two parents (IVY-1363) (thanks to Mitch Gitman and Jean-Louis Boudart)
+- FIX: ivy.xml extends feature complains about Windows filesystem path (IVY-1359) (thanks to Mitch Gitman and Jean-Louis Boudart)
+- FIX: buildlist task chokes on absolute path to parent Ivy module (IVY-1364) (thanks to Mitch Gitman and Jean-Louis Boudart)
+- FIX: The ignore circular dependency strategy is clobbering the warn strategy (IVY-1353) (Thanks to Carl Quinn)
+- FIX: Buildnumber and IvyFindRevision Ant tasks should honour defaultBranch setting (IVY-1344) (Thanks to Ales Nosek)
+- FIX: ApacheURLLister.retrieveListing() fails if the encoding of the URL list is different from the default encoding (IVY-1060) (Thanks to Robin Fernandes)
+- FIX: global exclude rules is not applying to root ivy files
 - FIX: Exclude doesn't work when there is some circular dependencies (IVY-1309)
 - FIX: Impossible to get artifacts when data has not been loaded for multiple dynamic revisions (IVY-1333)
 - FIX: Ivy didn't properly handle some file: URLs (IVY-1340)
@@ -183,7 +202,7 @@ List of changes since Ivy 2.2.0:
 - FIX: ivy:report ant task intermittently "cannot compile stylesheet" (IVY-1325)
 - FIX: Maven 'eclipse-plugin', 'jbi-component' and 'jbi-shared-library' packaging is now mapped to 'jar' extension (IVY-899)
 - FIX: Infinite loop in latest-compatible conflict manager (IVY-1233) (thanks to Payam Hekmat and Sven Zethelius)
-- FIX: extends section of ivy.xml info does not replace variable in location tag (IVY-1287) (thanks to Jean-Louis Boudart)
+- FIX: extends section of ivy.xml info does not replace variable in location tag (IVY-1287)
 - FIX: Valid Path does not work for Filesystem Resolver (IVY-1268)
 - FIX: quiet="true" does not surpress download 'dots' on packager resolver (IVY-1269)
 - FIX: Dynamic version resolution result can be incorrect when ivy metadata contains extra attributes (IVY-1236)
@@ -198,7 +217,7 @@ List of changes since Ivy 2.2.0:
 - FIX: UseCacheOnly doesn't respect the cache configuration in the ivysettings (IVY-1227)
 - FIX: UseCacheOnly is influenced by the TTL on cached metadata (IVY-1243)
 - FIX: ConcurrentModificationException on ivy settings loading (IVY-1250)
-- FIX: Module inheritance sometimes fails to locate parent descriptor in deliver process (IVY-1248) (thanks to Jean-Louis Boudart)
+- FIX: Module inheritance sometimes fails to locate parent descriptor in deliver process (IVY-1248)
 - FIX: <cachefileset> on an empty configuration produces a very slow-to-evaluate fileset (IVY-1272)
 - FIX: Ivy does not apply overridden properties to m2 parent dependency versions specified using properties (IVY-1299)
 - FIX: Ivy does not apply overridden properties to m2 parent dependency versions specified using dependencyManagement properties (IVY-1301)

--- a/doc/tutorial/log/chained-resolvers.txt
+++ b/doc/tutorial/log/chained-resolvers.txt
@@ -1,0 +1,38 @@
+[ivy@apache:/ivy/chained-resolvers/chainedresolvers-project]$ ant 
+Buildfile: /ivy/chained-resolvers/chainedresolvers-project/build.xml
+
+resolve:
+[ivy:retrieve] :: Apache Ivy 2.3.0 - 20130110142753 :: http://ant.apache.org/ivy/ ::
+[ivy:retrieve] :: loading settings :: file = /ivy/chained-resolvers/settings/ivysettings.xml
+[ivy:retrieve] :: resolving dependencies :: org.apache#chained-resolvers;working@apache
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	found commons-lang#commons-lang;2.0 in ibiblio
+[ivy:retrieve] 	found org.apache#test;1.0 in libraries
+[ivy:retrieve] downloading http://repo1.maven.org/maven2/commons-lang/commons-lang/2.0/commons-lang-2.0.jar ...
+[ivy:retrieve] ...................... (165kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] commons-lang#commons-lang;2.0!commons-lang.jar (484ms)
+[ivy:retrieve] downloading /ivy/chained-resolvers/settings/repository/test-1.0.jar ...
+[ivy:retrieve] .. (1kB)
+[ivy:retrieve] 	[SUCCESSFUL ] org.apache#test;1.0!test.jar (15ms)
+[ivy:retrieve] :: resolution report :: resolve 749ms :: artifacts dl 499ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|      default     |   2   |   2   |   1   |   0   ||   2   |   2   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache#chained-resolvers
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	2 artifacts copied, 0 already retrieved (166kB/32ms)
+
+run:
+    [mkdir] Created dir: /ivy/chained-resolvers/chainedresolvers-project/build
+    [javac] /ivy/chained-resolvers/chainedresolvers-project/build.xml:58: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
+    [javac] Compiling 1 source file to /ivy/chained-resolvers/chainedresolvers-project/build
+     [java] standard message :example world !
+     [java] capitalized by org.apache.commons.lang.WordUtils : Example World !
+     [java] upperCased by test.StringUtils : EXAMPLE WORLD !
+
+BUILD SUCCESSFUL
+Total time: 3 seconds

--- a/doc/tutorial/log/configurations-lib.txt
+++ b/doc/tutorial/log/configurations-lib.txt
@@ -1,0 +1,68 @@
+[ivy@apache:/ivy/configurations/multi-projects/filter-framework]$ ant 
+Buildfile: /ivy/configurations/multi-projects/filter-framework/build.xml
+
+clean:
+
+resolve:
+[ivy:retrieve] :: Apache Ivy 2.3.0 - 20130110142753 :: http://ant.apache.org/ivy/ ::
+[ivy:retrieve] :: loading settings :: url = jar:file:///home/ivy/ivy.jar!/org/apache/ivy/core/settings/ivysettings.xml
+[ivy:retrieve] :: resolving dependencies :: org.apache#filter-framework;working@apache
+[ivy:retrieve] 	confs: [api, homemade-impl, cc-impl, test]
+[ivy:retrieve] 	found commons-collections#commons-collections;3.1 in public
+[ivy:retrieve] 	found junit#junit;3.8 in public
+[ivy:retrieve] downloading http://repo1.maven.org/maven2/commons-collections/commons-collections/3.1/commons-collections-3.1.jar ...
+[ivy:retrieve] ..................................... (546kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] commons-collections#commons-collections;3.1!commons-collections.jar (1341ms)
+[ivy:retrieve] downloading http://repo1.maven.org/maven2/junit/junit/3.8/junit-3.8.jar ...
+[ivy:retrieve] .......... (118kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] junit#junit;3.8!junit.jar (406ms)
+[ivy:retrieve] :: resolution report :: resolve 842ms :: artifacts dl 1779ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|        api       |   0   |   0   |   0   |   0   ||   0   |   0   |
+	|   homemade-impl  |   0   |   0   |   0   |   0   ||   0   |   0   |
+	|      cc-impl     |   1   |   1   |   1   |   0   ||   1   |   1   |
+	|       test       |   2   |   2   |   2   |   0   ||   2   |   2   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache#filter-framework
+[ivy:retrieve] 	confs: [api, homemade-impl, cc-impl, test]
+[ivy:retrieve] 	3 artifacts copied, 0 already retrieved (1211kB/62ms)
+
+build:
+    [mkdir] Created dir: /ivy/configurations/multi-projects/filter-framework/build
+    [mkdir] Created dir: /ivy/configurations/multi-projects/filter-framework/distrib
+    [javac] Compiling 4 source files to /ivy/configurations/multi-projects/filter-framework/build
+    [javac] Note: Some input files use unchecked or unsafe operations.
+    [javac] Note: Recompile with -Xlint:unchecked for details.
+      [jar] Building jar: /ivy/configurations/multi-projects/filter-framework/distrib/filter-api.jar
+      [jar] Building jar: /ivy/configurations/multi-projects/filter-framework/distrib/filter-hmimpl.jar
+      [jar] Building jar: /ivy/configurations/multi-projects/filter-framework/distrib/filter-ccimpl.jar
+
+test:
+    [mkdir] Created dir: /ivy/configurations/multi-projects/filter-framework/build/test-report
+    [mkdir] Created dir: /ivy/configurations/multi-projects/filter-framework/build/test-classes
+    [javac] /ivy/configurations/multi-projects/filter-framework/build.xml:82: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
+    [javac] Compiling 3 source files to /ivy/configurations/multi-projects/filter-framework/build/test-classes
+    [junit] Running filter.ccimpl.CCFilterTest
+    [junit] Tests run: 5, Failures: 0, Errors: 0, Time elapsed: 0,063 sec
+    [junit] Running filter.hmimpl.HMFilterTest
+    [junit] Tests run: 5, Failures: 0, Errors: 0, Time elapsed: 0,063 sec
+
+publish:
+[ivy:publish] :: delivering :: org.apache#filter-framework;working@apache :: 1.3 :: release :: Thu Jan 10 14:34:51 CET 2013
+[ivy:publish] 	delivering ivy file to /ivy/configurations/multi-projects/filter-framework/distrib/ivy.xml
+[ivy:publish] :: publishing :: org.apache#filter-framework
+[ivy:publish] 	published filter-api to /home/ivy/.ivy2/local/org.apache/filter-framework/1.3.part/jars/filter-api.jar
+[ivy:publish] 	published filter-hmimpl to /home/ivy/.ivy2/local/org.apache/filter-framework/1.3.part/jars/filter-hmimpl.jar
+[ivy:publish] 	published filter-ccimpl to /home/ivy/.ivy2/local/org.apache/filter-framework/1.3.part/jars/filter-ccimpl.jar
+[ivy:publish] 	published ivy to /home/ivy/.ivy2/local/org.apache/filter-framework/1.3.part/ivys/ivy.xml
+[ivy:publish] 	publish commited: moved /home/ivy/.ivy2/local/org.apache/filter-framework/1.3.part 
+[ivy:publish] 		to /home/ivy/.ivy2/local/org.apache/filter-framework/1.3
+     [echo] project filter-framework released with version 1.3
+
+BUILD SUCCESSFUL
+Total time: 8 seconds

--- a/doc/tutorial/log/configurations-runcc.txt
+++ b/doc/tutorial/log/configurations-runcc.txt
@@ -1,0 +1,46 @@
+[ivy@apache:/ivy/configurations/multi-projects/myapp]$ ant 
+Buildfile: /ivy/configurations/multi-projects/myapp/build.xml
+
+resolve:
+[ivy:retrieve] :: Apache Ivy 2.3.0 - 20130110142753 :: http://ant.apache.org/ivy/ ::
+[ivy:retrieve] :: loading settings :: url = jar:file:///home/ivy/ivy.jar!/org/apache/ivy/core/settings/ivysettings.xml
+[ivy:retrieve] :: resolving dependencies :: org.apache#myapp;working@apache
+[ivy:retrieve] 	confs: [build, noexternaljar, withexternaljar]
+[ivy:retrieve] 	found org.apache#filter-framework;1.3 in local
+[ivy:retrieve] 	[1.3] org.apache#filter-framework;latest.integration
+[ivy:retrieve] 	found commons-collections#commons-collections;3.1 in public
+[ivy:retrieve] downloading /home/ivy/.ivy2/local/org.apache/filter-framework/1.3/jars/filter-ccimpl.jar ...
+[ivy:retrieve] .. (1kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] org.apache#filter-framework;1.3!filter-ccimpl.jar (0ms)
+[ivy:retrieve] downloading /home/ivy/.ivy2/local/org.apache/filter-framework/1.3/jars/filter-hmimpl.jar ...
+[ivy:retrieve] .. (1kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] org.apache#filter-framework;1.3!filter-hmimpl.jar (62ms)
+[ivy:retrieve] downloading /home/ivy/.ivy2/local/org.apache/filter-framework/1.3/jars/filter-api.jar ...
+[ivy:retrieve] .. (1kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] org.apache#filter-framework;1.3!filter-api.jar (16ms)
+[ivy:retrieve] :: resolution report :: resolve 172ms :: artifacts dl 78ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|       build      |   1   |   1   |   1   |   0   ||   1   |   1   |
+	|   noexternaljar  |   1   |   1   |   1   |   0   ||   2   |   2   |
+	|  withexternaljar |   2   |   1   |   1   |   0   ||   3   |   2   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache#myapp
+[ivy:retrieve] 	confs: [build, noexternaljar, withexternaljar]
+[ivy:retrieve] 	6 artifacts copied, 0 already retrieved (552kB/140ms)
+
+build:
+    [mkdir] Created dir: /ivy/configurations/multi-projects/myapp/build
+    [javac] Compiling 1 source file to /ivy/configurations/multi-projects/myapp/build
+
+run-cc:
+     [java] Filtering with:class filter.ccimpl.CCFilter
+     [java] Result :[two, tree]
+
+BUILD SUCCESSFUL
+Total time: 2 seconds

--- a/doc/tutorial/log/configurations-runhm.txt
+++ b/doc/tutorial/log/configurations-runhm.txt
@@ -1,0 +1,32 @@
+[ivy@apache:/ivy/configurations/multi-projects/myapp]$ ant run-hm
+Buildfile: /ivy/configurations/multi-projects/myapp/build.xml
+
+resolve:
+[ivy:retrieve] :: Apache Ivy 2.3.0 - 20130110142753 :: http://ant.apache.org/ivy/ ::
+[ivy:retrieve] :: loading settings :: url = jar:file:///home/ivy/ivy.jar!/org/apache/ivy/core/settings/ivysettings.xml
+[ivy:retrieve] :: resolving dependencies :: org.apache#myapp;working@apache
+[ivy:retrieve] 	confs: [build, noexternaljar, withexternaljar]
+[ivy:retrieve] 	found org.apache#filter-framework;1.3 in local
+[ivy:retrieve] 	[1.3] org.apache#filter-framework;latest.integration
+[ivy:retrieve] 	found commons-collections#commons-collections;3.1 in public
+[ivy:retrieve] :: resolution report :: resolve 109ms :: artifacts dl 16ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|       build      |   1   |   1   |   0   |   0   ||   1   |   0   |
+	|   noexternaljar  |   1   |   1   |   0   |   0   ||   2   |   0   |
+	|  withexternaljar |   2   |   1   |   0   |   0   ||   3   |   0   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache#myapp
+[ivy:retrieve] 	confs: [build, noexternaljar, withexternaljar]
+[ivy:retrieve] 	0 artifacts copied, 6 already retrieved (0kB/15ms)
+
+build:
+
+run-hm:
+     [java] Filtering with:class filter.hmimpl.HMFilter
+     [java] Result :[two, tree]
+
+BUILD SUCCESSFUL
+Total time: 1 second

--- a/doc/tutorial/log/dependence-depending-2.txt
+++ b/doc/tutorial/log/dependence-depending-2.txt
@@ -1,0 +1,40 @@
+[ivy@apache:/ivy/dependence/depender]$ ant 
+Buildfile: /ivy/dependence/depender/build.xml
+
+clean:
+
+resolve:
+[ivy:retrieve] :: Apache Ivy 2.3.0 - 20130110142753 :: http://ant.apache.org/ivy/ ::
+[ivy:retrieve] :: loading settings :: file = /ivy/dependence/settings/ivysettings.xml
+[ivy:retrieve] :: resolving dependencies :: org.apache#depender;working@apache
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	found org.apache#dependee;2 in projects
+[ivy:retrieve] 	[2] org.apache#dependee;latest.integration
+[ivy:retrieve] 	found commons-lang#commons-lang;2.0 in libraries
+[ivy:retrieve] downloading /ivy/dependence/settings/repository/dependee-2.jar ...
+[ivy:retrieve] .. (1kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] org.apache#dependee;2!dependee.jar (0ms)
+[ivy:retrieve] :: resolution report :: resolve 140ms :: artifacts dl 0ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|      default     |   2   |   1   |   1   |   0   ||   2   |   1   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache#depender
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	2 artifacts copied, 0 already retrieved (167kB/16ms)
+
+compile:
+    [mkdir] Created dir: /ivy/dependence/depender/build/classes
+    [javac] Compiling 1 source file to /ivy/dependence/depender/build/classes
+
+run:
+     [java] you are using version 2 of class standalone.Main
+     [java] standard message : i am depending.Main and standalone.Main will do the job for me
+     [java]     [standalone.Main] capitalizing string "i am depending.Main and standalone.Main will do the job for me" using org.apache.commons.lang.WordUtils
+     [java] capitalized message : I Am Depending.main And Standalone.main Will Do The Job For Me
+
+BUILD SUCCESSFUL
+Total time: 1 second

--- a/doc/tutorial/log/dependence-depending.txt
+++ b/doc/tutorial/log/dependence-depending.txt
@@ -1,0 +1,40 @@
+[ivy@apache:/ivy/dependence/depender]$ ant 
+Buildfile: /ivy/dependence/depender/build.xml
+
+clean:
+
+resolve:
+[ivy:retrieve] :: Apache Ivy 2.3.0 - 20130110142753 :: http://ant.apache.org/ivy/ ::
+[ivy:retrieve] :: loading settings :: file = /ivy/dependence/settings/ivysettings.xml
+[ivy:retrieve] :: resolving dependencies :: org.apache#depender;working@apache
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	found org.apache#dependee;1 in projects
+[ivy:retrieve] 	[1] org.apache#dependee;latest.integration
+[ivy:retrieve] 	found commons-lang#commons-lang;2.0 in libraries
+[ivy:retrieve] downloading /ivy/dependence/settings/repository/dependee-1.jar ...
+[ivy:retrieve] .. (1kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] org.apache#dependee;1!dependee.jar (0ms)
+[ivy:retrieve] :: resolution report :: resolve 140ms :: artifacts dl 16ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|      default     |   2   |   1   |   1   |   0   ||   2   |   1   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache#depender
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	2 artifacts copied, 0 already retrieved (167kB/16ms)
+
+compile:
+    [mkdir] Created dir: /ivy/dependence/depender/build/classes
+    [javac] Compiling 1 source file to /ivy/dependence/depender/build/classes
+
+run:
+     [java] you are using version 1 of class standalone.Main
+     [java] standard message : i am depending.Main and standalone.Main will do the job for me
+     [java]     [standalone.Main] capitalizing string "i am depending.Main and standalone.Main will do the job for me" using org.apache.commons.lang.WordUtils
+     [java] capitalized message : I Am Depending.main And Standalone.main Will Do The Job For Me
+
+BUILD SUCCESSFUL
+Total time: 1 second

--- a/doc/tutorial/log/dependence-standalone-2.txt
+++ b/doc/tutorial/log/dependence-standalone-2.txt
@@ -1,0 +1,37 @@
+[ivy@apache:/ivy/dependence/dependee]$ ant publish
+Buildfile: /ivy/dependence/dependee/build.xml
+
+resolve:
+[ivy:retrieve] :: Apache Ivy 2.3.0 - 20130110142753 :: http://ant.apache.org/ivy/ ::
+[ivy:retrieve] :: loading settings :: file = /ivy/dependence/settings/ivysettings.xml
+[ivy:retrieve] :: resolving dependencies :: org.apache#dependee;working@apache
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	found commons-lang#commons-lang;2.0 in libraries
+[ivy:retrieve] :: resolution report :: resolve 62ms :: artifacts dl 16ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|      default     |   1   |   0   |   0   |   0   ||   1   |   0   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache#dependee
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	0 artifacts copied, 1 already retrieved (0kB/0ms)
+
+compile:
+
+jar:
+[propertyfile] Updating property file: /ivy/dependence/dependee/build/classes/version.properties
+      [jar] Building jar: /ivy/dependence/dependee/build/dependee.jar
+
+publish:
+   [delete] Deleting: /ivy/dependence/dependee/build/ivy.xml
+[ivy:publish] :: delivering :: org.apache#dependee;working@apache :: 2 :: release :: Thu Jan 10 14:34:40 CET 2013
+[ivy:publish] 	delivering ivy file to /ivy/dependence/dependee/build/ivy.xml
+[ivy:publish] :: publishing :: org.apache#dependee
+[ivy:publish] 	published dependee to /ivy/dependence/settings/repository/dependee-2.jar
+[ivy:publish] 	published ivy to /ivy/dependence/settings/repository/dependee-2.xml
+     [echo] project dependee released with version 2
+
+BUILD SUCCESSFUL
+Total time: 1 second

--- a/doc/tutorial/log/dependence-standalone.txt
+++ b/doc/tutorial/log/dependence-standalone.txt
@@ -1,0 +1,42 @@
+[ivy@apache:/ivy/dependence/dependee]$ ant publish
+Buildfile: /ivy/dependence/dependee/build.xml
+
+resolve:
+[ivy:retrieve] :: Apache Ivy 2.3.0 - 20130110142753 :: http://ant.apache.org/ivy/ ::
+[ivy:retrieve] :: loading settings :: file = /ivy/dependence/settings/ivysettings.xml
+[ivy:retrieve] :: resolving dependencies :: org.apache#dependee;working@apache
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	found commons-lang#commons-lang;2.0 in libraries
+[ivy:retrieve] downloading http://repo1.maven.org/maven2/commons-lang/commons-lang/2.0/commons-lang-2.0.jar ...
+[ivy:retrieve] ...................... (165kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] commons-lang#commons-lang;2.0!commons-lang.jar (468ms)
+[ivy:retrieve] :: resolution report :: resolve 234ms :: artifacts dl 468ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|      default     |   1   |   1   |   0   |   0   ||   1   |   1   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache#dependee
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	1 artifacts copied, 0 already retrieved (165kB/16ms)
+
+compile:
+    [mkdir] Created dir: /ivy/dependence/dependee/build/classes
+    [javac] Compiling 1 source file to /ivy/dependence/dependee/build/classes
+
+jar:
+[propertyfile] Creating new property file: /ivy/dependence/dependee/build/classes/version.properties
+      [jar] Building jar: /ivy/dependence/dependee/build/dependee.jar
+
+publish:
+[ivy:publish] :: delivering :: org.apache#dependee;working@apache :: 1 :: release :: Thu Jan 10 14:34:36 CET 2013
+[ivy:publish] 	delivering ivy file to /ivy/dependence/dependee/build/ivy.xml
+[ivy:publish] :: publishing :: org.apache#dependee
+[ivy:publish] 	published dependee to /ivy/dependence/settings/repository/dependee-1.jar
+[ivy:publish] 	published ivy to /ivy/dependence/settings/repository/dependee-1.xml
+     [echo] project dependee released with version 1
+
+BUILD SUCCESSFUL
+Total time: 2 seconds

--- a/doc/tutorial/log/dual.txt
+++ b/doc/tutorial/log/dual.txt
@@ -1,0 +1,45 @@
+[ivy@apache:/ivy/dual/project]$ ant 
+Buildfile: /ivy/dual/project/build.xml
+
+resolve:
+[ivy:retrieve] :: Apache Ivy 2.3.0 - 20130110142753 :: http://ant.apache.org/ivy/ ::
+[ivy:retrieve] :: loading settings :: file = /ivy/dual/settings/ivysettings.xml
+[ivy:retrieve] :: resolving dependencies :: org.apache#hello-ivy;working@apache
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	found commons-httpclient#commons-httpclient;2.0.2 in ivys
+[ivy:retrieve] 	found commons-logging#commons-logging;1.0.4 in ibiblio
+[ivy:retrieve] 	found commons-lang#commons-lang;2.0 in ibiblio
+[ivy:retrieve] downloading http://repo1.maven.org/maven2/commons-httpclient/commons-httpclient/2.0.2/commons-httpclient-2.0.2.jar ...
+[ivy:retrieve] ........................... (220kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] commons-httpclient#commons-httpclient;2.0.2!commons-httpclient.jar (655ms)
+[ivy:retrieve] downloading http://repo1.maven.org/maven2/commons-lang/commons-lang/2.0/commons-lang-2.0.jar ...
+[ivy:retrieve] .............. (165kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] commons-lang#commons-lang;2.0!commons-lang.jar (452ms)
+[ivy:retrieve] downloading http://repo1.maven.org/maven2/commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.jar ...
+[ivy:retrieve] ...... (37kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] commons-logging#commons-logging;1.0.4!commons-logging.jar (187ms)
+[ivy:retrieve] :: resolution report :: resolve 203ms :: artifacts dl 1310ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|      default     |   3   |   3   |   1   |   0   ||   3   |   3   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache#hello-ivy
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	3 artifacts copied, 0 already retrieved (423kB/31ms)
+
+run:
+    [mkdir] Created dir: /ivy/dual/project/build
+    [javac] Compiling 1 source file to /ivy/dual/project/build
+     [java] standard message : hello ivy !
+     [java] capitalized by org.apache.commons.lang.WordUtils : Hello Ivy !
+     [java] head status code with httpclient: 200
+     [java] now check if httpclient dependency on commons-logging has been realized
+     [java] found logging class in classpath: interface org.apache.commons.logging.Log
+
+BUILD SUCCESSFUL
+Total time: 3 seconds

--- a/doc/tutorial/log/hello-ivy-1.txt
+++ b/doc/tutorial/log/hello-ivy-1.txt
@@ -1,0 +1,60 @@
+[ivy@apache:/ivy/hello-ivy]$ ant 
+Buildfile: /ivy/hello-ivy/build.xml
+
+resolve:
+[ivy:retrieve] :: Apache Ivy 2.3.0 - 20130110142753 :: http://ant.apache.org/ivy/ ::
+[ivy:retrieve] :: loading settings :: url = jar:file:///home/ivy/ivy.jar!/org/apache/ivy/core/settings/ivysettings.xml
+[ivy:retrieve] :: resolving dependencies :: org.apache#hello-ivy;working@apache
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	found commons-lang#commons-lang;2.0 in public
+[ivy:retrieve] 	found commons-cli#commons-cli;1.0 in public
+[ivy:retrieve] 	found commons-logging#commons-logging;1.0 in public
+[ivy:retrieve] downloading http://repo1.maven.org/maven2/commons-lang/commons-lang/2.0/commons-lang-2.0-javadoc.jar ...
+[ivy:retrieve] ................................... (467kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] commons-lang#commons-lang;2.0!commons-lang.jar(javadoc) (1154ms)
+[ivy:retrieve] downloading http://repo1.maven.org/maven2/commons-lang/commons-lang/2.0/commons-lang-2.0-sources.jar ...
+[ivy:retrieve] .................. (245kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] commons-lang#commons-lang;2.0!commons-lang.jar(source) (764ms)
+[ivy:retrieve] downloading http://repo1.maven.org/maven2/commons-lang/commons-lang/2.0/commons-lang-2.0.jar ...
+[ivy:retrieve] ............... (165kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] commons-lang#commons-lang;2.0!commons-lang.jar (484ms)
+[ivy:retrieve] downloading http://repo1.maven.org/maven2/commons-cli/commons-cli/1.0/commons-cli-1.0-javadoc.jar ...
+[ivy:retrieve] ....... (92kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] commons-cli#commons-cli;1.0!commons-cli.jar(javadoc) (375ms)
+[ivy:retrieve] downloading http://repo1.maven.org/maven2/commons-cli/commons-cli/1.0/commons-cli-1.0.jar ...
+[ivy:retrieve] ..... (29kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] commons-cli#commons-cli;1.0!commons-cli.jar (171ms)
+[ivy:retrieve] downloading http://repo1.maven.org/maven2/commons-cli/commons-cli/1.0/commons-cli-1.0-sources.jar ...
+[ivy:retrieve] ...... (48kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] commons-cli#commons-cli;1.0!commons-cli.jar(source) (281ms)
+[ivy:retrieve] downloading http://repo1.maven.org/maven2/commons-logging/commons-logging/1.0/commons-logging-1.0.jar ...
+[ivy:retrieve] .... (21kB)
+[ivy:retrieve] .. (0kB)
+[ivy:retrieve] 	[SUCCESSFUL ] commons-logging#commons-logging;1.0!commons-logging.jar (249ms)
+[ivy:retrieve] :: resolution report :: resolve 1326ms :: artifacts dl 3541ms
+[ivy:retrieve] 	:: evicted modules:
+[ivy:retrieve] 	commons-lang#commons-lang;1.0 by [commons-lang#commons-lang;2.0] in [default]
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|      default     |   4   |   3   |   3   |   1   ||   7   |   7   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache#hello-ivy
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	7 artifacts copied, 0 already retrieved (1069kB/78ms)
+
+run:
+    [mkdir] Created dir: /ivy/hello-ivy/build
+    [javac] Compiling 1 source file to /ivy/hello-ivy/build
+     [java] standard message : hello ivy !
+     [java] capitalized by org.apache.commons.lang.WordUtils : Hello Ivy !
+
+BUILD SUCCESSFUL
+Total time: 6 seconds

--- a/doc/tutorial/log/hello-ivy-2.txt
+++ b/doc/tutorial/log/hello-ivy-2.txt
@@ -1,0 +1,30 @@
+[ivy@apache:/ivy/hello-ivy]$ ant 
+Buildfile: /ivy/hello-ivy/build.xml
+
+resolve:
+[ivy:retrieve] :: Apache Ivy 2.3.0 - 20130110142753 :: http://ant.apache.org/ivy/ ::
+[ivy:retrieve] :: loading settings :: url = jar:file:///home/ivy/ivy.jar!/org/apache/ivy/core/settings/ivysettings.xml
+[ivy:retrieve] :: resolving dependencies :: org.apache#hello-ivy;working@apache
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	found commons-lang#commons-lang;2.0 in public
+[ivy:retrieve] 	found commons-cli#commons-cli;1.0 in public
+[ivy:retrieve] 	found commons-logging#commons-logging;1.0 in public
+[ivy:retrieve] :: resolution report :: resolve 171ms :: artifacts dl 0ms
+[ivy:retrieve] 	:: evicted modules:
+[ivy:retrieve] 	commons-lang#commons-lang;1.0 by [commons-lang#commons-lang;2.0] in [default]
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|      default     |   4   |   0   |   0   |   1   ||   7   |   0   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache#hello-ivy
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	0 artifacts copied, 7 already retrieved (0kB/16ms)
+
+run:
+     [java] standard message : hello ivy !
+     [java] capitalized by org.apache.commons.lang.WordUtils : Hello Ivy !
+
+BUILD SUCCESSFUL
+Total time: 1 second

--- a/doc/tutorial/log/install-deps.txt
+++ b/doc/tutorial/log/install-deps.txt
@@ -1,0 +1,258 @@
+[ivy@apache:/ivy/build-a-ivy-repository]$ ant maven2-deps
+Buildfile: /ivy/build-a-ivy-repository/build.xml
+
+load-ivy:
+
+init-ivy:
+
+maven2-deps:
+[ivy:install] :: Apache Ivy 2.3.0 - 20130110142753 :: http://ant.apache.org/ivy/ ::
+[ivy:install] :: loading settings :: file = /ivy/build-a-ivy-repository/settings/ivysettings-basic.xml
+[ivy:install] :: installing org.hibernate#hibernate;3.2.5.ga ::
+[ivy:install] :: resolving dependencies ::
+[ivy:install] 	found org.hibernate#hibernate;3.2.5.ga in libraries
+[ivy:install] 	found net.sf.ehcache#ehcache;1.2.3 in libraries
+[ivy:install] 	found commons-logging#commons-logging;1.0.4 in libraries
+[ivy:install] 	found commons-collections#commons-collections;2.1 in libraries
+[ivy:install] 	found javax.transaction#jta;1.0.1B in libraries
+[ivy:install] 	found asm#asm-attrs;1.5.3 in libraries
+[ivy:install] 	found dom4j#dom4j;1.6.1 in libraries
+[ivy:install] 	found antlr#antlr;2.7.6 in libraries
+[ivy:install] 	found cglib#cglib;2.1_3 in libraries
+[ivy:install] 	found asm#asm;1.5.3 in libraries
+[ivy:install] 	found commons-collections#commons-collections;2.1.1 in libraries
+[ivy:install] 	found ant#ant;1.6.5 in libraries
+[ivy:install] 	found swarmcache#swarmcache;1.0RC2 in libraries
+[ivy:install] 	found commons-logging#commons-logging;1.0.2 in libraries
+[ivy:install] 	found jgroups#jgroups-all;2.2.8 in libraries
+[ivy:install] 	found jboss#jboss-cache;1.2.2 in libraries
+[ivy:install] 	found jboss#jboss-system;4.0.2 in libraries
+[ivy:install] 	found jboss#jboss-common;4.0.2 in libraries
+[ivy:install] 	found slide#webdavlib;2.0 in libraries
+[ivy:install] 	found xerces#xercesImpl;2.6.2 in libraries
+[ivy:install] 	found jboss#jboss-minimal;4.0.2 in libraries
+[ivy:install] 	found jboss#jboss-j2se;200504122039 in libraries
+[ivy:install] 	found concurrent#concurrent;1.3.4 in libraries
+[ivy:install] 	found jgroups#jgroups-all;2.2.7 in libraries
+[ivy:install] 	found c3p0#c3p0;0.9.1 in libraries
+[ivy:install] 	found javax.security#jacc;1.0 in libraries
+[ivy:install] 	found opensymphony#oscache;2.1 in libraries
+[ivy:install] 	found proxool#proxool;0.8.3 in libraries
+[ivy:install] :: downloading artifacts to cache ::
+[ivy:install] downloading http://repo1.maven.org/maven2/org/hibernate/hibernate/3.2.5.ga/hibernate-3.2.5.ga-sources.jar ...
+[ivy:install] ...........................................
+[ivy:install] ...............................
+[ivy:install] .. (1470kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] org.hibernate#hibernate;3.2.5.ga!hibernate.jar(source) (3323ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/org/hibernate/hibernate/3.2.5.ga/hibernate-3.2.5.ga-javadoc.jar ...
+[ivy:install] ...................................
+[ivy:install] .............................
+[ivy:install] ............................
+[ivy:install] ...................................
+[ivy:install] ...............................
+[ivy:install] .........................
+[ivy:install] ......................
+[ivy:install] ...............................
+[ivy:install] ................................
+[ivy:install] ..........................................
+[ivy:install] ............... (7352kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] org.hibernate#hibernate;3.2.5.ga!hibernate.jar(javadoc) (16380ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/org/hibernate/hibernate/3.2.5.ga/hibernate-3.2.5.ga.jar ...
+[ivy:install] .......................................
+[ivy:install] ........................................
+[ivy:install] ..............................
+[ivy:install] ... (2202kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] org.hibernate#hibernate;3.2.5.ga!hibernate.jar (4867ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/net/sf/ehcache/ehcache/1.2.3/ehcache-1.2.3.jar ...
+[ivy:install] .................. (203kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] net.sf.ehcache#ehcache;1.2.3!ehcache.jar (546ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.jar ...
+[ivy:install] ...... (37kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] commons-logging#commons-logging;1.0.4!commons-logging.jar (187ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/asm/asm-attrs/1.5.3/asm-attrs-1.5.3.jar ...
+[ivy:install] ..... (16kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] asm#asm-attrs;1.5.3!asm-attrs.jar (156ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/dom4j/dom4j/1.6.1/dom4j-1.6.1.jar ...
+[ivy:install] ........................ (306kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] dom4j#dom4j;1.6.1!dom4j.jar (765ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/antlr/antlr/2.7.6/antlr-2.7.6.jar ...
+[ivy:install] .......................... (433kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] antlr#antlr;2.7.6!antlr.jar (1060ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/cglib/cglib/2.1_3/cglib-2.1_3.jar ...
+[ivy:install] ...................... (275kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] cglib#cglib;2.1_3!cglib.jar (702ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/asm/asm/1.5.3/asm-1.5.3.jar ...
+[ivy:install] ..... (25kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] asm#asm;1.5.3!asm.jar (156ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/commons-collections/commons-collections/2.1.1/commons-collections-2.1.1.jar ...
+[ivy:install] .................. (171kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] commons-collections#commons-collections;2.1.1!commons-collections.jar (687ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/commons-collections/commons-collections/2.1/commons-collections-2.1.jar ...
+[ivy:install] ................. (161kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] commons-collections#commons-collections;2.1!commons-collections.jar (452ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/ant/ant/1.6.5/ant-1.6.5.jar ...
+[ivy:install] .....................................
+[ivy:install] ............. (1009kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] ant#ant;1.6.5!ant.jar (2247ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/swarmcache/swarmcache/1.0RC2/swarmcache-1.0RC2.jar ...
+[ivy:install] ..... (29kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] swarmcache#swarmcache;1.0RC2!swarmcache.jar (327ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/jboss/jboss-cache/1.2.2/jboss-cache-1.2.2.jar ...
+[ivy:install] ........................... (365kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] jboss#jboss-cache;1.2.2!jboss-cache.jar (983ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/jgroups/jgroups-all/2.2.8/jgroups-all-2.2.8.jar ...
+[ivy:install] .................................
+[ivy:install] ............................
+[ivy:install] ................ (1573kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] jgroups#jgroups-all;2.2.8!jgroups-all.jar (4976ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/c3p0/c3p0/0.9.1/c3p0-0.9.1.jar ...
+[ivy:install] ............................................. (594kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] c3p0#c3p0;0.9.1!c3p0.jar (1373ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/opensymphony/oscache/2.1/oscache-2.1.jar ...
+[ivy:install] ......... (111kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] opensymphony#oscache;2.1!oscache.jar (546ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/proxool/proxool/0.8.3/proxool-0.8.3.jar ...
+[ivy:install] ............................. (464kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] proxool#proxool;0.8.3!proxool.jar (1154ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/commons-logging/commons-logging/1.0.2/commons-logging-1.0.2.jar ...
+[ivy:install] ..... (25kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] commons-logging#commons-logging;1.0.2!commons-logging.jar (218ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/jboss/jboss-system/4.0.2/jboss-system-4.0.2.jar ...
+[ivy:install] ...................... (227kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] jboss#jboss-system;4.0.2!jboss-system.jar (687ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/jboss/jboss-common/4.0.2/jboss-common-4.0.2.jar ...
+[ivy:install] ........................... (457kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] jboss#jboss-common;4.0.2!jboss-common.jar (1123ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/jboss/jboss-minimal/4.0.2/jboss-minimal-4.0.2.jar ...
+[ivy:install] ................. (163kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] jboss#jboss-minimal;4.0.2!jboss-minimal.jar (468ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/jboss/jboss-j2se/200504122039/jboss-j2se-200504122039.jar ...
+[ivy:install] ........................ (350kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] jboss#jboss-j2se;200504122039!jboss-j2se.jar (1107ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/concurrent/concurrent/1.3.4/concurrent-1.3.4.jar ...
+[ivy:install] ....................... (184kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] concurrent#concurrent;1.3.4!concurrent.jar (500ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/jgroups/jgroups-all/2.2.7/jgroups-all-2.2.7.jar ...
+[ivy:install] .......................................
+[ivy:install] ..................................
+[ivy:install] ............ (1613kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] jgroups#jgroups-all;2.2.7!jgroups-all.jar (3619ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/slide/webdavlib/2.0/webdavlib-2.0.jar ...
+[ivy:install] ............ (128kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] slide#webdavlib;2.0!webdavlib.jar (390ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/xerces/xercesImpl/2.6.2/xercesImpl-2.6.2.jar ...
+[ivy:install] .................................
+[ivy:install] .............. (986kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] xerces#xercesImpl;2.6.2!xercesImpl.jar (2340ms)
+[ivy:install] :: installing in my-repository ::
+[ivy:install] 	published hibernate to /ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate/sources/hibernate-3.2.5.ga.jar
+[ivy:install] 	published hibernate to /ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate/javadocs/hibernate-3.2.5.ga.jar
+[ivy:install] 	published hibernate to /ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate/jars/hibernate-3.2.5.ga.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate/ivys/ivy-3.2.5.ga.xml
+[ivy:install] 	published ehcache to /ivy/build-a-ivy-repository/myrepository/no-namespace/net.sf.ehcache/ehcache/jars/ehcache-1.2.3.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/net.sf.ehcache/ehcache/ivys/ivy-1.2.3.xml
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/javax.transaction/jta/ivys/ivy-1.0.1B.xml
+[ivy:install] 	published commons-logging to /ivy/build-a-ivy-repository/myrepository/no-namespace/commons-logging/commons-logging/jars/commons-logging-1.0.4.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/commons-logging/commons-logging/ivys/ivy-1.0.4.xml
+[ivy:install] 	published asm-attrs to /ivy/build-a-ivy-repository/myrepository/no-namespace/asm/asm-attrs/jars/asm-attrs-1.5.3.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/asm/asm-attrs/ivys/ivy-1.5.3.xml
+[ivy:install] 	published dom4j to /ivy/build-a-ivy-repository/myrepository/no-namespace/dom4j/dom4j/jars/dom4j-1.6.1.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/dom4j/dom4j/ivys/ivy-1.6.1.xml
+[ivy:install] 	published antlr to /ivy/build-a-ivy-repository/myrepository/no-namespace/antlr/antlr/jars/antlr-2.7.6.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/antlr/antlr/ivys/ivy-2.7.6.xml
+[ivy:install] 	published cglib to /ivy/build-a-ivy-repository/myrepository/no-namespace/cglib/cglib/jars/cglib-2.1_3.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/cglib/cglib/ivys/ivy-2.1_3.xml
+[ivy:install] 	published asm to /ivy/build-a-ivy-repository/myrepository/no-namespace/asm/asm/jars/asm-1.5.3.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/asm/asm/ivys/ivy-1.5.3.xml
+[ivy:install] 	published commons-collections to /ivy/build-a-ivy-repository/myrepository/no-namespace/commons-collections/commons-collections/jars/commons-collections-2.1.1.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/commons-collections/commons-collections/ivys/ivy-2.1.1.xml
+[ivy:install] 	published commons-collections to /ivy/build-a-ivy-repository/myrepository/no-namespace/commons-collections/commons-collections/jars/commons-collections-2.1.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/commons-collections/commons-collections/ivys/ivy-2.1.xml
+[ivy:install] 	published ant to /ivy/build-a-ivy-repository/myrepository/no-namespace/ant/ant/jars/ant-1.6.5.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/ant/ant/ivys/ivy-1.6.5.xml
+[ivy:install] 	published swarmcache to /ivy/build-a-ivy-repository/myrepository/no-namespace/swarmcache/swarmcache/jars/swarmcache-1.0RC2.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/swarmcache/swarmcache/ivys/ivy-1.0RC2.xml
+[ivy:install] 	published jboss-cache to /ivy/build-a-ivy-repository/myrepository/no-namespace/jboss/jboss-cache/jars/jboss-cache-1.2.2.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/jboss/jboss-cache/ivys/ivy-1.2.2.xml
+[ivy:install] 	published jgroups-all to /ivy/build-a-ivy-repository/myrepository/no-namespace/jgroups/jgroups-all/jars/jgroups-all-2.2.8.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/jgroups/jgroups-all/ivys/ivy-2.2.8.xml
+[ivy:install] 	published c3p0 to /ivy/build-a-ivy-repository/myrepository/no-namespace/c3p0/c3p0/jars/c3p0-0.9.1.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/c3p0/c3p0/ivys/ivy-0.9.1.xml
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/javax.security/jacc/ivys/ivy-1.0.xml
+[ivy:install] 	published oscache to /ivy/build-a-ivy-repository/myrepository/no-namespace/opensymphony/oscache/jars/oscache-2.1.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/opensymphony/oscache/ivys/ivy-2.1.xml
+[ivy:install] 	published proxool to /ivy/build-a-ivy-repository/myrepository/no-namespace/proxool/proxool/jars/proxool-0.8.3.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/proxool/proxool/ivys/ivy-0.8.3.xml
+[ivy:install] 	published commons-logging to /ivy/build-a-ivy-repository/myrepository/no-namespace/commons-logging/commons-logging/jars/commons-logging-1.0.2.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/commons-logging/commons-logging/ivys/ivy-1.0.2.xml
+[ivy:install] 	published jboss-system to /ivy/build-a-ivy-repository/myrepository/no-namespace/jboss/jboss-system/jars/jboss-system-4.0.2.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/jboss/jboss-system/ivys/ivy-4.0.2.xml
+[ivy:install] 	published jboss-common to /ivy/build-a-ivy-repository/myrepository/no-namespace/jboss/jboss-common/jars/jboss-common-4.0.2.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/jboss/jboss-common/ivys/ivy-4.0.2.xml
+[ivy:install] 	published jboss-minimal to /ivy/build-a-ivy-repository/myrepository/no-namespace/jboss/jboss-minimal/jars/jboss-minimal-4.0.2.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/jboss/jboss-minimal/ivys/ivy-4.0.2.xml
+[ivy:install] 	published jboss-j2se to /ivy/build-a-ivy-repository/myrepository/no-namespace/jboss/jboss-j2se/jars/jboss-j2se-200504122039.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/jboss/jboss-j2se/ivys/ivy-200504122039.xml
+[ivy:install] 	published concurrent to /ivy/build-a-ivy-repository/myrepository/no-namespace/concurrent/concurrent/jars/concurrent-1.3.4.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/concurrent/concurrent/ivys/ivy-1.3.4.xml
+[ivy:install] 	published jgroups-all to /ivy/build-a-ivy-repository/myrepository/no-namespace/jgroups/jgroups-all/jars/jgroups-all-2.2.7.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/jgroups/jgroups-all/ivys/ivy-2.2.7.xml
+[ivy:install] 	published webdavlib to /ivy/build-a-ivy-repository/myrepository/no-namespace/slide/webdavlib/jars/webdavlib-2.0.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/slide/webdavlib/ivys/ivy-2.0.xml
+[ivy:install] 	published xercesImpl to /ivy/build-a-ivy-repository/myrepository/no-namespace/xerces/xercesImpl/jars/xercesImpl-2.6.2.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/xerces/xercesImpl/ivys/ivy-2.6.2.xml
+[ivy:install] :: install resolution report ::
+[ivy:install] :: resolution report :: resolve 0ms :: artifacts dl 51402ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|      default     |   28  |   28  |   28  |   0   ||   30  |   28  |
+	---------------------------------------------------------------------
+[ivy:install] 
+[ivy:install] :: problems summary ::
+[ivy:install] :::: WARNINGS
+[ivy:install] 		[NOT FOUND  ] javax.transaction#jta;1.0.1B!jta.jar (0ms)
+[ivy:install] 	==== libraries: tried
+[ivy:install] 	  http://repo1.maven.org/maven2/javax/transaction/jta/1.0.1B/jta-1.0.1B.jar
+[ivy:install] 		[NOT FOUND  ] javax.security#jacc;1.0!jacc.jar (0ms)
+[ivy:install] 	==== libraries: tried
+[ivy:install] 	  http://repo1.maven.org/maven2/javax/security/jacc/1.0/jacc-1.0.jar
+[ivy:install] 		::::::::::::::::::::::::::::::::::::::::::::::
+[ivy:install] 		::              FAILED DOWNLOADS            ::
+[ivy:install] 		:: ^ see resolution messages for details  ^ ::
+[ivy:install] 		::::::::::::::::::::::::::::::::::::::::::::::
+[ivy:install] 		:: javax.transaction#jta;1.0.1B!jta.jar
+[ivy:install] 		:: javax.security#jacc;1.0!jacc.jar
+[ivy:install] 		::::::::::::::::::::::::::::::::::::::::::::::
+[ivy:install] 
+[ivy:install] 
+[ivy:install] :: USE VERBOSE OR DEBUG MESSAGE LEVEL FOR MORE DETAILS

--- a/doc/tutorial/log/install-namespace.txt
+++ b/doc/tutorial/log/install-namespace.txt
@@ -1,0 +1,37 @@
+[ivy@apache:/ivy/build-a-ivy-repository]$ ant maven2-namespace
+Buildfile: /ivy/build-a-ivy-repository/build.xml
+
+load-ivy:
+
+init-ivy:
+
+maven2-namespace:
+[ivy:install] :: Apache Ivy 2.3.0 - 20130110142753 :: http://ant.apache.org/ivy/ ::
+[ivy:install] :: loading settings :: file = /ivy/build-a-ivy-repository/settings/ivysettings-advanced.xml
+[ivy:install] :: installing apache#commons-lang;1.0 ::
+[ivy:install] :: resolving dependencies ::
+[ivy:install] 	found apache#commons-lang;1.0 in libraries
+[ivy:install] :: downloading artifacts to cache ::
+[ivy:install] downloading http://repo1.maven.org/maven2/commons-lang/commons-lang/1.0/commons-lang-1.0.jar ...
+[ivy:install] .................. (62kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] apache#commons-lang;1.0!commons-lang.jar (234ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/commons-lang/commons-lang/1.0/commons-lang-1.0-javadoc.jar ...
+[ivy:install] ......... (170kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] apache#commons-lang;1.0!commons-lang.jar(javadoc) (468ms)
+[ivy:install] :: installing in my-repository ::
+[ivy:install] 	published commons-lang to /ivy/build-a-ivy-repository/myrepository/advanced/apache/commons-lang/jars/commons-lang-1.0.jar
+[ivy:install] 	published commons-lang to /ivy/build-a-ivy-repository/myrepository/advanced/apache/commons-lang/javadocs/commons-lang-1.0.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/advanced/apache/commons-lang/ivys/ivy-1.0.xml
+[ivy:install] :: install resolution report ::
+[ivy:install] :: resolution report :: resolve 0ms :: artifacts dl 702ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|      default     |   1   |   1   |   1   |   0   ||   2   |   2   |
+	---------------------------------------------------------------------
+
+BUILD SUCCESSFUL
+Total time: 2 seconds

--- a/doc/tutorial/log/install.txt
+++ b/doc/tutorial/log/install.txt
@@ -1,0 +1,37 @@
+[ivy@apache:/ivy/build-a-ivy-repository]$ ant maven2
+Buildfile: /ivy/build-a-ivy-repository/build.xml
+
+load-ivy:
+
+init-ivy:
+
+maven2:
+[ivy:install] :: Apache Ivy 2.3.0 - 20130110142753 :: http://ant.apache.org/ivy/ ::
+[ivy:install] :: loading settings :: file = /ivy/build-a-ivy-repository/settings/ivysettings-basic.xml
+[ivy:install] :: installing commons-lang#commons-lang;1.0 ::
+[ivy:install] :: resolving dependencies ::
+[ivy:install] 	found commons-lang#commons-lang;1.0 in libraries
+[ivy:install] :: downloading artifacts to cache ::
+[ivy:install] downloading http://repo1.maven.org/maven2/commons-lang/commons-lang/1.0/commons-lang-1.0-javadoc.jar ...
+[ivy:install] ...................... (170kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] commons-lang#commons-lang;1.0!commons-lang.jar(javadoc) (624ms)
+[ivy:install] downloading http://repo1.maven.org/maven2/commons-lang/commons-lang/1.0/commons-lang-1.0.jar ...
+[ivy:install] ....... (62kB)
+[ivy:install] .. (0kB)
+[ivy:install] 	[SUCCESSFUL ] commons-lang#commons-lang;1.0!commons-lang.jar (328ms)
+[ivy:install] :: installing in my-repository ::
+[ivy:install] 	published commons-lang to /ivy/build-a-ivy-repository/myrepository/no-namespace/commons-lang/commons-lang/javadocs/commons-lang-1.0.jar
+[ivy:install] 	published commons-lang to /ivy/build-a-ivy-repository/myrepository/no-namespace/commons-lang/commons-lang/jars/commons-lang-1.0.jar
+[ivy:install] 	published ivy to /ivy/build-a-ivy-repository/myrepository/no-namespace/commons-lang/commons-lang/ivys/ivy-1.0.xml
+[ivy:install] :: install resolution report ::
+[ivy:install] :: resolution report :: resolve 0ms :: artifacts dl 952ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|      default     |   1   |   1   |   1   |   0   ||   2   |   2   |
+	---------------------------------------------------------------------
+
+BUILD SUCCESSFUL
+Total time: 2 seconds

--- a/doc/tutorial/log/multi-project-find-antp.txt
+++ b/doc/tutorial/log/multi-project-find-antp.txt
@@ -1,0 +1,17 @@
+[ivy@apache:/ivy/multi-project/projects/find]$ ant -p
+Buildfile: /ivy/multi-project/projects/find/build.xml
+
+Main targets:
+
+ clean          --> clean the project
+ clean-build    --> clean the project built files
+ clean-lib      --> clean the project libraries directory (dependencies)
+ clean-local    --> cleans the local repository for the current module
+ compile        --> compile the project
+ jar            --> make a jar file for this project
+ publish        --> publish this project in the ivy repository
+ publish-local  --> publish this project in the local ivy repository
+ report         --> generates a report of dependencies
+ resolve        --> resolve and retrieve dependencies with ivy
+ run            --> compile and run the project
+Default target: compile

--- a/doc/tutorial/log/multi-project-general-antp.txt
+++ b/doc/tutorial/log/multi-project-general-antp.txt
@@ -1,0 +1,8 @@
+[ivy@apache:/ivy/multi-project]$ ant -p
+Buildfile: /ivy/multi-project/build.xml
+
+Main targets:
+
+ clean        clean tutorial: delete repository, ivy cache, and all projects
+ clean-all    clean all projects
+ publish-all  compile, jar and publish all projects in the right order

--- a/doc/tutorial/log/multi-project-general-publishall.txt
+++ b/doc/tutorial/log/multi-project-general-publishall.txt
@@ -1,0 +1,366 @@
+[ivy@apache:/ivy/multi-project]$ ant publish-all
+Buildfile: /ivy/multi-project/build.xml
+
+load-ivy:
+
+buildlist:
+[ivy:buildlist] :: Apache Ivy 2.3.0 - 20130110142753 :: http://ant.apache.org/ivy/ ::
+[ivy:buildlist] :: loading settings :: url = jar:file:///home/ivy/ivy.jar!/org/apache/ivy/core/settings/ivysettings.xml
+
+publish-all:
+
+clean-build:
+
+load-ivy:
+    [mkdir] Created dir: C:/Users/Maarten/.ivy2/jars
+
+ivy-new-version:
+ [ivy:info] :: loading settings :: url = jar:file:///home/ivy/ivy.jar!/org/apache/ivy/core/settings/ivysettings.xml
+
+version:
+    [mkdir] Created dir: /ivy/multi-project/projects/version/build/classes
+
+clean-lib:
+
+resolve:
+    [mkdir] Created dir: /ivy/multi-project/projects/version/lib
+[ivy:resolve] :: resolving dependencies :: org.apache.ivy.example#version;working@apache
+[ivy:resolve] 	confs: [default]
+[ivy:resolve] :: resolution report :: resolve 94ms :: artifacts dl 0ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|      default     |   0   |   0   |   0   |   0   ||   0   |   0   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache.ivy.example#version
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	0 artifacts copied, 0 already retrieved (0kB/16ms)
+
+compile:
+    [javac] Compiling 1 source file to /ivy/multi-project/projects/version/build/classes
+    [javac] Note: /ivy/multi-project/projects/version/src/version/Version.java uses unchecked or unsafe operations.
+    [javac] Note: Recompile with -Xlint:unchecked for details.
+
+jar:
+      [jar] Building jar: /ivy/multi-project/projects/version/build/version.jar
+
+publish:
+[ivy:publish] :: delivering :: org.apache.ivy.example#version;working@apache :: 1.0-dev-b1 :: release :: Thu Jan 10 14:36:23 CET 2013
+[ivy:publish] 	delivering ivy file to /ivy/multi-project/projects/version/build/ivy.xml
+[ivy:publish] :: publishing :: org.apache.ivy.example#version
+[ivy:publish] 	published version to /ivy/multi-project/repository/shared/org.apache.ivy.example/version/1.0-dev-b1.part/jars/version.jar
+[ivy:publish] 	published ivy to /ivy/multi-project/repository/shared/org.apache.ivy.example/version/1.0-dev-b1.part/ivys/ivy.xml
+[ivy:publish] 	publish commited: moved /ivy/multi-project/repository/shared/org.apache.ivy.example/version/1.0-dev-b1.part 
+[ivy:publish] 		to /ivy/multi-project/repository/shared/org.apache.ivy.example/version/1.0-dev-b1
+     [echo] project version released with version 1.0-dev-b1
+
+clean-build:
+
+load-ivy:
+
+ivy-new-version:
+ [ivy:info] :: loading settings :: url = jar:file:///home/ivy/ivy.jar!/org/apache/ivy/core/settings/ivysettings.xml
+
+version:
+    [mkdir] Created dir: /ivy/multi-project/projects/list/build/classes
+
+clean-lib:
+
+resolve:
+    [mkdir] Created dir: /ivy/multi-project/projects/list/lib
+[ivy:resolve] :: resolving dependencies :: org.apache.ivy.example#list;working@apache
+[ivy:resolve] 	confs: [core, standalone]
+[ivy:resolve] 	found org.apache.ivy.example#version;1.0-dev-b1 in shared
+[ivy:resolve] 	[1.0-dev-b1] org.apache.ivy.example#version;latest.integration
+[ivy:resolve] 	found commons-cli#commons-cli;1.0 in public
+[ivy:resolve] 	found commons-logging#commons-logging;1.0 in public
+[ivy:resolve] 	found commons-lang#commons-lang;1.0 in public
+[ivy:resolve] 	found junit#junit;3.7 in public
+[ivy:resolve] downloading /ivy/multi-project/repository/shared/org.apache.ivy.example/version/1.0-dev-b1/jars/version.jar ...
+[ivy:resolve] .. (1kB)
+[ivy:resolve] .. (0kB)
+[ivy:resolve] 	[SUCCESSFUL ] org.apache.ivy.example#version;1.0-dev-b1!version.jar (31ms)
+[ivy:resolve] downloading http://repo1.maven.org/maven2/commons-cli/commons-cli/1.0/commons-cli-1.0.jar ...
+[ivy:resolve] ..... (29kB)
+[ivy:resolve] .. (0kB)
+[ivy:resolve] 	[SUCCESSFUL ] commons-cli#commons-cli;1.0!commons-cli.jar (187ms)
+[ivy:resolve] downloading http://repo1.maven.org/maven2/commons-logging/commons-logging/1.0/commons-logging-1.0.jar ...
+[ivy:resolve] ..... (21kB)
+[ivy:resolve] .. (0kB)
+[ivy:resolve] 	[SUCCESSFUL ] commons-logging#commons-logging;1.0!commons-logging.jar (156ms)
+[ivy:resolve] downloading http://repo1.maven.org/maven2/commons-lang/commons-lang/1.0/commons-lang-1.0.jar ...
+[ivy:resolve] ...... (62kB)
+[ivy:resolve] .. (0kB)
+[ivy:resolve] 	[SUCCESSFUL ] commons-lang#commons-lang;1.0!commons-lang.jar (250ms)
+[ivy:resolve] downloading http://repo1.maven.org/maven2/junit/junit/3.7/junit-3.7.jar ...
+[ivy:resolve] ......... (114kB)
+[ivy:resolve] .. (0kB)
+[ivy:resolve] 	[SUCCESSFUL ] junit#junit;3.7!junit.jar (390ms)
+[ivy:resolve] :: resolution report :: resolve 3073ms :: artifacts dl 1030ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|       core       |   1   |   1   |   1   |   0   ||   1   |   1   |
+	|    standalone    |   5   |   5   |   5   |   0   ||   5   |   5   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache.ivy.example#list
+[ivy:retrieve] 	confs: [core, standalone]
+[ivy:retrieve] 	5 artifacts copied, 0 already retrieved (229kB/47ms)
+
+compile:
+    [javac] Compiling 2 source files to /ivy/multi-project/projects/list/build/classes
+    [javac] Note: /ivy/multi-project/projects/list/src/list/ListFile.java uses unchecked or unsafe operations.
+    [javac] Note: Recompile with -Xlint:unchecked for details.
+
+jar:
+      [jar] Building jar: /ivy/multi-project/projects/list/build/list.jar
+
+publish:
+[ivy:publish] :: delivering :: org.apache.ivy.example#list;working@apache :: 1.0-dev-b1 :: release :: Thu Jan 10 14:36:29 CET 2013
+[ivy:publish] 	delivering ivy file to /ivy/multi-project/projects/list/build/ivy.xml
+[ivy:publish] :: publishing :: org.apache.ivy.example#list
+[ivy:publish] 	published list to /ivy/multi-project/repository/shared/org.apache.ivy.example/list/1.0-dev-b1.part/jars/list.jar
+[ivy:publish] 	published ivy to /ivy/multi-project/repository/shared/org.apache.ivy.example/list/1.0-dev-b1.part/ivys/ivy.xml
+[ivy:publish] 	publish commited: moved /ivy/multi-project/repository/shared/org.apache.ivy.example/list/1.0-dev-b1.part 
+[ivy:publish] 		to /ivy/multi-project/repository/shared/org.apache.ivy.example/list/1.0-dev-b1
+     [echo] project list released with version 1.0-dev-b1
+
+clean-build:
+
+load-ivy:
+
+ivy-new-version:
+ [ivy:info] :: loading settings :: url = jar:file:///home/ivy/ivy.jar!/org/apache/ivy/core/settings/ivysettings.xml
+
+version:
+    [mkdir] Created dir: /ivy/multi-project/projects/find/build/classes
+
+clean-lib:
+
+resolve:
+    [mkdir] Created dir: /ivy/multi-project/projects/find/lib
+[ivy:resolve] :: resolving dependencies :: org.apache.ivy.example#find;working@apache
+[ivy:resolve] 	confs: [core, standalone]
+[ivy:resolve] 	found org.apache.ivy.example#version;1.0-dev-b1 in shared
+[ivy:resolve] 	[1.0-dev-b1] org.apache.ivy.example#version;latest.integration
+[ivy:resolve] 	found org.apache.ivy.example#list;1.0-dev-b1 in shared
+[ivy:resolve] 	[1.0-dev-b1] org.apache.ivy.example#list;latest.integration
+[ivy:resolve] 	found commons-collections#commons-collections;3.1 in public
+[ivy:resolve] 	found commons-cli#commons-cli;1.0 in public
+[ivy:resolve] 	found commons-logging#commons-logging;1.0 in public
+[ivy:resolve] 	found commons-lang#commons-lang;1.0 in public
+[ivy:resolve] 	found junit#junit;3.7 in public
+[ivy:resolve] downloading /ivy/multi-project/repository/shared/org.apache.ivy.example/list/1.0-dev-b1/jars/list.jar ...
+[ivy:resolve] .. (2kB)
+[ivy:resolve] .. (0kB)
+[ivy:resolve] 	[SUCCESSFUL ] org.apache.ivy.example#list;1.0-dev-b1!list.jar (0ms)
+[ivy:resolve] downloading http://repo1.maven.org/maven2/commons-collections/commons-collections/3.1/commons-collections-3.1.jar ...
+[ivy:resolve] ................................................. (546kB)
+[ivy:resolve] .. (0kB)
+[ivy:resolve] 	[SUCCESSFUL ] commons-collections#commons-collections;3.1!commons-collections.jar (1248ms)
+[ivy:resolve] :: resolution report :: resolve 2325ms :: artifacts dl 1263ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|       core       |   3   |   3   |   2   |   0   ||   3   |   2   |
+	|    standalone    |   7   |   3   |   2   |   0   ||   7   |   2   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache.ivy.example#find
+[ivy:retrieve] 	confs: [core, standalone]
+[ivy:retrieve] 	7 artifacts copied, 0 already retrieved (778kB/63ms)
+
+compile:
+    [javac] Compiling 2 source files to /ivy/multi-project/projects/find/build/classes
+
+jar:
+      [jar] Building jar: /ivy/multi-project/projects/find/build/find.jar
+
+publish:
+[ivy:publish] :: delivering :: org.apache.ivy.example#find;working@apache :: 1.0-dev-b1 :: release :: Thu Jan 10 14:36:35 CET 2013
+[ivy:publish] 	delivering ivy file to /ivy/multi-project/projects/find/build/ivy.xml
+[ivy:publish] :: publishing :: org.apache.ivy.example#find
+[ivy:publish] 	published find to /ivy/multi-project/repository/shared/org.apache.ivy.example/find/1.0-dev-b1.part/jars/find.jar
+[ivy:publish] 	published ivy to /ivy/multi-project/repository/shared/org.apache.ivy.example/find/1.0-dev-b1.part/ivys/ivy.xml
+[ivy:publish] 	publish commited: moved /ivy/multi-project/repository/shared/org.apache.ivy.example/find/1.0-dev-b1.part 
+[ivy:publish] 		to /ivy/multi-project/repository/shared/org.apache.ivy.example/find/1.0-dev-b1
+     [echo] project find released with version 1.0-dev-b1
+
+clean-build:
+
+load-ivy:
+
+ivy-new-version:
+ [ivy:info] :: loading settings :: url = jar:file:///home/ivy/ivy.jar!/org/apache/ivy/core/settings/ivysettings.xml
+
+version:
+    [mkdir] Created dir: /ivy/multi-project/projects/size/build/classes
+
+clean-lib:
+
+resolve:
+    [mkdir] Created dir: /ivy/multi-project/projects/size/lib
+[ivy:resolve] :: resolving dependencies :: org.apache.ivy.example#size;working@apache
+[ivy:resolve] 	confs: [default]
+[ivy:resolve] 	found org.apache.ivy.example#version;1.0-dev-b1 in shared
+[ivy:resolve] 	[1.0-dev-b1] org.apache.ivy.example#version;latest.integration
+[ivy:resolve] 	found org.apache.ivy.example#list;1.0-dev-b1 in shared
+[ivy:resolve] 	[1.0-dev-b1] org.apache.ivy.example#list;latest.integration
+[ivy:resolve] :: resolution report :: resolve 2013ms :: artifacts dl 0ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|      default     |   2   |   2   |   0   |   0   ||   2   |   0   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache.ivy.example#size
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	2 artifacts copied, 0 already retrieved (4kB/0ms)
+
+compile:
+    [javac] Compiling 1 source file to /ivy/multi-project/projects/size/build/classes
+
+jar:
+      [jar] Building jar: /ivy/multi-project/projects/size/build/size.jar
+
+publish:
+[ivy:publish] :: delivering :: org.apache.ivy.example#size;working@apache :: 1.0-dev-b1 :: release :: Thu Jan 10 14:36:38 CET 2013
+[ivy:publish] 	delivering ivy file to /ivy/multi-project/projects/size/build/ivy.xml
+[ivy:publish] :: publishing :: org.apache.ivy.example#size
+[ivy:publish] 	published size to /ivy/multi-project/repository/shared/org.apache.ivy.example/size/1.0-dev-b1.part/jars/size.jar
+[ivy:publish] 	published ivy to /ivy/multi-project/repository/shared/org.apache.ivy.example/size/1.0-dev-b1.part/ivys/ivy.xml
+[ivy:publish] 	publish commited: moved /ivy/multi-project/repository/shared/org.apache.ivy.example/size/1.0-dev-b1.part 
+[ivy:publish] 		to /ivy/multi-project/repository/shared/org.apache.ivy.example/size/1.0-dev-b1
+     [echo] project size released with version 1.0-dev-b1
+
+clean-build:
+
+load-ivy:
+
+ivy-new-version:
+ [ivy:info] :: loading settings :: url = jar:file:///home/ivy/ivy.jar!/org/apache/ivy/core/settings/ivysettings.xml
+
+version:
+    [mkdir] Created dir: /ivy/multi-project/projects/sizewhere/build/classes
+
+clean-lib:
+
+resolve:
+    [mkdir] Created dir: /ivy/multi-project/projects/sizewhere/lib
+[ivy:resolve] :: resolving dependencies :: org.apache.ivy.example#sizewhere;working@apache
+[ivy:resolve] 	confs: [core, standalone]
+[ivy:resolve] 	found org.apache.ivy.example#version;1.0-dev-b1 in shared
+[ivy:resolve] 	[1.0-dev-b1] org.apache.ivy.example#version;latest.integration
+[ivy:resolve] 	found org.apache.ivy.example#size;1.0-dev-b1 in shared
+[ivy:resolve] 	[1.0-dev-b1] org.apache.ivy.example#size;latest.integration
+[ivy:resolve] 	found org.apache.ivy.example#list;1.0-dev-b1 in shared
+[ivy:resolve] 	found org.apache.ivy.example#find;1.0-dev-b1 in shared
+[ivy:resolve] 	[1.0-dev-b1] org.apache.ivy.example#find;latest.integration
+[ivy:resolve] 	found commons-collections#commons-collections;3.1 in public
+[ivy:resolve] 	found commons-cli#commons-cli;1.0 in public
+[ivy:resolve] 	found commons-logging#commons-logging;1.0 in public
+[ivy:resolve] 	found commons-lang#commons-lang;1.0 in public
+[ivy:resolve] 	found junit#junit;3.7 in public
+[ivy:resolve] downloading /ivy/multi-project/repository/shared/org.apache.ivy.example/size/1.0-dev-b1/jars/size.jar ...
+[ivy:resolve] .. (1kB)
+[ivy:resolve] .. (0kB)
+[ivy:resolve] 	[SUCCESSFUL ] org.apache.ivy.example#size;1.0-dev-b1!size.jar (47ms)
+[ivy:resolve] downloading /ivy/multi-project/repository/shared/org.apache.ivy.example/find/1.0-dev-b1/jars/find.jar ...
+[ivy:resolve] .. (3kB)
+[ivy:resolve] .. (0kB)
+[ivy:resolve] 	[SUCCESSFUL ] org.apache.ivy.example#find;1.0-dev-b1!find.jar (47ms)
+[ivy:resolve] :: resolution report :: resolve 3307ms :: artifacts dl 109ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|       core       |   5   |   3   |   2   |   0   ||   5   |   2   |
+	|    standalone    |   9   |   3   |   2   |   0   ||   9   |   2   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache.ivy.example#sizewhere
+[ivy:retrieve] 	confs: [core, standalone]
+[ivy:retrieve] 	9 artifacts copied, 0 already retrieved (783kB/78ms)
+
+compile:
+    [javac] Compiling 2 source files to /ivy/multi-project/projects/sizewhere/build/classes
+
+jar:
+      [jar] Building jar: /ivy/multi-project/projects/sizewhere/build/sizewhere.jar
+
+publish:
+[ivy:publish] :: delivering :: org.apache.ivy.example#sizewhere;working@apache :: 1.0-dev-b1 :: release :: Thu Jan 10 14:36:44 CET 2013
+[ivy:publish] 	delivering ivy file to /ivy/multi-project/projects/sizewhere/build/ivy.xml
+[ivy:publish] :: publishing :: org.apache.ivy.example#sizewhere
+[ivy:publish] 	published sizewhere to /ivy/multi-project/repository/shared/org.apache.ivy.example/sizewhere/1.0-dev-b1.part/jars/sizewhere.jar
+[ivy:publish] 	published ivy to /ivy/multi-project/repository/shared/org.apache.ivy.example/sizewhere/1.0-dev-b1.part/ivys/ivy.xml
+[ivy:publish] 	publish commited: moved /ivy/multi-project/repository/shared/org.apache.ivy.example/sizewhere/1.0-dev-b1.part 
+[ivy:publish] 		to /ivy/multi-project/repository/shared/org.apache.ivy.example/sizewhere/1.0-dev-b1
+     [echo] project sizewhere released with version 1.0-dev-b1
+
+clean-build:
+
+load-ivy:
+
+ivy-new-version:
+ [ivy:info] :: loading settings :: url = jar:file:///home/ivy/ivy.jar!/org/apache/ivy/core/settings/ivysettings.xml
+
+version:
+    [mkdir] Created dir: /ivy/multi-project/projects/console/build/classes
+
+clean-lib:
+
+resolve:
+    [mkdir] Created dir: /ivy/multi-project/projects/console/lib
+[ivy:resolve] :: resolving dependencies :: org.apache.ivy.example#console;working@apache
+[ivy:resolve] 	confs: [default]
+[ivy:resolve] 	found org.apache.ivy.example#version;1.0-dev-b1 in shared
+[ivy:resolve] 	[1.0-dev-b1] org.apache.ivy.example#version;latest.integration
+[ivy:resolve] 	found org.apache.ivy.example#list;1.0-dev-b1 in shared
+[ivy:resolve] 	[1.0-dev-b1] org.apache.ivy.example#list;latest.integration
+[ivy:resolve] 	found commons-cli#commons-cli;1.0 in public
+[ivy:resolve] 	found commons-logging#commons-logging;1.0 in public
+[ivy:resolve] 	found commons-lang#commons-lang;1.0 in public
+[ivy:resolve] 	found junit#junit;3.7 in public
+[ivy:resolve] 	found org.apache.ivy.example#find;1.0-dev-b1 in shared
+[ivy:resolve] 	[1.0-dev-b1] org.apache.ivy.example#find;latest.integration
+[ivy:resolve] 	found commons-collections#commons-collections;3.1 in public
+[ivy:resolve] 	found org.apache.ivy.example#sizewhere;1.0-dev-b1 in shared
+[ivy:resolve] 	[1.0-dev-b1] org.apache.ivy.example#sizewhere;latest.integration
+[ivy:resolve] 	found org.apache.ivy.example#size;1.0-dev-b1 in shared
+[ivy:resolve] downloading /ivy/multi-project/repository/shared/org.apache.ivy.example/sizewhere/1.0-dev-b1/jars/sizewhere.jar ...
+[ivy:resolve] .. (2kB)
+[ivy:resolve] .. (0kB)
+[ivy:resolve] 	[SUCCESSFUL ] org.apache.ivy.example#sizewhere;1.0-dev-b1!sizewhere.jar (15ms)
+[ivy:resolve] :: resolution report :: resolve 4134ms :: artifacts dl 47ms
+	---------------------------------------------------------------------
+	|                  |            modules            ||   artifacts   |
+	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
+	---------------------------------------------------------------------
+	|      default     |   10  |   4   |   1   |   0   ||   10  |   1   |
+	---------------------------------------------------------------------
+[ivy:retrieve] :: retrieving :: org.apache.ivy.example#console
+[ivy:retrieve] 	confs: [default]
+[ivy:retrieve] 	10 artifacts copied, 0 already retrieved (785kB/47ms)
+
+compile:
+    [javac] Compiling 1 source file to /ivy/multi-project/projects/console/build/classes
+    [javac] Note: /ivy/multi-project/projects/console/src/console/Main.java uses unchecked or unsafe operations.
+    [javac] Note: Recompile with -Xlint:unchecked for details.
+
+jar:
+      [jar] Building jar: /ivy/multi-project/projects/console/build/console.jar
+
+publish:
+[ivy:publish] :: delivering :: org.apache.ivy.example#console;working@apache :: 1.0-dev-b1 :: release :: Thu Jan 10 14:36:50 CET 2013
+[ivy:publish] 	delivering ivy file to /ivy/multi-project/projects/console/build/ivy.xml
+[ivy:publish] :: publishing :: org.apache.ivy.example#console
+[ivy:publish] 	published console to /ivy/multi-project/repository/shared/org.apache.ivy.example/console/1.0-dev-b1.part/jars/console.jar
+[ivy:publish] 	published ivy to /ivy/multi-project/repository/shared/org.apache.ivy.example/console/1.0-dev-b1.part/ivys/ivy.xml
+[ivy:publish] 	publish commited: moved /ivy/multi-project/repository/shared/org.apache.ivy.example/console/1.0-dev-b1.part 
+[ivy:publish] 		to /ivy/multi-project/repository/shared/org.apache.ivy.example/console/1.0-dev-b1
+     [echo] project console released with version 1.0-dev-b1
+
+BUILD SUCCESSFUL
+Total time: 30 seconds

--- a/doc/tutorial/log/myrepository-content-deps.txt
+++ b/doc/tutorial/log/myrepository-content-deps.txt
@@ -1,0 +1,13 @@
+[ivy@apache:/]$ find /ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate -type f -print
+/ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate/ivys/ivy-3.2.5.ga.xml
+/ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate/ivys/ivy-3.2.5.ga.xml.md5
+/ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate/ivys/ivy-3.2.5.ga.xml.sha1
+/ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate/jars/hibernate-3.2.5.ga.jar
+/ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate/jars/hibernate-3.2.5.ga.jar.md5
+/ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate/jars/hibernate-3.2.5.ga.jar.sha1
+/ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate/javadocs/hibernate-3.2.5.ga.jar
+/ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate/javadocs/hibernate-3.2.5.ga.jar.md5
+/ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate/javadocs/hibernate-3.2.5.ga.jar.sha1
+/ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate/sources/hibernate-3.2.5.ga.jar
+/ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate/sources/hibernate-3.2.5.ga.jar.md5
+/ivy/build-a-ivy-repository/myrepository/no-namespace/org.hibernate/hibernate/sources/hibernate-3.2.5.ga.jar.sha1

--- a/doc/tutorial/log/myrepository-content-namespace.txt
+++ b/doc/tutorial/log/myrepository-content-namespace.txt
@@ -1,0 +1,10 @@
+$ find /ivy/build-a-ivy-repository/myrepository/advanced -type f -print
+/ivy/build-a-ivy-repository/myrepository/advanced/apache/commons-lang/ivys/ivy-1.0.xml
+/ivy/build-a-ivy-repository/myrepository/advanced/apache/commons-lang/ivys/ivy-1.0.xml.md5
+/ivy/build-a-ivy-repository/myrepository/advanced/apache/commons-lang/ivys/ivy-1.0.xml.sha1
+/ivy/build-a-ivy-repository/myrepository/advanced/apache/commons-lang/jars/commons-lang-1.0.jar
+/ivy/build-a-ivy-repository/myrepository/advanced/apache/commons-lang/jars/commons-lang-1.0.jar.md5
+/ivy/build-a-ivy-repository/myrepository/advanced/apache/commons-lang/jars/commons-lang-1.0.jar.sha1
+/ivy/build-a-ivy-repository/myrepository/advanced/apache/commons-lang/javadocs/commons-lang-1.0.jar
+/ivy/build-a-ivy-repository/myrepository/advanced/apache/commons-lang/javadocs/commons-lang-1.0.jar.md5
+/ivy/build-a-ivy-repository/myrepository/advanced/apache/commons-lang/javadocs/commons-lang-1.0.jar.sha1

--- a/doc/tutorial/log/myrepository-content.txt
+++ b/doc/tutorial/log/myrepository-content.txt
@@ -1,0 +1,10 @@
+[ivy@apache:/]$ find /ivy/build-a-ivy-repository/myrepository/no-namespace -type f -print
+/ivy/build-a-ivy-repository/myrepository/no-namespace/commons-lang/commons-lang/ivys/ivy-1.0.xml
+/ivy/build-a-ivy-repository/myrepository/no-namespace/commons-lang/commons-lang/ivys/ivy-1.0.xml.md5
+/ivy/build-a-ivy-repository/myrepository/no-namespace/commons-lang/commons-lang/ivys/ivy-1.0.xml.sha1
+/ivy/build-a-ivy-repository/myrepository/no-namespace/commons-lang/commons-lang/jars/commons-lang-1.0.jar
+/ivy/build-a-ivy-repository/myrepository/no-namespace/commons-lang/commons-lang/jars/commons-lang-1.0.jar.md5
+/ivy/build-a-ivy-repository/myrepository/no-namespace/commons-lang/commons-lang/jars/commons-lang-1.0.jar.sha1
+/ivy/build-a-ivy-repository/myrepository/no-namespace/commons-lang/commons-lang/javadocs/commons-lang-1.0.jar
+/ivy/build-a-ivy-repository/myrepository/no-namespace/commons-lang/commons-lang/javadocs/commons-lang-1.0.jar.md5
+/ivy/build-a-ivy-repository/myrepository/no-namespace/commons-lang/commons-lang/javadocs/commons-lang-1.0.jar.sha1

--- a/version.properties
+++ b/version.properties
@@ -16,9 +16,9 @@
 #	 * specific language governing permissions and limitations
 #	 * under the License.
 #	 ***************************************************************
-target.ivy.version=2.3.1
+target.ivy.version=2.3.0
 # Following OSGi spec: have to be 3 numbers separated by dots
-target.ivy.bundle.version=2.3.1
+target.ivy.bundle.version=2.3.0
 # in case we want to add a qualifier such as alpha, beta, etc...
 # if non empty, add a '_' at the end of the qualifier, so the version would look like 1.2.3.alpha_200901011200
-target.ivy.bundle.version.qualifier=alpha_
+target.ivy.bundle.version.qualifier=

--- a/version.properties
+++ b/version.properties
@@ -21,4 +21,4 @@ target.ivy.version=2.3.0
 target.ivy.bundle.version=2.3.0
 # in case we want to add a qualifier such as alpha, beta, etc...
 # if non empty, add a '_' at the end of the qualifier, so the version would look like 1.2.3.alpha_200901011200
-target.ivy.bundle.version.qualifier=
+target.ivy.bundle.version.qualifier=final_


### PR DESCRIPTION
This adds caching around exclude rules. In that small sample that I tested, this change has reduced the overheads from having exclude rules significantly.
