### PR TITLE
Comment out explicit check against M2_PATTERN

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,10 +6,23 @@ lazy val makeModuleProperties = taskKey[Seq[File]]("Create module.properties fil
 lazy val root = (project in file(".")).
   settings(versionWithGit: _*).
   settings(
+    inThisBuild(Seq(
+      organization := "org.scala-sbt.ivy",
+      homepage := Some(url("https://github.com/sbt/ivy")),
+      description := "patched Ivy for sbt",
+      licenses := List("Apache-2.0" -> url("https://github.com/sbt/ivy/blob/2.3.x-sbt/LICENSE")),
+      scmInfo := Some(ScmInfo(url("https://github.com/sbt/ivy"), "git@github.com:sbt/ivy.git")),
+      developers := List(
+        Developer("eed3si9n", "Eugene Yokota", "@eed3si9n", url("https://github.com/eed3si9n"))
+      ),
+      bintrayReleaseOnPublish := false,
+      bintrayOrganization := Some("sbt"),
+      bintrayRepository := "maven-releases",
+      bintrayPackage := "ivy"
+    )),
     // TODO - Read from version.properties
     git.baseVersion := "2.3.0-sbt",
     name := "ivy",
-    organization := "org.scala-sbt.ivy",
     unmanagedSourceDirectories in Compile := Seq(
       baseDirectory.value / "src" / "java"
     ),
@@ -55,7 +68,6 @@ lazy val root = (project in file(".")).
     autoScalaLibrary := false,
     crossPaths := false,
     javaVersionPrefix in javaVersionCheck := Some("1.6"),
-    // TODO - publish settings
-    publishMavenStyle := false,
-    publishTo := Some(Resolver.url("publish-typesafe-releases", url("http://private-repo.typesafe.com/typesafe/ivy-releases"))(Resolver.ivyStylePatterns))
+    bintrayPackage := (bintrayPackage in ThisBuild).value,
+    bintrayRepository := (bintrayRepository in ThisBuild).value
   )

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9-M1

--- a/src/java/org/apache/ivy/plugins/resolver/IBiblioResolver.java
+++ b/src/java/org/apache/ivy/plugins/resolver/IBiblioResolver.java
@@ -495,7 +495,8 @@ public class IBiblioResolver extends URLResolver {
     }
 
     private boolean shouldUseMavenMetadata(String pattern) {
-        return isUseMavenMetadata() && isM2compatible() && pattern.endsWith(M2_PATTERN);
+        // pattern is customized on the resolvers converted by sbt.
+        return isUseMavenMetadata() && isM2compatible(); // && pattern.endsWith(M2_PATTERN);
     }
 
 


### PR DESCRIPTION
REF sbt/sbt#2005, and potentially relates to some of the SNAPSHOT issues listed on sbt/sbt#1780.

Ivy checks if the repository patterns ends with `M2_PATTERN` to see if `maven-metadata.xml` should be used. Because sbt customizes the pattern, Ivy will end up not using `maven-metadata.xml`.

/review @jsuereth, @dwijnand
