### PR TITLE
fix ArrayIndexOutOfBoundsException when Java 9

### DIFF
--- a/src/java/org/apache/ivy/util/url/IvyAuthenticator.java
+++ b/src/java/org/apache/ivy/util/url/IvyAuthenticator.java
@@ -208,8 +208,7 @@ public final class IvyAuthenticator extends Authenticator {
         // https://docs.oracle.com/javase/8/docs/technotes/guides/versioning/spec/versioning2.html
         final String[] version = System.getProperty("java.specification.version").split("\\.");
         final int version0 = Integer.parseInt(version[0]);
-        final int version1 = Integer.parseInt(version[1]);
-        return version0 == 1 ? version1 : version0;
+        return version0 == 1 ? Integer.parseInt(version[1]) : version0;
     }
 
 }


### PR DESCRIPTION
```
[debug] problem occurred while resolving dependency: org.xerial.sbt#sbt-sonatype;2.0 {compile=[default(compile)]} with typesafe-ivy-releases: java.lang.ArrayIndexOutOfBoundsException: 1
[debug] 	at org.apache.ivy.util.url.IvyAuthenticator.getJavaVersion(IvyAuthenticator.java:211)
[debug] 	at org.apache.ivy.util.url.IvyAuthenticator.isJavaVersion9Plus(IvyAuthenticator.java:205)
[debug] 	at org.apache.ivy.util.url.IvyAuthenticator.getOriginalAuthenticator(IvyAuthenticator.java:151)
[debug] 	at org.apache.ivy.util.url.IvyAuthenticator.install(IvyAuthenticator.java:54)
[debug] 	at sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.getURLInfo(GigahorseUrlHandler.scala:38)
[debug] 	at sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler.getURLInfo(GigahorseUrlHandler.scala:29)
[debug] 	at org.apache.ivy.util.url.URLHandlerDispatcher.getURLInfo(URLHandlerDispatcher.java:66)
[debug] 	at org.apache.ivy.plugins.repository.url.URLResource.init(URLResource.java:65)
[debug] 	at org.apache.ivy.plugins.repository.url.URLResource.exists(URLResource.java:81)
[debug] 	at org.apache.ivy.plugins.resolver.RepositoryResolver.findResourceUsingPattern(RepositoryResolver.java:97)
[debug] 	at org.apache.ivy.plugins.resolver.AbstractPatternsBasedResolver.findResourceUsingPatterns(AbstractPatternsBasedResolver.java:96)
[debug] 	at org.apache.ivy.plugins.resolver.AbstractPatternsBasedResolver.findIvyFileRef(AbstractPatternsBasedResolver.java:66)
[debug] 	at org.apache.ivy.plugins.resolver.BasicResolver.getDependency(BasicResolver.java:228)
[debug] 	at sbt.internal.librarymanagement.ConvertResolver$$anonfun$defaultConvert$lzycompute$1$$anon$2.sbt$internal$librarymanagement$ConvertResolver$DescriptorRequired$$super$getDependency(ConvertResolver.scala:215)
[debug] 	at sbt.internal.librarymanagement.ConvertResolver$DescriptorRequired.getDependency(ConvertResolver.scala:291)
[debug] 	at sbt.internal.librarymanagement.ConvertResolver$DescriptorRequired.getDependency$(ConvertResolver.scala:288)
[debug] 	at sbt.internal.librarymanagement.ConvertResolver$$anonfun$defaultConvert$lzycompute$1$$anon$2.getDependency(ConvertResolver.scala:215)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.performResolution$1(SbtChainResolver.scala:152)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.$anonfun$getResults$3(SbtChainResolver.scala:172)
[debug] 	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:234)
[debug] 	at scala.collection.Iterator.foreach(Iterator.scala:929)
[debug] 	at scala.collection.Iterator.foreach$(Iterator.scala:929)
[debug] 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1417)
[debug] 	at scala.collection.IterableLike.foreach(IterableLike.scala:71)
[debug] 	at scala.collection.IterableLike.foreach$(IterableLike.scala:70)
[debug] 	at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
[debug] 	at scala.collection.TraversableLike.map(TraversableLike.scala:234)
[debug] 	at scala.collection.TraversableLike.map$(TraversableLike.scala:227)
[debug] 	at scala.collection.AbstractTraversable.map(Traversable.scala:104)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.getResults(SbtChainResolver.scala:165)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.results$lzycompute$1(SbtChainResolver.scala:321)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.results$1(SbtChainResolver.scala:321)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.$anonfun$getDependency$1(SbtChainResolver.scala:323)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.$anonfun$resolveByAllMeans$2(SbtChainResolver.scala:249)
[debug] 	at scala.Option.orElse(Option.scala:289)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.resolveByAllMeans(SbtChainResolver.scala:247)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.getDependency(SbtChainResolver.scala:324)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver.getDependency(SbtChainResolver.scala:90)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.performResolution$1(SbtChainResolver.scala:152)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.$anonfun$getResults$3(SbtChainResolver.scala:172)
[debug] 	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:234)
[debug] 	at scala.collection.Iterator.foreach(Iterator.scala:929)
[debug] 	at scala.collection.Iterator.foreach$(Iterator.scala:929)
[debug] 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1417)
[debug] 	at scala.collection.IterableLike.foreach(IterableLike.scala:71)
[debug] 	at scala.collection.IterableLike.foreach$(IterableLike.scala:70)
[debug] 	at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
[debug] 	at scala.collection.TraversableLike.map(TraversableLike.scala:234)
[debug] 	at scala.collection.TraversableLike.map$(TraversableLike.scala:227)
[debug] 	at scala.collection.AbstractTraversable.map(Traversable.scala:104)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.getResults(SbtChainResolver.scala:165)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.results$lzycompute$1(SbtChainResolver.scala:321)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.results$1(SbtChainResolver.scala:321)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.$anonfun$getDependency$1(SbtChainResolver.scala:323)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.$anonfun$resolveByAllMeans$2(SbtChainResolver.scala:249)
[debug] 	at scala.Option.orElse(Option.scala:289)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.resolveByAllMeans(SbtChainResolver.scala:247)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver$CustomSbtResolution$.getDependency(SbtChainResolver.scala:324)
[debug] 	at sbt.internal.librarymanagement.ivyint.SbtChainResolver.getDependency(SbtChainResolver.scala:90)
[debug] 	at org.apache.ivy.core.resolve.IvyNode.loadData(IvyNode.java:169)
[debug] 	at org.apache.ivy.core.resolve.VisitNode.loadData(VisitNode.java:292)
[debug] 	at org.apache.ivy.core.resolve.ResolveEngine.fetchDependencies(ResolveEngine.java:714)
[debug] 	at org.apache.ivy.core.resolve.ResolveEngine.doFetchDependencies(ResolveEngine.java:799)
[debug] 	at org.apache.ivy.core.resolve.ResolveEngine.fetchDependencies(ResolveEngine.java:722)
[debug] 	at org.apache.ivy.core.resolve.ResolveEngine.getDependencies(ResolveEngine.java:594)
[debug] 	at org.apache.ivy.core.resolve.ResolveEngine.resolve(ResolveEngine.java:234)
[debug] 	at org.apache.ivy.Ivy.resolve(Ivy.java:517)
[debug] 	at sbt.internal.librarymanagement.IvyActions$.resolveAndRetrieve(IvyActions.scala:319)
[debug] 	at sbt.internal.librarymanagement.IvyActions$.$anonfun$updateEither$1(IvyActions.scala:205)
[debug] 	at sbt.internal.librarymanagement.IvySbt$Module.$anonfun$withModule$1(Ivy.scala:229)
[debug] 	at sbt.internal.librarymanagement.IvySbt.$anonfun$withIvy$1(Ivy.scala:190)
[debug] 	at sbt.internal.librarymanagement.IvySbt.sbt$internal$librarymanagement$IvySbt$$action$1(Ivy.scala:70)
[debug] 	at sbt.internal.librarymanagement.IvySbt$$anon$3.call(Ivy.scala:77)
[debug] 	at xsbt.boot.Locks$GlobalLock.withChannel$1(Locks.scala:93)
[debug] 	at xsbt.boot.Locks$GlobalLock.xsbt$boot$Locks$GlobalLock$$withChannelRetries$1(Locks.scala:78)
[debug] 	at xsbt.boot.Locks$GlobalLock$$anonfun$withFileLock$1.apply(Locks.scala:97)
[debug] 	at xsbt.boot.Using$.withResource(Using.scala:10)
[debug] 	at xsbt.boot.Using$.apply(Using.scala:9)
[debug] 	at xsbt.boot.Locks$GlobalLock.ignoringDeadlockAvoided(Locks.scala:58)
[debug] 	at xsbt.boot.Locks$GlobalLock.withLock(Locks.scala:48)
[debug] 	at xsbt.boot.Locks$.apply0(Locks.scala:31)
[debug] 	at xsbt.boot.Locks$.apply(Locks.scala:28)
[debug] 	at sbt.internal.librarymanagement.IvySbt.withDefaultLogger(Ivy.scala:77)
[debug] 	at sbt.internal.librarymanagement.IvySbt.withIvy(Ivy.scala:185)
[debug] 	at sbt.internal.librarymanagement.IvySbt.withIvy(Ivy.scala:182)
[debug] 	at sbt.internal.librarymanagement.IvySbt$Module.withModule(Ivy.scala:228)
[debug] 	at sbt.internal.librarymanagement.IvyActions$.updateEither(IvyActions.scala:190)
[debug] 	at sbt.librarymanagement.ivy.IvyDependencyResolution.update(IvyDependencyResolution.scala:20)
[debug] 	at sbt.librarymanagement.DependencyResolution.update(DependencyResolution.scala:56)
[debug] 	at sbt.internal.LibraryManagement$.resolve$1(LibraryManagement.scala:38)
[debug] 	at sbt.internal.LibraryManagement$.$anonfun$cachedUpdate$12(LibraryManagement.scala:91)
[debug] 	at sbt.util.Tracked$.$anonfun$lastOutput$1(Tracked.scala:68)
[debug] 	at sbt.internal.LibraryManagement$.$anonfun$cachedUpdate$19(LibraryManagement.scala:104)
[debug] 	at scala.util.control.Exception$Catch.apply(Exception.scala:224)
[debug] 	at sbt.internal.LibraryManagement$.$anonfun$cachedUpdate$11(LibraryManagement.scala:104)
[debug] 	at sbt.internal.LibraryManagement$.$anonfun$cachedUpdate$11$adapted(LibraryManagement.scala:87)
[debug] 	at sbt.util.Tracked$.$anonfun$inputChanged$1(Tracked.scala:149)
[debug] 	at sbt.internal.LibraryManagement$.cachedUpdate(LibraryManagement.scala:118)
[debug] 	at sbt.Classpaths$.$anonfun$updateTask$5(Defaults.scala:2353)
[debug] 	at scala.Function1.$anonfun$compose$1(Function1.scala:44)
[debug] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:42)
[debug] 	at sbt.std.Transform$$anon$4.work(System.scala:64)
[debug] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:257)
[debug] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[debug] 	at sbt.Execute.work(Execute.scala:266)
[debug] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:257)
[debug] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:167)
[debug] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:32)
[debug] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[debug] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:514)
[debug] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[debug] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
[debug] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
[debug] 	at java.base/java.lang.Thread.run(Thread.java:844)
```