### PR TITLE
On JDK 9 call java.net.Authenticator.getDefault

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ cache:
 addons:
   hosts: workaround-travis-ci-issue-5227
   hostname: workaround-travis-ci-issue-5227
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - ant
+      - ant-optional
 
 language: java
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,24 @@
 # Use Docker-based container (instead of OpenVZ)
 sudo: false
 
+# https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
+# Travis now defaults to Trusty, which is missing openjdk6.
+dist: precise
+
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot
+
+# WORKAROUND https://github.com/travis-ci/travis-ci/issues/5227
+addons:
+  hosts: workaround-travis-ci-issue-5227
+  hostname: workaround-travis-ci-issue-5227
+
 language: java
 jdk:
   - openjdk6
 
-
+before_cache:
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt  -name "*.lock"               -print -delete

--- a/src/java/org/apache/ivy/util/url/IvyAuthenticator.java
+++ b/src/java/org/apache/ivy/util/url/IvyAuthenticator.java
@@ -156,7 +156,9 @@ public final class IvyAuthenticator extends Authenticator {
             final Field f = Authenticator.class.getDeclaredField("theAuthenticator");
             f.setAccessible(true);
             return (Authenticator) f.get(null);
-        } catch (final ReflectiveOperationException e) {
+        } catch (final NoSuchFieldException e) {
+            handleReflectionException(e);
+        } catch (final IllegalAccessException e) {
             handleReflectionException(e);
         } catch (final RuntimeException e) {
             handleReflectionException0(e);
@@ -168,7 +170,11 @@ public final class IvyAuthenticator extends Authenticator {
         try {
             final Method m = Authenticator.class.getDeclaredMethod("getDefault");
             return (Authenticator) m.invoke(null);
-        } catch (final ReflectiveOperationException e) {
+        } catch (final NoSuchMethodException e) {
+            handleReflectionException(e);
+        } catch (final InvocationTargetException e) {
+            handleReflectionException(e);
+        } catch (final IllegalAccessException e) {
             handleReflectionException(e);
         } catch (final RuntimeException e) {
             handleReflectionException0(e);
@@ -176,14 +182,21 @@ public final class IvyAuthenticator extends Authenticator {
         return null;
     }
 
-    private static void handleReflectionException0(final RuntimeException e) {
+    private static void handleReflectionException0(final RuntimeException e0) {
         try {
-            throw e;
-        } catch (final SecurityException | ExceptionInInitializerError | IllegalArgumentException | ClassCastException | NullPointerException e) {
+            throw e0;
+        } catch (final SecurityException e) {
+            handleReflectionException(e);
+        } catch (final ExceptionInInitializerError e) {
+            handleReflectionException(e);
+        } catch (final IllegalArgumentException e) {
+            handleReflectionException(e);
+        } catch (final ClassCastException e) {
+            handleReflectionException(e);
+        } catch (final NullPointerException e) {
             handleReflectionException(e);
         }
     }
-
 
     private static void handleReflectionException(final Throwable t) {
         Message.debug("Error occurred while getting the original authenticator: " + t.getMessage());

--- a/src/java/org/apache/ivy/util/url/IvyAuthenticator.java
+++ b/src/java/org/apache/ivy/util/url/IvyAuthenticator.java
@@ -50,15 +50,7 @@ public final class IvyAuthenticator extends Authenticator {
         // We will try to use the original authenticator as backup authenticator. 
         // Since there is no getter available, so try to use some reflection to 
         // obtain it. If that doesn't work, assume there is no original authenticator
-        Authenticator original = null;
-        
-        try {
-            Field f = Authenticator.class.getDeclaredField("theAuthenticator");
-            f.setAccessible(true);
-            original = (Authenticator) f.get(null);
-        } catch (Throwable t) {
-            Message.debug("Error occurred while getting the original authenticator: " + t.getMessage());            
-        }
+        final Authenticator original = getOriginalAuthenticator();
 
         if (!(original instanceof IvyAuthenticator)) {
             try {
@@ -152,6 +144,17 @@ public final class IvyAuthenticator extends Authenticator {
         // fallback to the Ivy 2.2.0 behavior
         String proxyHost = System.getProperty("http.proxyHost");
         return getRequestingHost().equals(proxyHost);
+    }
+
+    private static Authenticator getOriginalAuthenticator() {
+        try {
+            final Field f = Authenticator.class.getDeclaredField("theAuthenticator");
+            f.setAccessible(true);
+            return (Authenticator) f.get(null);
+        } catch (final Throwable t) {
+            Message.debug("Error occurred while getting the original authenticator: " + t.getMessage());
+            return null;
+        }
     }
 
 }

--- a/test/java/org/apache/ivy/util/url/ArtifactoryListingTest.java
+++ b/test/java/org/apache/ivy/util/url/ArtifactoryListingTest.java
@@ -30,6 +30,6 @@ public class ArtifactoryListingTest extends TestCase {
         
         List content = lister.listAll(new URL("http://repo.jfrog.org/artifactory/libs-releases-local/org/apache/wicket/wicket/"));
         assertNotNull(content);
-        assertEquals(5, content.size());
+        assertEquals(3, content.size());
     }
 }


### PR DESCRIPTION
JDK 9 complains when java.lang.reflect.Field#setAccessible is called. So on
JDK 9 to get the default Authenticator on JDK you can just call
Authenticator.getDefault(). However ivy targets JDK 6..

So on JDK < 9 we do what we've always done, and on JDK 9+ we use java
reflection to call Authenticator.getDefault(), which is public and doesn't
require setAccessible(true).

Required for sbt/launcher#38