### PR TITLE
Debug-print HTTP body and headers on publish failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build/
 lib/
 test/jar-repos/
 test/repositories/
+target/
+.idea/


### PR DESCRIPTION
Be more verbose on PUT operation failure
    
TL;DR: Print HTTP (truncated) response body and headers when a PUT operation fails on upload to better explain why upload failed.
    
Long story:
    
Publish failure might be caused by unsufficient privileges, and 401 or 403 HTTP status code is returned. Such well-formed, standard-compliant response codes are enough for a developper to figure out credentials are either bad or missing. At the same time, repository services might enforce immutability (and return a 409 when artifact version is already published) and/or strict versioning rules (e.g returning a 400 when artifact is not semver compliant)
    
However, some artifact hosting services - namely Azure Artifacts - have a slightly more obfuscated AND anally-retentive behavior: those will issue a `203: Non-authoritative answer` both when the credentials are bad, or something else entirely is happening, for instance when the supplied version number doesn't match with an undocumented scheme/regex...
    
In that case, the HTTP status code simply isn't sufficient. On a 203, a `Warning` header may be provided, or in any case, a full explanation may be given in the request body.
    
This code print headers at DEBUG logging level and truncated reponse body in the event of a publish failure on an unknow code to enhance developper experience.
