### PR TITLE
fix: use ivy pattern for packager cache

### DIFF
--- a/src/java/org/apache/ivy/plugins/resolver/packager/PackagerCacheEntry.java
+++ b/src/java/org/apache/ivy/plugins/resolver/packager/PackagerCacheEntry.java
@@ -228,10 +228,8 @@ public class PackagerCacheEntry {
     }
 
     private static File getSubdir(File rootDir, ModuleRevisionId mr) {
-        return new File(rootDir,
-          mr.getOrganisation() + File.separatorChar
-          + mr.getName() + File.separatorChar
-          + mr.getRevision());
+        String subDir = IvyPatternHelper.substitute("[organisation]/[module]/[revision]", mr);
+        return new File(rootDir, subDir);
     }
 }
 


### PR DESCRIPTION
Cherry-pick of 8644f1b12e17ec1d5d013d7ef84cc830ff5a6bf5