### PR TITLE
fix: make module attribute string encoding deterministic

### DIFF
--- a/src/java/org/apache/ivy/core/module/id/ModuleRevisionId.java
+++ b/src/java/org/apache/ivy/core/module/id/ModuleRevisionId.java
@@ -21,6 +21,7 @@ import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.WeakHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -274,7 +275,7 @@ public class ModuleRevisionId extends UnmodifiableExtendableItem {
 
     public String encodeToString() {
         StringBuffer buf = new StringBuffer();
-        Map attributes = new HashMap(getAttributes());
+        Map attributes = new TreeMap(getAttributes());
         attributes.keySet().removeAll(getExtraAttributes().keySet());
         attributes.putAll(getQualifiedExtraAttributes());
 

--- a/test/java/org/apache/ivy/core/module/id/ModuleRevisionIdTest.java
+++ b/test/java/org/apache/ivy/core/module/id/ModuleRevisionIdTest.java
@@ -65,6 +65,11 @@ public class ModuleRevisionIdTest extends TestCase {
         testEncodeDecodeToString(ModuleRevisionId.newInstance("org/apache", "pre/name",
             "1.0-dev8/2", extraAttributes));
 
+        String encoded = ModuleRevisionId.newInstance("org/apache", "pre/name", "1.0-dev8/2", extraAttributes).encodeToString();
+        // We expect the encoding/ordering to be stable for reproducibility.
+        // If necessary this may vary across Ivy versions,
+        // but ideally only intentionally.
+        assertEquals("+att.name:#@#:+att.value:#@#:+att/name:#@#:+att/value:#@#:+att<name:#@#:+att<value:#@#:+branch:#@#:+@#:NULL:#@:#@#:+extra:#@#:+extravalue:#@#:+module:#@#:+pre/name:#@#:+nullatt:#@#:+@#:NULL:#@:#@#:+organisation:#@#:+org/apache:#@#:+revision:#@#:+1.0-dev8/2:#@#:", encoded);
     }
 
     private void testEncodeDecodeToString(ModuleRevisionId mrid) {


### PR DESCRIPTION
This value makes it into the `pom.xml`'s `extraDependencyAttributes` property, and it'd be good to have this be deterministic: aside from general hygiene, generating them bit-by-bit reproducibly helps validating no malware was sneaked into the artifacts. This is also called 'Reproducible Builds' (https://reproducible-builds.org/)