### PR TITLE
[NO MERGE] Force deleting sources/javadoc to fix sbt/sbt#1750

### DIFF
--- a/src/java/org/apache/ivy/core/cache/DefaultRepositoryCacheManager.java
+++ b/src/java/org/apache/ivy/core/cache/DefaultRepositoryCacheManager.java
@@ -1211,6 +1211,7 @@ public class DefaultRepositoryCacheManager implements RepositoryCacheManager, Iv
                     Message.verbose(mrid + " has changed: deleting old artifacts");
                     deleteOldArtifacts = true;
                 }
+                System.out.println("gh1750 ivy");
                 if (deleteOldArtifacts) {
                     String[] confs = md.getConfigurationsNames();
                     for (int i = 0; i < confs.length; i++) {

--- a/src/java/org/apache/ivy/core/cache/DefaultRepositoryCacheManager.java
+++ b/src/java/org/apache/ivy/core/cache/DefaultRepositoryCacheManager.java
@@ -51,6 +51,7 @@ import org.apache.ivy.plugins.namespace.NameSpaceHelper;
 import org.apache.ivy.plugins.parser.ModuleDescriptorParser;
 import org.apache.ivy.plugins.parser.ModuleDescriptorParserRegistry;
 import org.apache.ivy.plugins.parser.ParserSettings;
+import org.apache.ivy.plugins.parser.m2.PomModuleDescriptorBuilder;
 import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorParser;
 import org.apache.ivy.plugins.repository.ArtifactResourceResolver;
 import org.apache.ivy.plugins.repository.Repository;
@@ -1218,6 +1219,13 @@ public class DefaultRepositoryCacheManager implements RepositoryCacheManager, Iv
                             if (!prepAndDeleteArtifact(arts[j], options, backupDownloader)) return null;
                         }
                     }
+
+                    final Artifact sourceArtifact  = PomModuleDescriptorBuilder.getSourceArtifact(md, mrid);
+                    final Artifact srcArtifact     = PomModuleDescriptorBuilder.getSrcArtifact(md, mrid);
+                    final Artifact javadocArtifact = PomModuleDescriptorBuilder.getJavadocArtifact(md, mrid);
+                    if (!prepAndDeleteArtifact(sourceArtifact,  options, backupDownloader)) return null;
+                    if (!prepAndDeleteArtifact(srcArtifact,     options, backupDownloader)) return null;
+                    if (!prepAndDeleteArtifact(javadocArtifact, options, backupDownloader)) return null;
                 } else if (isChanging(dd, mrid, options)) {
                     Message.verbose(mrid
                         + " is changing, but has not changed: will trust cached artifacts if any");

--- a/src/java/org/apache/ivy/core/cache/DefaultRepositoryCacheManager.java
+++ b/src/java/org/apache/ivy/core/cache/DefaultRepositoryCacheManager.java
@@ -1215,24 +1215,7 @@ public class DefaultRepositoryCacheManager implements RepositoryCacheManager, Iv
                     for (int i = 0; i < confs.length; i++) {
                         Artifact[] arts = md.getArtifacts(confs[i]);
                         for (int j = 0; j < arts.length; j++) {
-                            Artifact transformedArtifact = NameSpaceHelper.transform(
-                                arts[j], options.getNamespace().getToSystemTransformer());
-                            ArtifactOrigin origin = getSavedArtifactOrigin(
-                                transformedArtifact);
-                            File artFile = getArchiveFileInCache(
-                                transformedArtifact, origin, false);
-                            if (artFile.exists()) {
-                                Message.debug("deleting " + artFile);
-                                if (!artFile.delete()) {
-                                    // Old artifacts couldn't get deleted!
-                                    // Restore the original ivy file so the next time we
-                                    // resolve the old artifacts are deleted again
-                                    backupDownloader.restore();
-                                    Message.error("Couldn't delete outdated artifact from cache: " + artFile);
-                                    return null;
-                                }
-                            }
-                            removeSavedArtifactOrigin(transformedArtifact);
+                            if (!prepAndDeleteArtifact(arts[j], options, backupDownloader)) return null;
                         }
                     }
                 } else if (isChanging(dd, mrid, options)) {
@@ -1357,7 +1340,28 @@ public class DefaultRepositoryCacheManager implements RepositoryCacheManager, Iv
         }
         return isCheckmodified();
     }
-    
+
+    private boolean prepAndDeleteArtifact(final Artifact artifact, final CacheMetadataOptions options,
+                                          final BackupResourceDownloader backupDownloader) throws IOException {
+        final Artifact transformedArtifact =
+            NameSpaceHelper.transform(artifact, options.getNamespace().getToSystemTransformer());
+        final ArtifactOrigin origin = getSavedArtifactOrigin(transformedArtifact);
+        final File artFile = getArchiveFileInCache(transformedArtifact, origin, false);
+        if (artFile.exists()) {
+            Message.debug("deleting " + artFile);
+            if (!artFile.delete()) {
+                // Old artifacts couldn't get deleted!
+                // Restore the original ivy file so the next time we
+                // resolve the old artifacts are deleted again
+                backupDownloader.restore();
+                Message.error("Couldn't delete outdated artifact from cache: " + artFile);
+                return false;
+            }
+        }
+        removeSavedArtifactOrigin(transformedArtifact);
+        return true;
+    }
+
     public void clean() {
         FileUtil.forceDelete(getBasedir());
     }

--- a/src/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorBuilder.java
+++ b/src/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorBuilder.java
@@ -635,23 +635,27 @@ public class PomModuleDescriptorBuilder {
         return mainArtifact;
     }
 
-    public Artifact getSourceArtifact() {
+    public static Artifact getSourceArtifact(final ModuleDescriptor md, final ModuleRevisionId mrid) {
         return new MDArtifact(
-            ivyModuleDescriptor, mrid.getName(), "source", "jar", 
+            md, mrid.getName(), "source", "jar",
             null, Collections.singletonMap("m:classifier", "sources"));
     }
 
-    public Artifact getSrcArtifact() {
+    public static Artifact getSrcArtifact(final ModuleDescriptor md, final ModuleRevisionId mrid) {
         return new MDArtifact(
-            ivyModuleDescriptor, mrid.getName(), "source", "jar", 
+            md, mrid.getName(), "source", "jar",
             null, Collections.singletonMap("m:classifier", "src"));
     }
 
-    public Artifact getJavadocArtifact() {
+    public static Artifact getJavadocArtifact(final ModuleDescriptor md, final ModuleRevisionId mrid) {
         return new MDArtifact(
-            ivyModuleDescriptor, mrid.getName(), "javadoc", "jar", 
+            md, mrid.getName(), "javadoc", "jar",
             null, Collections.singletonMap("m:classifier", "javadoc"));
     }
+
+    public Artifact getSourceArtifact()  { return getSourceArtifact(  ivyModuleDescriptor, mrid); }
+    public Artifact getSrcArtifact()     { return getSrcArtifact(     ivyModuleDescriptor, mrid); }
+    public Artifact getJavadocArtifact() { return getJavadocArtifact( ivyModuleDescriptor, mrid); }
 
     public void addSourceArtifact() {
         ivyModuleDescriptor.addArtifact("sources", getSourceArtifact());


### PR DESCRIPTION
This is an attempt fix sbt/sbt#1750 by forcing the deletion of any sources, src or javadoc present if a POM was updated (ie. new SNAPSHOT release).

But I can't seem to change sbt to use this updated version to finish testing it works.

Can anyone try please?

The last commit is just for debugging my problem with updating, intended to be dropped.
