### PR TITLE
show current action while publishing artifact to repository

### DIFF
--- a/src/java/org/apache/ivy/plugins/resolver/RepositoryResolver.java
+++ b/src/java/org/apache/ivy/plugins/resolver/RepositoryResolver.java
@@ -213,6 +213,7 @@ public class RepositoryResolver extends AbstractPatternsBasedResolver {
 
         String dest = getDestination(destPattern, artifact, mrid);
 
+        Message.info("\tpublishing " + artifact.getName() + " to " + hidePassword(repository.standardize(dest)));
         put(artifact, src, dest, overwrite);
         Message.info("\tpublished " + artifact.getName() + " to " + hidePassword(repository.standardize(dest)));
     }


### PR DESCRIPTION
The problem is that "published ..." message is there only when upload is done.
Uploading big artifact to repository can take significant amount of time. It can take minutes.
Or even dozens of minutes for big uploads over slow Internet uplink.

It is not obvious what happens when upload is started. The console just hangs.
More user friendly would be to show for a user what is about to happen. In this case upload of an artifact will take place.