### PR TITLE
Set explicit HTTP Accept header to avoid text/html

### DIFF
--- a/src/java/org/apache/ivy/util/url/BasicURLHandler.java
+++ b/src/java/org/apache/ivy/util/url/BasicURLHandler.java
@@ -164,6 +164,7 @@ public class BasicURLHandler extends AbstractURLHandler {
             conn = url.openConnection();
             conn.setRequestProperty("User-Agent", "Apache Ivy/" + Ivy.getIvyVersion());
             conn.setRequestProperty("Accept-Encoding", "gzip,deflate");
+            conn.setRequestProperty("Accept", "application/octet-stream, application/json, application/xml, */*");
             if (conn instanceof HttpURLConnection) {
                 HttpURLConnection httpCon = (HttpURLConnection) conn;
                 if (!checkStatusCode(url, httpCon)) {
@@ -199,6 +200,7 @@ public class BasicURLHandler extends AbstractURLHandler {
             srcConn = src.openConnection();
             srcConn.setRequestProperty("User-Agent", "Apache Ivy/" + Ivy.getIvyVersion());
             srcConn.setRequestProperty("Accept-Encoding", "gzip,deflate");
+            srcConn.setRequestProperty("Accept", "application/octet-stream, application/json, application/xml, */*");
             if (srcConn instanceof HttpURLConnection) {
                 HttpURLConnection httpCon = (HttpURLConnection) srcConn;
                 int status = httpCon.getResponseCode();
@@ -260,6 +262,7 @@ public class BasicURLHandler extends AbstractURLHandler {
             conn.setDoOutput(true);
             conn.setRequestMethod("PUT");
             conn.setRequestProperty("User-Agent", "Apache Ivy/" + Ivy.getIvyVersion());
+            conn.setRequestProperty("Accept", "application/octet-stream, application/json, application/xml, */*");
             conn.setRequestProperty("Content-type", "application/octet-stream");
             conn.setRequestProperty("Content-length", Long.toString(source.length()));
             conn.setInstanceFollowRedirects(true);

--- a/src/java/org/apache/ivy/util/url/IvyAuthenticator.java
+++ b/src/java/org/apache/ivy/util/url/IvyAuthenticator.java
@@ -89,6 +89,7 @@ public final class IvyAuthenticator extends Authenticator {
 
             // sbt change, driven by https://github.com/sbt/sbt/issues/2366
             if (c == null) {
+                Message.debug("authentication: requesting prompt: " + getRequestingPrompt());
                 c = CredentialsStore.INSTANCE.getCredentials(null, getRequestingHost());
                 Message.debug("authentication: k='"
                         + Credentials.buildKey(null, getRequestingHost()) + "' c='" + c + "'");


### PR DESCRIPTION
By default, `java.net.HttpURLConnection` HTTP `Accept` header is set to `text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2`

This leads to Microsoft servers responding with a 203 status code and an HTML pages when uploading or downloading artifacts to Azure Artifacts.

Given that Maven also have a similar issue (`text/html` as the preferred response content-type), Microsoft has implemented a workaround that ignores the `Accept` header values when `User-Agent` is `Apache Maven/*`. However, this workaround is not implemented on their side for SBT.

This pull request sets HTTP `Accept` header to `application/octet-stream, application/json, application/xml, */*` to fix this behavior, as evidenced here:

https://dev.azure.com/aironek/sbt-test/_build/results?buildId=43&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=b60649db-91ed-45ce-b0dd-c9633ee87772

Given that the last component is `*/*`, this shoud be backward-compatible with other serivces (Nexus, Artifactory, etc) that reply with different content-types.